### PR TITLE
Add more TypeScript Syntax support

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -380,7 +380,7 @@
         "languageId": "javascript"
       }, {
         "scopes": ["source.ts", "source.tsx"],
-        "syntaxes": ["Packages/TypeScript-TmLanguage/TypeScript.tmLanguage"],
+        "syntaxes": ["Packages/TypeScript-TmLanguage/TypeScript.tmLanguage", "Packages/TypeScript Syntax/TypeScript.tmLanguage"],
         "languageId": "typescript"
       }
       ]
@@ -401,7 +401,7 @@
         "languageId": "javascript"
       }, {
         "scopes": ["source.ts", "source.tsx"],
-        "syntaxes": ["Packages/TypeScript-TmLanguage/TypeScript.tmLanguage"],
+        "syntaxes": ["Packages/TypeScript-TmLanguage/TypeScript.tmLanguage", "Packages/TypeScript Syntax/TypeScript.tmLanguage"],
         "languageId": "typescript"
       }
       ]
@@ -415,7 +415,7 @@
         "languageId": "javascript"
       }, {
         "scopes": ["source.ts", "source.tsx"],
-        "syntaxes": ["Packages/TypeScript-TmLanguage/TypeScript.tmLanguage"],
+        "syntaxes": ["Packages/TypeScript-TmLanguage/TypeScript.tmLanguage", "Packages/TypeScript Syntax/TypeScript.tmLanguage"],
         "languageId": "typescript"
       }
       ]


### PR DESCRIPTION
Allow LSP to process TypeScript using the lighter-weight "TypeScript Syntax" package rather than the full "TypeScript" package that includes a full language server protocol implementation