### PR TITLE
Fix "goto def" for a foreign file (outside the workspace)

### DIFF
--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -101,8 +101,9 @@ class DocumentHandlerFactory(object):
         self._sublime = sublime
         self._settings = settings
 
-    def for_window(self, window: 'WindowLike', configs: 'ConfigRegistry') -> DocumentHandler:
-        return WindowDocumentHandler(self._sublime, self._settings, window, configs)
+    def for_window(self, window: 'WindowLike', workspace: ProjectFolders,
+                   configs: 'ConfigRegistry') -> DocumentHandler:
+        return WindowDocumentHandler(self._sublime, self._settings, window, workspace, configs)
 
 
 def nop() -> None:
@@ -110,7 +111,8 @@ def nop() -> None:
 
 
 class WindowDocumentHandler(object):
-    def __init__(self, sublime: 'Any', settings: Settings, window: WindowLike, configs: ConfigRegistry) -> None:
+    def __init__(self, sublime: 'Any', settings: Settings, window: WindowLike, workspace: ProjectFolders,
+                 configs: ConfigRegistry) -> None:
         self._sublime = sublime
         self._settings = settings
         self._configs = configs
@@ -118,6 +120,7 @@ class WindowDocumentHandler(object):
         self._document_states = dict()  # type: Dict[str, DocumentState]
         self._pending_buffer_changes = dict()  # type: Dict[int, Dict]
         self._sessions = dict()  # type: Dict[str, List[Session]]
+        self._workspace = workspace
         self.changed = nop
         self.saved = nop
 
@@ -145,12 +148,21 @@ class WindowDocumentHandler(object):
     def _get_applicable_sessions(self, view: ViewLike, notification_type: 'Optional[str]' = None) -> 'List[Session]':
         sessions = []  # type: List[Session]
         syntax = view.settings().get("syntax")
-        for config_name, config_sessions in self._sessions.items():
-            for session in config_sessions:
-                if config_supports_syntax(session.config, syntax):
+
+        def conditional_append(session: Session) -> None:
+            if config_supports_syntax(session.config, syntax):
+                if not notification_type or self._session_supports_notification(session, notification_type):
+                    sessions.append(session)
+
+        if view in self._workspace:
+            for sessions_per_config_name in self._sessions.values():
+                for session in sessions_per_config_name:
                     if session.handles_path(view.file_name()):
-                        if not notification_type or self._session_supports_notification(session, notification_type):
-                            sessions.append(session)
+                        conditional_append(session)
+        else:
+            for sessions_per_config_name in self._sessions.values():
+                assert len(sessions_per_config_name) > 0
+                conditional_append(sessions_per_config_name[0])
         return sessions
 
     def _session_supports_notification(self, session: 'Session', notification_type: str) -> bool:
@@ -323,11 +335,20 @@ def extract_message(params: 'Any') -> str:
 
 
 class WindowManager(object):
-    def __init__(self, window: WindowLike, settings: Settings, configs: ConfigRegistry, documents: DocumentHandler,
-                 diagnostics: DiagnosticsStorage, session_starter: 'Callable', sublime: 'Any',
-                 handler_dispatcher: LanguageHandlerListener, on_closed: 'Optional[Callable]' = None,
-                 server_panel_factory: 'Optional[Callable]' = None) -> None:
-
+    def __init__(
+        self,
+        window: WindowLike,
+        workspace: ProjectFolders,
+        settings: Settings,
+        configs: ConfigRegistry,
+        documents: DocumentHandler,
+        diagnostics: DiagnosticsStorage,
+        session_starter: 'Callable',
+        sublime: 'Any',
+        handler_dispatcher: LanguageHandlerListener,
+        on_closed: 'Optional[Callable]' = None,
+        server_panel_factory: 'Optional[Callable]' = None
+    ) -> None:
         self._window = window
         self._settings = settings
         self._configs = configs
@@ -342,7 +363,9 @@ class WindowManager(object):
         self._on_closed = on_closed
         self._is_closing = False
         self._initialization_lock = threading.Lock()
-        self._workspace = ProjectFolders(self._window, self._on_project_changed, self._on_project_switched)
+        self._workspace = workspace
+        self._workspace.on_changed = self._on_project_changed
+        self._workspace.on_switched = self._on_project_switched
 
     def _on_project_changed(self, folders: 'List[str]') -> None:
         workspace_folders = get_workspace_folders(self._workspace.folders)
@@ -357,19 +380,20 @@ class WindowManager(object):
     def get_session(self, config_name: str, file_path: str) -> 'Optional[Session]':
         return self._find_session(config_name, file_path)
 
-    def _is_session_ready(self, config_name: str, file_path: str) -> bool:
-        maybe_session = self._find_session(config_name, file_path)
-        return maybe_session is not None and maybe_session.state == ClientStates.READY
-
     def _can_start_config(self, config_name: str, file_path: str) -> bool:
         return not bool(self._find_session(config_name, file_path))
 
     def _find_session(self, config_name: str, file_path: str) -> 'Optional[Session]':
-        if config_name in self._sessions:
-            for session in self._sessions[config_name]:
-                if session.handles_path(file_path):
-                    return session
-
+        if file_path in self._workspace:
+            if config_name in self._sessions:
+                for session in self._sessions[config_name]:
+                    if session.handles_path(file_path):
+                        return session
+        else:
+            sessions = self._sessions.get(config_name, None)
+            if not sessions:
+                return None
+            return sessions[0]
         return None
 
     def update_configs(self) -> None:
@@ -401,29 +425,46 @@ class WindowManager(object):
             self._workspace.update()
             self._initialize_on_open(view)
 
+    def needed_configs(self, file_path: str, configs: 'List[ClientConfig]') -> 'List[ClientConfig]':
+        new_configs = []
+        for c in configs:
+            sessions = self._sessions.get(c.name, None)
+            if sessions is None:
+                new_configs.append(c)
+                continue
+            assert isinstance(sessions, list)
+            assert len(sessions) > 0
+            first_session = sessions[0]
+            if first_session.supports_workspace_folders():
+                # A workspace-aware language server handles any path, both inside and outside the workspace.
+                continue
+            if file_path in self._workspace:
+                if any(s.handles_path(file_path) for s in sessions):
+                    # The file_path is inside the workspace, and there's a non-workspace-aware language server that can
+                    # handle this path. So no new session is needed.
+                    continue
+                # There is no non-workspace-aware language that handles this path, but it is inside the workspace. So
+                # we must start a new session.
+                new_configs.append(c)
+                continue
+            # We're now dealing with a non-workspace-aware language server, and the file_path is outside the workspace.
+            # Let us then take the first language server in the list that shall handle this path.
+            # (so no new session is needed).
+        return new_configs
+
     def _initialize_on_open(self, view: ViewLike) -> None:
         file_path = view.file_name() or ""
 
-        def needed_configs(configs: 'List[ClientConfig]') -> 'List[ClientConfig]':
-            new_configs = []
-            for c in configs:
-                if c.name not in self._sessions:
-                    new_configs.append(c)
-                elif all(not s.handles_path(file_path) for s in self._sessions[c.name]):
-                    debug('path not in existing {} session: {}'.format(c.name, file_path))
-                    new_configs.append(c)
-            return new_configs
-
         # have all sessions for this document been started?
         with self._initialization_lock:
-            new_configs = needed_configs(self._configs.syntax_configs(view, include_disabled=True))
+            new_configs = self.needed_configs(file_path, self._configs.syntax_configs(view, include_disabled=True))
 
             if any(new_configs):
                 # TODO: cannot observe project setting changes
                 # have to check project overrides every session request
                 self.update_configs()
 
-                startable_configs = needed_configs(self._configs.syntax_configs(view))
+                startable_configs = self.needed_configs(file_path, self._configs.syntax_configs(view))
 
                 for config in startable_configs:
 
@@ -670,12 +711,14 @@ class WindowRegistry(object):
         if state is None:
             if not self._settings:
                 raise RuntimeError("no settings")
+            workspace = ProjectFolders(window)
             window_configs = self._configs.for_window(window)
-            window_documents = self._documents.for_window(window, window_configs)
+            window_documents = self._documents.for_window(window, workspace, window_configs)
             diagnostics_ui = self._diagnostics_ui_class(window,
                                                         window_documents) if self._diagnostics_ui_class else None
             state = WindowManager(
                 window=window,
+                workspace=workspace,
                 settings=self._settings,
                 configs=window_configs,
                 documents=window_documents,

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -1,6 +1,6 @@
 from .diagnostics import DiagnosticsStorage
 from .logging import debug
-from .types import (ClientStates, ClientConfig, WindowLike, ViewLike,
+from .types import (ClientConfig, WindowLike, ViewLike,
                     LanguageConfig, config_supports_syntax, ConfigRegistry,
                     GlobalConfigs, Settings)
 from .edit import parse_workspace_edit

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -1,7 +1,7 @@
 from .logging import debug
 from .protocol import WorkspaceFolder
 from .types import WindowLike
-from os.path import commonprefix, realpath
+from os.path import commonprefix
 
 try:
     from typing import List, Optional, Any, Dict, Iterable, Union, Callable
@@ -34,7 +34,6 @@ class ProjectFolders(object):
 
     def is_foreign(self, p: str) -> bool:
         """Note that for a folderless window no path is foreign"""
-        p = realpath(p)
         return all(commonprefix((f, p)) != f for f in self.folders)
 
     def is_inside(self, p: str) -> bool:

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -1,6 +1,7 @@
 from .logging import debug
 from .protocol import WorkspaceFolder
 from .types import WindowLike
+from os.path import commonprefix, realpath
 
 try:
     from typing import List, Optional, Any, Dict, Iterable, Union, Callable
@@ -11,11 +12,11 @@ except ImportError:
 
 class ProjectFolders(object):
 
-    def __init__(self, window: WindowLike, on_changed: 'Callable[[List[str]], None]',
-                 on_switched: 'Callable[[List[str]], None]') -> None:
+    def __init__(self, window: WindowLike) -> None:
         self._window = window
-        self._on_changed = on_changed
-        self._on_switched = on_switched
+        self.on_changed = None  # type: Optional[Callable[[List[str]], None]]
+        self.on_switched = None  # type: Optional[Callable[[List[str]], None]]
+        self.folders = []  # type: List[str]
         self._current_project_file_name = self._window.project_file_name()
         self._set_folders(window.folders())
 
@@ -25,9 +26,28 @@ class ProjectFolders(object):
             is_update = self._can_update_to(new_folders)
             self._set_folders(new_folders)
             if is_update:
-                self._on_changed(new_folders)
+                if self.on_changed:
+                    self.on_changed(new_folders)
             else:
-                self._on_switched(new_folders)
+                if self.on_switched:
+                    self.on_switched(new_folders)
+
+    def is_foreign(self, p: str) -> bool:
+        """Note that for a folderless window no path is foreign"""
+        p = realpath(p)
+        return all(commonprefix((f, p)) != f for f in self.folders)
+
+    def is_inside(self, p: str) -> bool:
+        """The negation of is_foreign"""
+        return not self.is_foreign(p)
+
+    def __contains__(self, item: 'Any') -> bool:
+        if isinstance(item, str):
+            return self.is_inside(item)
+        elif item is None:
+            return True
+        else:
+            return getattr(item, "file_name")() in self
 
     def _set_folders(self, folders: 'List[str]') -> None:
         self.folders = folders

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -175,12 +175,8 @@ class TextDocumentTestCase(DeferrableTestCase):
                 self.session = self.wm._find_session(self.config.name, self.view.file_name())
                 if not self.session:
                     return False
-            if not self.session.client:
-                return False
-            if self.session.state != ClientStates.READY:
-                return False
-            if not self.session.capabilities:
-                return False
+            self.session.ready_lock.acquire()
+            self.session.ready_lock.release()
             return True
 
         yield {"condition": condition, "timeout": TIMEOUT_TIME, "period": PERIOD_TIME}

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -3,6 +3,7 @@ from LSP.plugin.core.sessions import create_session
 from LSP.plugin.core.sessions import Session
 from LSP.plugin.core.types import ClientConfig
 from LSP.plugin.core.windows import WindowDocumentHandler
+from LSP.plugin.core.workspace import ProjectFolders
 from os.path import basename
 from test_mocks import MockClient
 from test_mocks import MockConfigs
@@ -34,7 +35,8 @@ class WindowDocumentHandlerTests(unittest.TestCase):
         project_path = "/"
         folders = [WorkspaceFolder.from_path(project_path)]
         view.set_window(window)
-        handler = WindowDocumentHandler(test_sublime, MockSettings(), window, MockConfigs())
+        workspace = ProjectFolders(window)
+        handler = WindowDocumentHandler(test_sublime, MockSettings(), window, workspace, MockConfigs())
         client = MockClient()
         session = self.assert_if_none(
             create_session(TEST_CONFIG, folders, dict(), MockSettings(),
@@ -96,7 +98,8 @@ class WindowDocumentHandlerTests(unittest.TestCase):
         project_path = "/"
         folders = [WorkspaceFolder.from_path(project_path)]
         view.set_window(window)
-        handler = WindowDocumentHandler(test_sublime, MockSettings(), window, MockConfigs())
+        workspace = ProjectFolders(window)
+        handler = WindowDocumentHandler(test_sublime, MockSettings(), window, workspace, MockConfigs())
         client = MockClient()
         session = self.assert_if_none(
             create_session(TEST_CONFIG, folders, dict(), MockSettings(),

--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -282,7 +282,7 @@ class MockDocuments(object):
 
 
 class TestDocumentHandlerFactory(object):
-    def for_window(self, window, configs):
+    def for_window(self, window, workspace, configs):
         return MockDocuments()
 
 

--- a/tests/test_single_document.py
+++ b/tests/test_single_document.py
@@ -1,6 +1,6 @@
 # from copy import deepcopy
 from LSP.plugin.hover import _test_contents
-from setup import close_test_view, TextDocumentTestCase, TIMEOUT_TIME, PERIOD_TIME, CI
+from setup import close_test_view, TextDocumentTestCase, TIMEOUT_TIME, PERIOD_TIME
 import sublime
 import os
 
@@ -48,9 +48,11 @@ class SingleDocumentTestCase(TextDocumentTestCase):
         pass
 
     def test_did_close(self) -> 'Generator':
+        yield 100
         assert self.view
         close_test_view(self.view)
         self.view = None
+        yield 100
         yield from self.await_message("textDocument/didClose")
 
     def test_did_change(self) -> 'Generator':
@@ -195,10 +197,10 @@ class SingleDocumentTestCase(TextDocumentTestCase):
         self.view.sel().add(sublime.Region(0, 0))
         method = 'textDocument/{}'.format(text_document_request)
         self.set_response(method, response)
+        yield 100
         self.view.run_command('lsp_symbol_{}'.format(subl_command_suffix))
+        yield 100
         yield from self.await_message(method)
-        if CI:
-            yield 500
 
         def condition() -> bool:
             nonlocal self

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -43,7 +43,9 @@ class WorkspaceFoldersTest(unittest.TestCase):
         on_switched = mock.Mock()
         window = MockWindow(folders=[])
 
-        wf = ProjectFolders(window, on_changed, on_switched)
+        wf = ProjectFolders(window)
+        wf.on_changed = on_changed
+        wf.on_switched = on_switched
         window.set_folders([os.path.dirname(__file__)])
         wf.update()
         assert on_changed.call_count == 1
@@ -56,7 +58,9 @@ class WorkspaceFoldersTest(unittest.TestCase):
         parent_folder = os.path.dirname(folder)
         window = MockWindow(folders=[folder])
 
-        wf = ProjectFolders(window, on_changed, on_switched)
+        wf = ProjectFolders(window)
+        wf.on_changed = on_changed
+        wf.on_switched = on_switched
 
         window.set_folders([folder, parent_folder])
         wf.update()
@@ -70,7 +74,9 @@ class WorkspaceFoldersTest(unittest.TestCase):
         parent_folder = os.path.dirname(folder)
         window = MockWindow(folders=[folder, parent_folder])
 
-        wf = ProjectFolders(window, on_changed, on_switched)
+        wf = ProjectFolders(window)
+        wf.on_changed = on_changed
+        wf.on_switched = on_switched
 
         window.set_folders([parent_folder, folder])
         wf.update()
@@ -84,7 +90,9 @@ class WorkspaceFoldersTest(unittest.TestCase):
         parent_folder = os.path.dirname(folder)
         window = MockWindow(folders=[folder])
 
-        wf = ProjectFolders(window, on_changed, on_switched)
+        wf = ProjectFolders(window)
+        wf.on_changed = on_changed
+        wf.on_switched = on_switched
 
         window.set_folders([parent_folder])
         wf.update()
@@ -97,7 +105,9 @@ class WorkspaceFoldersTest(unittest.TestCase):
 
         window = MockWindow(folders=[])
 
-        wf = ProjectFolders(window, on_changed, on_switched)
+        wf = ProjectFolders(window)
+        wf.on_changed = on_changed
+        wf.on_switched = on_switched
 
         wf.update()
 
@@ -105,3 +115,14 @@ class WorkspaceFoldersTest(unittest.TestCase):
         assert on_switched.call_count == 0
 
         self.assertEqual(wf.folders, [])
+
+    def test_is_foreign(self) -> None:
+        on_changed = mock.Mock()
+        on_switched = mock.Mock()
+        window = MockWindow(folders=["/etc", "/var"])
+        wf = ProjectFolders(window)
+        wf.on_changed = on_changed
+        wf.on_switched = on_switched
+        wf.update()
+        self.assertTrue(wf.is_foreign("/bin/ls"))
+        self.assertTrue(wf.is_inside("/etc/profile"))

--- a/unittesting.json
+++ b/unittesting.json
@@ -1,8 +1,8 @@
 {
     "deferred": true,
-    "verbosity": 1,
+    "verbosity": 0,
     "capture_console": false,
-    "failfast": false,
+    "failfast": true,
     "reload_package_on_testing": true,
     "start_coverage_after_reload": false,
     "show_reload_progress": false,


### PR DESCRIPTION
- Take the first available language server if it's workspace-unaware
- Take the one and only language server if it's workspace-aware
- Ensure things work when ST is started with a foreign file
- Ensure sessions know what type of language server they are dealing with
  (i.e. workspace-aware or workspace-unaware) with a mutex lock.
  Actually, you can use that same mutex lock to check wether a
  session is ready (thus simplifying some test code)

The DocumentHandler needs to know wether a file is inside or outside the workspace for its _get_applicable_sessions method.