### PR TITLE
Session state

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,3 +37,28 @@ jobs:
     - run: |
         pip3 install coverage==4.5.4 codecov==2.0.15
         codecov
+
+  Windows:
+    runs-on: windows-latest
+    env:
+      CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
+      SUBLIME_TEXT_VERSION: "3"
+      SUBLIME_TEXT_ARCH: x64
+      PACKAGE: LSP
+    steps:
+    - uses: actions/checkout@v1
+    - run: python3 tests/server.py --version
+    - run: python3 tests/adjust_unittesting_config_for_ci.py
+    - run: (new-object net.webclient).DownloadFile("https://raw.githubusercontent.com/SublimeText/UnitTesting/master/sbin/github.ps1","github.ps1")
+    - run: |
+        ./github.ps1 "bootstrap" -verbose
+        ./github.ps1 "install_package_control" -verbose
+        ./github.ps1 "run_tests" -coverage -verbose
+      name: Run UnitTesting tests
+    - run: pip3 install mypy==0.750 flake8==3.7.9 yapf==0.29.0 --user
+    - run: mypy -p plugin
+    - run: flake8 plugin tests
+    - run: yapf --diff plugin/core/main.py
+    - run: |
+        pip3 install coverage==4.5.4 codecov==2.0.15
+        codecov

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,28 +37,3 @@ jobs:
     - run: |
         pip3 install coverage==4.5.4 codecov==2.0.15
         codecov
-
-  Windows:
-    runs-on: windows-latest
-    env:
-      CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
-      SUBLIME_TEXT_VERSION: "3"
-      SUBLIME_TEXT_ARCH: x64
-      PACKAGE: LSP
-    steps:
-    - uses: actions/checkout@v1
-    - run: python tests/server.py --version
-    - run: python tests/adjust_unittesting_config_for_ci.py
-    - run: (new-object net.webclient).DownloadFile("https://raw.githubusercontent.com/SublimeText/UnitTesting/master/sbin/github.ps1","github.ps1")
-    - run: |
-        ./github.ps1 "bootstrap" -verbose
-        ./github.ps1 "install_package_control" -verbose
-        ./github.ps1 "run_tests" -coverage -verbose
-      name: Run UnitTesting tests
-    - run: pip3 install mypy==0.750 flake8==3.7.9 yapf==0.29.0 --user
-    - run: mypy -p plugin
-    - run: flake8 plugin tests
-    - run: yapf --diff plugin/core/main.py
-    - run: |
-        pip3 install coverage==4.5.4 codecov==2.0.15
-        codecov

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,8 +47,8 @@ jobs:
       PACKAGE: LSP
     steps:
     - uses: actions/checkout@v1
-    - run: python3 tests/server.py --version
-    - run: python3 tests/adjust_unittesting_config_for_ci.py
+    - run: python tests/server.py --version
+    - run: python tests/adjust_unittesting_config_for_ci.py
     - run: (new-object net.webclient).DownloadFile("https://raw.githubusercontent.com/SublimeText/UnitTesting/master/sbin/github.ps1","github.ps1")
     - run: |
         ./github.ps1 "bootstrap" -verbose

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -49,7 +49,6 @@ class CompletionHandler(LSPViewEventListener):
         self.initialized = False
         self.enabled = False
         self.trigger_chars = []  # type: List[str]
-        self.auto_complete_selector = view.settings().get("auto_complete_selector", "") or ""  # type: str
         self.resolve = False
         self.state = CompletionState.IDLE
         self.completions = []  # type: List[Any]
@@ -215,6 +214,10 @@ class CompletionHandler(LSPViewEventListener):
         else:
             debug('could not find completion item for inserted "{}"'.format(inserted))
 
+    def match_selector(self, location: int) -> bool:
+        selector = self.view.settings().get("auto_complete_selector", "") or ""  # type: str
+        return self.view.match_selector(location, selector)
+
     def on_query_completions(self, prefix: str, locations: 'List[int]') -> 'Optional[Tuple[List[Tuple[str,str]], int]]':
         if not self.initialized:
             self.initialize()
@@ -225,7 +228,7 @@ class CompletionHandler(LSPViewEventListener):
             flags |= sublime.INHIBIT_EXPLICIT_COMPLETIONS
 
         if self.enabled:
-            if not self.view.match_selector(locations[0], self.auto_complete_selector):
+            if not self.match_selector(locations[0]):
                 return ([], flags)
 
             reuse_completion = self.is_same_completion(prefix, locations)

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -82,7 +82,7 @@ class CompletionHandler(LSPViewEventListener):
                 'triggerCharacters') or []
             if self.trigger_chars:
                 self.register_trigger_chars(session)
-            self.auto_complete_selector = self.view.settings().get("auto_complete_selector", "") or ""  # type: str
+            self.auto_complete_selector = self.view.settings().get("auto_complete_selector", "") or ""
 
     def _view_language(self, config_name: str) -> 'Optional[str]':
         languages = self.view.settings().get('lsp_language')

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -49,6 +49,7 @@ class CompletionHandler(LSPViewEventListener):
         self.initialized = False
         self.enabled = False
         self.trigger_chars = []  # type: List[str]
+        self.auto_complete_selector = ""
         self.resolve = False
         self.state = CompletionState.IDLE
         self.completions = []  # type: List[Any]
@@ -81,6 +82,7 @@ class CompletionHandler(LSPViewEventListener):
                 'triggerCharacters') or []
             if self.trigger_chars:
                 self.register_trigger_chars(session)
+            self.auto_complete_selector = self.view.settings().get("auto_complete_selector", "") or ""  # type: str
 
     def _view_language(self, config_name: str) -> 'Optional[str]':
         languages = self.view.settings().get('lsp_language')
@@ -215,8 +217,7 @@ class CompletionHandler(LSPViewEventListener):
             debug('could not find completion item for inserted "{}"'.format(inserted))
 
     def match_selector(self, location: int) -> bool:
-        selector = self.view.settings().get("auto_complete_selector", "") or ""  # type: str
-        return self.view.match_selector(location, selector)
+        return self.view.match_selector(location, self.auto_complete_selector)
 
     def on_query_completions(self, prefix: str, locations: 'List[int]') -> 'Optional[Tuple[List[Tuple[str,str]], int]]':
         if not self.initialized:

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -1,4 +1,4 @@
-from .typing import Any, List, Dict, Optional, Union, Mapping
+from .typing import Any, List, Dict, Optional, Union, Mapping, Iterable
 from .url import filename_to_uri
 from .url import uri_to_filename
 import os
@@ -87,10 +87,12 @@ class DocumentHighlightKind(object):
 
 
 class Request:
-    def __init__(self, method: str, params: Optional[Mapping[str, Any]]) -> None:
+
+    __slots__ = ('method', 'params')
+
+    def __init__(self, method: str, params: Optional[Mapping[str, Any]] = None) -> None:
         self.method = method
         self.params = params
-        self.jsonrpc = "2.0"
 
     @classmethod
     def initialize(cls, params: dict) -> 'Request':
@@ -174,46 +176,48 @@ class Request:
 
     @classmethod
     def shutdown(cls) -> 'Request':
-        return Request("shutdown", None)
+        return Request("shutdown")
 
     def __repr__(self) -> str:
         return self.method + " " + str(self.params)
 
     def to_payload(self, id: int) -> Dict[str, Any]:
-        r = {
+        return {
             "jsonrpc": "2.0",
             "id": id,
-            "method": self.method
-        }  # type: Dict[str, Any]
-        if self.params is not None:
-            r["params"] = self.params
-        return r
+            "method": self.method,
+            "params": self.params
+        }
 
 
 class Response:
-    def __init__(self, request_id: int, result: Optional[Union[Dict[str, Any], List[Any]]]) -> None:
+
+    __slots__ = ('request_id', 'result')
+
+    def __init__(self, request_id: int, result: Union[None, Mapping[str, Any], Iterable[Any]]) -> None:
         self.request_id = request_id
         self.result = result
-        self.jsonrpc = "2.0"
 
-    def to_payload(self) -> 'Dict[str, Any]':
+    def to_payload(self) -> Dict[str, Any]:
         r = {
             "id": self.request_id,
-            "jsonrpc": self.jsonrpc,
+            "jsonrpc": "2.0",
             "result": self.result
         }
         return r
 
 
 class Notification:
-    def __init__(self, method: str, params: dict = {}) -> None:
+
+    __slots__ = ('method', 'params')
+
+    def __init__(self, method: str, params: Optional[Mapping[str, Any]] = None) -> None:
         self.method = method
         self.params = params
-        self.jsonrpc = "2.0"
 
     @classmethod
     def initialized(cls) -> 'Notification':
-        return Notification("initialized")
+        return Notification("initialized", {})
 
     @classmethod
     def didOpen(cls, params: dict) -> 'Notification':
@@ -247,15 +251,11 @@ class Notification:
         return self.method + " " + str(self.params)
 
     def to_payload(self) -> Dict[str, Any]:
-        r = {
+        return {
             "jsonrpc": "2.0",
-            "method": self.method
-        }  # type: Dict[str, Any]
-        if self.params is not None:
-            r["params"] = self.params
-        else:
-            r["params"] = dict()
-        return r
+            "method": self.method,
+            "params": self.params
+        }
 
 
 class Point(object):

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -7,7 +7,7 @@ from .configurations import (
 from .clients import (
     start_window_config
 )
-from .types import ClientStates, ClientConfig, WindowLike
+from .types import ClientConfig, WindowLike
 from .handlers import LanguageHandler
 from .logging import debug
 from .sessions import Session
@@ -114,9 +114,10 @@ def _sessions_for_view_and_window(view: sublime.View, window: 'Optional[sublime.
 
     manager = windows.lookup(window)
     scope_configs = manager._configs.scope_configs(view, point)
-    sessions = (manager.get_session(config.name, file_path) for config in scope_configs)
-    ready_sessions = (session for session in sessions if session and session.state == ClientStates.READY)
-    return ready_sessions
+    for config in scope_configs:
+        session = manager.get_session(config.name, file_path)
+        if session:
+            yield session
 
 
 def unload_sessions(window: sublime.Window) -> None:

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -79,15 +79,7 @@ def register_language_handler(handler: LanguageHandler) -> None:
 
 
 def client_from_session(session: 'Optional[Session]') -> 'Optional[Client]':
-    if session:
-        if session.client:
-            return session.client
-        else:
-            debug(session.config.name, "in state", session.state)
-            return None
-    else:
-        debug('no session found')
-        return None
+    return session.client if session is not None else None
 
 
 def sessions_for_view(view: sublime.View, point: 'Optional[int]' = None) -> 'Iterable[Session]':

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -272,11 +272,11 @@ class Session(object):
         else:
             debug("session with no workspace folders")
 
-        self.ready_lock.release()  # acquired in _initialize
-
         self.client.on_request(
             "workspace/workspaceFolders",
             lambda _params, request_id: self._handle_workspace_folders(request_id))
+
+        self.ready_lock.release()  # acquired in _initialize
 
         if self._on_post_initialize:
             self._on_post_initialize(self)

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -10,7 +10,7 @@ import os
 import threading
 
 
-ACQUIRE_READY_LOCK_TIMEOUT = 5
+ACQUIRE_READY_LOCK_TIMEOUT = 3
 
 
 def get_initialize_params(workspace_folders: List[WorkspaceFolder], config: ClientConfig) -> dict:
@@ -143,8 +143,7 @@ class Session(object):
         if not acquired:
             raise InitializeError(self.config.name)
         yield
-        if acquired:
-            self.ready_lock.release()
+        self.ready_lock.release()
 
     def handles_path(self, file_path: Optional[str]) -> bool:
         if not file_path:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1,4 +1,4 @@
-from .types import ClientConfig, ClientStates, Settings
+from .types import ClientConfig, Settings
 from .protocol import Request, Notification
 from .transports import start_tcp_transport, start_tcp_listener, TCPTransport, Transport
 from .rpc import Client, attach_stdio_client, Response
@@ -168,6 +168,14 @@ def diff_folders(old: 'List[WorkspaceFolder]',
     return added, removed
 
 
+class InitializeError(Exception):
+
+    def __init__(self, config_name: str) -> None:
+        super().__init__("The server did not respond to the initialize request within {} seconds".format(
+            ACQUIRE_READY_LOCK_TIMEOUT))
+        self.name = config_name
+
+
 class Session(object):
     def __init__(self,
                  config: ClientConfig,
@@ -177,7 +185,6 @@ class Session(object):
                  on_post_initialize: 'Optional[Callable[[Session], None]]' = None,
                  on_post_exit: 'Optional[Callable[[str], None]]' = None) -> None:
         self.config = config
-        self.state = ClientStates.STARTING
         self._on_post_initialize = on_post_initialize
         self._on_post_exit = on_post_exit
         self.capabilities = dict()  # type: Dict[str, Any]
@@ -198,8 +205,7 @@ class Session(object):
     def acquire_timeout(self) -> 'Generator[None, None, None]':
         acquired = self.ready_lock.acquire(True, ACQUIRE_READY_LOCK_TIMEOUT)
         if not acquired:
-            raise TimeoutError("{} did not respond to the initialize request within {} seconds".format(
-                self.config.name, ACQUIRE_READY_LOCK_TIMEOUT))
+            raise InitializeError(self.config.name)
         yield
         if acquired:
             self.ready_lock.release()
@@ -250,7 +256,6 @@ class Session(object):
             return self._unsafe_supports_workspace_folders()
 
     def _handle_initialize_error(self, error: 'Any') -> None:
-        self.state = ClientStates.STOPPING
         self.ready_lock.release()  # acquired in _initialize
         self.end()
 
@@ -267,7 +272,6 @@ class Session(object):
         else:
             debug("session with no workspace folders")
 
-        self.state = ClientStates.READY
         self.ready_lock.release()  # acquired in _initialize
 
         self.client.on_request(
@@ -281,7 +285,6 @@ class Session(object):
         self.client.send_response(Response(request_id, [wf.to_lsp() for wf in self._workspace_folders]))
 
     def end(self) -> None:
-        self.state = ClientStates.STOPPING
         self.client.send_request(
             Request.shutdown(),
             lambda result: self._handle_shutdown_result(),

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -15,7 +15,7 @@ except ImportError:
     pass
 
 
-ACQUIRE_READY_LOCK_TIMEOUT = 3
+ACQUIRE_READY_LOCK_TIMEOUT = 5
 
 
 def create_session(config: ClientConfig,

--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -41,6 +41,10 @@ class Transport(object, metaclass=ABCMeta):
     def send(self, message: str) -> None:
         pass
 
+    @abstractmethod
+    def close(self) -> None:
+        pass
+
 
 STATE_HEADERS = 0
 STATE_CONTENT = 1
@@ -253,7 +257,10 @@ class StdioTransport(Transport):
             else:
                 try:
                     msgbytes = bytes(message, 'UTF-8')
-                    self.process.stdin.write(msgbytes)
+                    try:
+                        self.process.stdin.write(msgbytes)
+                    except AttributeError:
+                        return
                     self.process.stdin.flush()
                 except (BrokenPipeError, OSError) as err:
                     exception_log("Failure writing to stdout", err)

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -38,12 +38,6 @@ class Settings(object):
         self.log_payloads = False
 
 
-class ClientStates(object):
-    STARTING = 0
-    READY = 1
-    STOPPING = 2
-
-
 def syntax_language(config: 'ClientConfig', syntax: str) -> 'Optional[LanguageConfig]':
     for language in config.languages:
         for lang_syntax in language.syntaxes:

--- a/tests/probe.txt
+++ b/tests/probe.txt
@@ -1,0 +1,3 @@
+Content-Length: 58
+
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -3,7 +3,7 @@ from LSP.plugin.core.protocol import Notification, Request, WorkspaceFolder
 from LSP.plugin.core.registry import windows
 from LSP.plugin.core.sessions import Session
 from LSP.plugin.core.settings import client_configs
-from LSP.plugin.core.types import ClientConfig, ClientStates, LanguageConfig
+from LSP.plugin.core.types import ClientConfig, LanguageConfig
 from os import environ
 from os.path import dirname
 from sublime_plugin import view_event_listeners, ViewEventListener
@@ -183,10 +183,9 @@ class TextDocumentTestCase(DeferrableTestCase):
 
         yield {"condition": condition, "timeout": TIMEOUT_TIME, "period": PERIOD_TIME}
 
-    def await_message(self, method: str, expected_session_state: int = ClientStates.READY) -> 'Generator':
+    def await_message(self, method: str) -> 'Generator':
         self.assertIsNotNone(self.session)
         assert self.session  # mypy
-        self.assertEqual(self.session.state, expected_session_state)
         promise = YieldPromise()
 
         def handler(params: 'Any') -> None:
@@ -202,7 +201,6 @@ class TextDocumentTestCase(DeferrableTestCase):
     def set_response(self, method: str, response: 'Any') -> None:
         self.assertIsNotNone(self.session)
         assert self.session  # mypy
-        self.assertEqual(self.session.state, ClientStates.READY)
         self.session.client.send_notification(
             Notification("$test/setResponse", {"method": method, "response": response}))
 
@@ -216,7 +214,6 @@ class TextDocumentTestCase(DeferrableTestCase):
         close_test_view(self.view)
         self.wm.end_config_sessions(self.config.name)  # TODO: Shouldn't this be automatic once the last view closes?
         if self.session:
-            yield lambda: self.session.state == ClientStates.STOPPING
             yield lambda: self.session.client is None
 
     def await_clear_view_and_save(self) -> 'Generator':

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -1,12 +1,12 @@
 from LSP.plugin.core.logging import debug
 from LSP.plugin.core.protocol import Notification, Request, WorkspaceFolder
 from LSP.plugin.core.registry import windows
-from LSP.plugin.core.sessions import InitializeError
 from LSP.plugin.core.sessions import Session
 from LSP.plugin.core.settings import client_configs
 from LSP.plugin.core.types import ClientConfig, LanguageConfig
 from os import environ
 from os.path import dirname
+from os.path import join
 from sublime_plugin import view_event_listeners, ViewEventListener
 from test_mocks import basic_responses
 from unittesting import DeferrableTestCase
@@ -16,7 +16,7 @@ import sublime
 CI = any(key in environ for key in ("TRAVIS", "CI", "GITHUB_ACTIONS"))
 
 project_path = dirname(__file__)
-test_file_path = project_path + "/testfile.txt"
+test_file_path = join(project_path, "testfile.txt")
 workspace_folders = [WorkspaceFolder.from_path(project_path)]
 TIMEOUT_TIME = 10000 if CI else 2000
 PERIOD_TIME = 100 if CI else 1
@@ -50,7 +50,7 @@ class YieldPromise:
 def make_stdio_test_config() -> ClientConfig:
     return ClientConfig(
         name="TEST",
-        binary_args=["python3", "$packages/LSP/tests/server.py"],
+        binary_args=["python3", join("$packages", "LSP", "tests", "server.py")],
         tcp_port=None,
         languages=[LanguageConfig(
             language_id="txt",
@@ -117,7 +117,7 @@ class TextDocumentTestCase(DeferrableTestCase):
             self.assertFalse(True)
         window = sublime.active_window()
         self.assertTrue(window)
-        filename = expand("$packages/LSP/tests/{}.txt".format(test_name), window)
+        filename = expand(join("$packages", "LSP", "tests", "{}.txt".format(test_name)), window)
         self.config.init_options["serverResponse"] = server_capabilities
         window.run_command("close_all")
         # Cleanly shut down all window managers by ending all their sessions

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -365,6 +365,7 @@ class QueryCompletionsTests(TextDocumentTestCase):
                 'def foo: Int = ???\n   def boo: Int = ???')
 
     def test_additional_edits(self) -> 'Generator':
+        yield 200
         self.set_response('textDocument/completion', completion_with_additional_edits)
         handler = self.get_view_event_listener("on_query_completions")
         self.assertIsNotNone(handler)

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -151,6 +151,11 @@ class InitializationTests(DeferrableTestCase):
 
 class QueryCompletionsTests(TextDocumentTestCase):
 
+    def init_view_settings(self) -> None:
+        super().init_view_settings()
+        assert self.view
+        self.view.settings().set("auto_complete_selector", "text.plain")
+
     def await_message(self, msg: str) -> 'Generator':
         if CI:
             yield 500
@@ -365,7 +370,6 @@ class QueryCompletionsTests(TextDocumentTestCase):
                 'def foo: Int = ???\n   def boo: Int = ???')
 
     def test_additional_edits(self) -> 'Generator':
-        yield 200
         self.set_response('textDocument/completion', completion_with_additional_edits)
         handler = self.get_view_event_listener("on_query_completions")
         self.assertIsNotNone(handler)

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -59,7 +59,11 @@ class ConfigTests(DeferrableTestCase):
 class WindowConfigTests(DeferrableTestCase):
 
     def setUp(self):
-        windows._windows.clear()
+        super().setUp()
+        w, windows._windows = windows._windows, {}
+        for window_id, wm in w.items():
+            wm.end_sessions()
+            yield lambda: len(wm._sessions) == 0
         self.view = sublime.active_window().open_file(test_file_path)
 
     def test_window_without_configs(self):
@@ -71,7 +75,7 @@ class WindowConfigTests(DeferrableTestCase):
         pass
 
     def doCleanups(self):
-        if self.view:
+        if hasattr(self, "view") and self.view:
             self.view.set_scratch(True)
             self.view.window().focus_view(self.view)
             self.view.window().run_command("close_file")

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -5,6 +5,8 @@ from LSP.plugin.core.diagnostics import (
     DiagnosticsStorage, DiagnosticsWalker, DiagnosticsCursor, CURSOR_FORWARD, CURSOR_BACKWARD)
 from LSP.plugin.core.protocol import Diagnostic, Point, Range, DiagnosticSeverity
 from test_protocol import LSP_MINIMAL_DIAGNOSTIC
+import sublime
+
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -12,7 +14,7 @@ if TYPE_CHECKING:
     assert List and Dict
 
 
-test_file_path = "/test.py"
+test_file_path = "test.py" if sublime.platform() == "windows" else "/test.py"
 test_file_uri = "file:///test.py"
 second_file_path = "/test2.py"
 second_file_uri = "file:///test2.py"
@@ -61,7 +63,8 @@ class DiagnosticsStorageTest(unittest.TestCase):
         self.assertEqual(len(view_diags["test_server"]), 1)
         self.assertEqual(view_diags["test_server"][0].message, LSP_MINIMAL_DIAGNOSTIC['message'])
         self.assertIn(test_file_path, wd.get())
-        ui.update.assert_called_with(test_file_path, "test_server", {'/test.py': {'test_server': [minimal_diagnostic]}})
+        ui.update.assert_called_with(
+            test_file_path, "test_server", {test_file_path: {'test_server': [minimal_diagnostic]}})
 
         wd.receive("test_server", make_update([]))
         view_diags = wd.get_by_file(test_file_path)

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -1,6 +1,8 @@
 import unittest
 from LSP.plugin.core.edit import sort_by_application_order, parse_workspace_edit, parse_text_edit
+from LSP.plugin.core.url import filename_to_uri
 from test_protocol import LSP_RANGE
+import sublime
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -8,16 +10,13 @@ if TYPE_CHECKING:
     assert List and Dict and Optional and Any and Iterable
 
 LSP_TEXT_EDIT = dict(newText='newText', range=LSP_RANGE)
-
-LSP_EDIT_CHANGES = {
-    'changes': {
-        'file:///file.py': [LSP_TEXT_EDIT]
-    }
-}
+FILENAME = 'C:\\file.py' if sublime.platform() == "windows" else '/file.py'
+URI = filename_to_uri(FILENAME)
+LSP_EDIT_CHANGES = {'changes': {URI: [LSP_TEXT_EDIT]}}
 
 LSP_EDIT_DOCUMENT_CHANGES = {
     'documentChanges': [{
-        'textDocument': {'uri': 'file:///file.py'},
+        'textDocument': {'uri': URI},
         'edits': [LSP_TEXT_EDIT]
     }]
 }
@@ -42,13 +41,15 @@ class WorkspaceEditTests(unittest.TestCase):
 
     def test_parse_changes_from_lsp(self):
         edit = parse_workspace_edit(LSP_EDIT_CHANGES)
+        self.assertIn(FILENAME, edit)
         self.assertEqual(len(edit), 1)
-        self.assertEqual(len(edit['/file.py']), 1)
+        self.assertEqual(len(edit[FILENAME]), 1)
 
     def test_parse_document_changes_from_lsp(self):
         edit = parse_workspace_edit(LSP_EDIT_DOCUMENT_CHANGES)
+        self.assertIn(FILENAME, edit)
         self.assertEqual(len(edit), 1)
-        self.assertEqual(len(edit['/file.py']), 1)
+        self.assertEqual(len(edit[FILENAME]), 1)
 
 
 class SortByApplicationOrderTests(unittest.TestCase):

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,9 +1,9 @@
-from LSP.plugin.core.process import log_stream
 from io import BytesIO
-from subprocess import Popen
+from LSP.plugin.core.process import log_stream
 from unittest import TestCase
 from unittest.mock import MagicMock
 import os
+import subprocess
 
 try:
     from typing import Iterator
@@ -17,7 +17,11 @@ class ProcessTests(TestCase):
 
     def test_log_stream_encoding_utf8(self):
         encoding = 'UTF-8'
-        process = Popen(args=['cmd.exe' if os.name == 'nt' else 'bash'], bufsize=1024)
+        si = None
+        if os.name == "nt":
+            si = subprocess.STARTUPINFO()  # type: ignore
+            si.dwFlags |= subprocess.SW_HIDE | subprocess.STARTF_USESHOWWINDOW  # type: ignore
+        process = subprocess.Popen(args=['cmd.exe' if os.name == 'nt' else 'bash'], bufsize=1024, startupinfo=si)
         process.poll = MagicMock(return_value=None)  # type: ignore
         text = '\U00010000'
         message = ""

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -32,3 +32,4 @@ class ProcessTests(TestCase):
 
         log_stream(process, BytesIO(text.encode(encoding)), log_callback)
         self.assertEqual(message.strip(), text)
+        process.kill()

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -72,6 +72,14 @@ class RequestTests(unittest.TestCase):
         self.assertEqual(payload["method"], "initialize")
         self.assertEqual(payload["params"], {"param": 1})
 
+    def test_shutdown(self):
+        req = Request.shutdown()
+        payload = req.to_payload(1)
+        self.assertEqual(payload["jsonrpc"], "2.0")
+        self.assertEqual(payload["id"], 1)
+        self.assertEqual(payload["method"], "shutdown")
+        self.assertEqual(payload["params"], None)
+
 
 class NotificationTests(unittest.TestCase):
 
@@ -82,3 +90,11 @@ class NotificationTests(unittest.TestCase):
         self.assertNotIn("id", payload)
         self.assertEqual(payload["method"], "initialized")
         self.assertEqual(payload["params"], dict())
+
+    def test_exit(self):
+        notification = Notification.exit()
+        payload = notification.to_payload()
+        self.assertEqual(payload["jsonrpc"], "2.0")
+        self.assertNotIn("id", payload)
+        self.assertEqual(payload["method"], "exit")
+        self.assertEqual(payload["params"], None)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -32,7 +32,6 @@ class SessionTest(unittest.TestCase):
 
     # @unittest.skip("need an example config")
     def test_can_create_session(self):
-
         config = ClientConfig(
             "test",
             ["cmd.exe"] if sublime.platform() == "windows" else ["ls"],
@@ -41,8 +40,7 @@ class SessionTest(unittest.TestCase):
         folders = [WorkspaceFolder.from_path(project_path)]
         session = self.assert_if_none(
             create_session(config, folders, dict(), Settings()))
-        session.end()
-        # self.assertIsNone(session.capabilities) -- empty dict
+        session.client.transport.close()
 
     def test_can_get_started_session(self):
         project_path = "/"

--- a/tests/test_single_document.py
+++ b/tests/test_single_document.py
@@ -1,4 +1,5 @@
 from LSP.plugin.hover import _test_contents
+from LSP.plugin.core.url import filename_to_uri
 from setup import TextDocumentTestCase, TIMEOUT_TIME, PERIOD_TIME, CI
 import unittest
 import sublime
@@ -14,7 +15,7 @@ SELFDIR = os.path.dirname(__file__)
 TEST_FILE_PATH = os.path.join(SELFDIR, 'testfile.txt')
 GOTO_RESPONSE = [
     {
-        'uri': TEST_FILE_PATH,
+        'uri': filename_to_uri(TEST_FILE_PATH),
         'range':
         {
             'start':


### PR DESCRIPTION
A session is ready _or_ initializing if and only if
1) it is present in wm._sessions

A session is ready if and only if
1) it is present in wm._sessions
2) a call to session.handles_path(...) or session.supports_workspace_folders() returns

A session that is exiting is immediately popped from wm._sessions, so we cannot obtain a session that is exiting.

Since wm.get_session(...) always calls session.handles_path, we are guaranteed a ready session.

We have to await the initialize request because we need to determine wether the session is workspace-aware or workspace-unaware before calling session.handles_path.

Language servers that don't respond to the initialize request are disabled temporarily for the window.

- ~Let's try adding a Windows CI~
- [x] Fix all tests on Windows. Some processes were left hanging, others needed filename_to_uri.
- ~Find and make sure that language servers that do elaborate stuff in the initialize request like downloading source code still work.~