### PR TITLE
An empty dict should enable a textDocumentSync notification

### DIFF
--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -165,7 +165,9 @@ class WindowDocumentHandler(object):
 
         # if a TextDocumentSyncOptions object was sent, we can disable some notifications
         if isinstance(sync_options, dict):
-            return bool(sync_options.get(notification_type))
+            notification = sync_options.get(notification_type)
+            if notification is None or notification is False:
+                return False
 
         # otherwise we send them all.
         return True


### PR DESCRIPTION
Noticed `didSave` was not being sent even though rust-analyzer requested `save: {}`.
```
>>> bool({})
False
```

Tested with rust-analyzer.