### PR TITLE
Disable a server only for a specific folder of the project, if it fails to init

### DIFF
--- a/plugin/core/clients.py
+++ b/plugin/core/clients.py
@@ -1,7 +1,7 @@
 from .protocol import WorkspaceFolder
 from .sessions import create_session, Session
 from .settings import ClientConfig, settings
-from .typing import List, Dict, Tuple, Callable, Optional
+from .typing import Any, List, Dict, Tuple, Callable, Optional
 import os
 import sublime
 
@@ -28,15 +28,17 @@ def get_window_env(window: sublime.Window, config: ClientConfig) -> Tuple[List[s
 
 def start_window_config(window: sublime.Window,
                         workspace_folders: List[WorkspaceFolder],
+                        designated_folder: Optional[WorkspaceFolder],
                         config: ClientConfig,
                         on_pre_initialize: Callable[[Session], None],
-                        on_post_initialize: Callable[[Session], None],
+                        on_post_initialize: Callable[[Session, Optional[Dict[str, Any]]], None],
                         on_post_exit: Callable[[str], None],
                         on_stderr_log: Optional[Callable[[str], None]]) -> Optional[Session]:
     args, env = get_window_env(window, config)
     config.binary_args = args
     return create_session(config=config,
                           workspace_folders=workspace_folders,
+                          designated_folder=designated_folder,
                           env=env,
                           settings=settings,
                           on_pre_initialize=on_pre_initialize,

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -435,6 +435,9 @@ class WorkspaceFolder:
             return self.name == other.name and self.path == other.path
         return False
 
+    def __hash__(self) -> int:
+        return hash(self.path)
+
     def to_lsp(self) -> Dict[str, str]:
         return {"name": self.name, "uri": self.uri()}
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -13,12 +13,12 @@ import threading
 ACQUIRE_READY_LOCK_TIMEOUT = 3
 
 
-def get_initialize_params(workspace_folders: List[WorkspaceFolder], config: ClientConfig) -> dict:
-    first_folder = workspace_folders[0] if workspace_folders else None
+def get_initialize_params(workspace_folders: List[WorkspaceFolder], designated_folder: Optional[WorkspaceFolder],
+                          config: ClientConfig) -> dict:
     initializeParams = {
         "processId": os.getpid(),
-        "rootUri": first_folder.uri() if first_folder else None,
-        "rootPath": first_folder.path if first_folder else None,
+        "rootUri": designated_folder.uri() if designated_folder else None,
+        "rootPath": designated_folder.path if designated_folder else None,
         "workspaceFolders": [folder.to_lsp() for folder in workspace_folders] if workspace_folders else None,
         "capabilities": {
             "textDocument": {
@@ -106,19 +106,20 @@ def diff_folders(old: List[WorkspaceFolder],
 
 class InitializeError(Exception):
 
-    def __init__(self, config_name: str) -> None:
-        super().__init__("The server did not respond to the initialize request within {} seconds".format(
-            ACQUIRE_READY_LOCK_TIMEOUT))
-        self.name = config_name
+    def __init__(self, session: 'Session') -> None:
+        super().__init__("{} did not respond to the initialize request within {} seconds".format(
+            session.config.name, ACQUIRE_READY_LOCK_TIMEOUT))
+        self.session = session
 
 
 class Session(object):
     def __init__(self,
                  config: ClientConfig,
                  workspace_folders: List[WorkspaceFolder],
+                 designated_folder: Optional[WorkspaceFolder],
                  client: Client,
                  on_pre_initialize: 'Optional[Callable[[Session], None]]' = None,
-                 on_post_initialize: 'Optional[Callable[[Session], None]]' = None,
+                 on_post_initialize: 'Optional[Callable[[Session, Optional[Dict[str, Any]]], None]]' = None,
                  on_post_exit: Optional[Callable[[str], None]] = None) -> None:
         self.config = config
         self._on_post_initialize = on_post_initialize
@@ -127,6 +128,7 @@ class Session(object):
         self.client = client
         self.ready_lock = threading.Lock()
         self._workspace_folders = workspace_folders
+        self.designated_folder = designated_folder
         if on_pre_initialize:
             on_pre_initialize(self)
         self._initialize()
@@ -141,7 +143,7 @@ class Session(object):
     def acquire_timeout(self) -> Generator[None, None, None]:
         acquired = self.ready_lock.acquire(True, ACQUIRE_READY_LOCK_TIMEOUT)
         if not acquired:
-            raise InitializeError(self.config.name)
+            raise InitializeError(self)
         yield
         self.ready_lock.release()
 
@@ -174,7 +176,7 @@ class Session(object):
 
     def _initialize(self) -> None:
         self.ready_lock.acquire()  # released in _handle_initialize_result or _handle_initialize_error
-        params = get_initialize_params(self._workspace_folders, self.config)
+        params = get_initialize_params(self._workspace_folders, self.designated_folder, self.config)
         self.client.send_request(
             Request.initialize(params),
             self._handle_initialize_result,
@@ -192,7 +194,8 @@ class Session(object):
 
     def _handle_initialize_error(self, error: Any) -> None:
         self.ready_lock.release()  # acquired in _initialize
-        self.end()
+        if self._on_post_initialize:
+            self._on_post_initialize(self, error)
 
     def _handle_initialize_result(self, result: Any) -> None:
         self.capabilities = result.get('capabilities', dict())
@@ -202,8 +205,9 @@ class Session(object):
             if self._unsafe_supports_workspace_folders():
                 debug('multi folder session:', self._workspace_folders)
             else:
-                self._workspace_folders = self._workspace_folders[:1]
-                debug('single folder session:', self._workspace_folders[0])
+                assert self.designated_folder  # mypy
+                self._workspace_folders = [self.designated_folder]
+                debug('single folder session:', self._workspace_folders)
         else:
             debug("session with no workspace folders")
 
@@ -214,7 +218,7 @@ class Session(object):
         self.ready_lock.release()  # acquired in _initialize
 
         if self._on_post_initialize:
-            self._on_post_initialize(self)
+            self._on_post_initialize(self, None)
 
     def _handle_workspace_folders(self, request_id: int) -> None:
         self.client.send_response(Response(request_id, [wf.to_lsp() for wf in self._workspace_folders]))
@@ -235,10 +239,11 @@ class Session(object):
 
 def create_session(config: ClientConfig,
                    workspace_folders: List[WorkspaceFolder],
+                   designated_folder: Optional[WorkspaceFolder],
                    env: dict,
                    settings: Settings,
                    on_pre_initialize: Optional[Callable[[Session], None]] = None,
-                   on_post_initialize: Optional[Callable[[Session], None]] = None,
+                   on_post_initialize: Optional[Callable[[Session, Optional[Dict[str, Any]]], None]] = None,
                    on_post_exit: Optional[Callable[[str], None]] = None,
                    on_stderr_log: Optional[Callable[[str], None]] = None,
                    bootstrap_client: Optional[Any] = None) -> Optional[Session]:
@@ -247,6 +252,7 @@ def create_session(config: ClientConfig,
         return Session(
             config=config,
             workspace_folders=workspace_folders,
+            designated_folder=designated_folder,
             client=client,
             on_pre_initialize=on_pre_initialize,
             on_post_initialize=on_post_initialize,

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -1,7 +1,7 @@
 from .diagnostics import DiagnosticsStorage
 from .edit import parse_workspace_edit
-from .logging import debug
-from .protocol import Notification, Response
+from .logging import debug, exception_log
+from .protocol import Notification, Response, WorkspaceFolder
 from .rpc import Client
 from .sessions import Session, InitializeError
 from .types import ClientConfig
@@ -12,13 +12,12 @@ from .types import LanguageConfig
 from .types import Settings
 from .types import ViewLike
 from .types import WindowLike
-from .typing import Optional, List, Callable, Dict, Any, Protocol
+from .typing import Optional, List, Callable, Dict, Any, Protocol, Set, Union
 from .url import filename_to_uri
 from .workspace import get_workspace_folders
 from .workspace import disable_in_project
 from .workspace import enable_in_project
 from .workspace import ProjectFolders
-from .workspace import sorted_workspace_folders
 import threading
 
 
@@ -366,6 +365,7 @@ class WindowManager(object):
         self._workspace = workspace
         self._workspace.on_changed = self._on_project_changed
         self._workspace.on_switched = self._on_project_switched
+        self._blacklist = {}  # type: Dict[str, Set[Optional[WorkspaceFolder]]]
 
     def _on_project_changed(self, folders: List[str]) -> None:
         workspace_folders = get_workspace_folders(self._workspace.folders)
@@ -381,7 +381,8 @@ class WindowManager(object):
         try:
             return self._find_session(config_name, file_path)
         except InitializeError as ex:
-            self._disable_temporarily(ex.name, ex)
+            assert ex.session.config.name == config_name
+            self._disable_temporarily(ex.session, ex, self._workspace.designated(file_path))
         return None
 
     def _find_session(self, config_name: str, file_path: str) -> Optional[Session]:
@@ -430,11 +431,9 @@ class WindowManager(object):
         new_configs = []
         for c in configs:
             sessions = self._sessions.get(c.name, None)
-            if sessions is None:
+            if not sessions:
                 new_configs.append(c)
                 continue
-            assert isinstance(sessions, list)
-            assert len(sessions) > 0
             first_session = sessions[0]
             if first_session.supports_workspace_folders():
                 # A workspace-aware language server handles any path, both inside and outside the workspace.
@@ -472,19 +471,39 @@ class WindowManager(object):
                     debug("window {} requests {} for {}".format(self._window.id(), config.name, file_path))
                     self._start_client(config, file_path)
 
-    def _disable_temporarily(self, name: str, e: Exception) -> None:
-        message = "\n\n".join([
-            "Could not start {}",
-            "{}",
-            "Server will be disabled for this window"
-        ]).format(name, str(e))
-        sessions = self._sessions.pop(name, [])
-        self._configs.disable_temporarily(name)
-        self._sublime.message_dialog(message)
-        for session in sessions:
+    def _disable_temporarily(self, session: Union[str, Session], ex: Exception,
+                             folder: Optional[WorkspaceFolder]) -> None:
+        if isinstance(session, Session):
+            # The process started, but failed to respond to the initialize request. Disable locally for the folder
             session.end()
+            name = session.config.name
+            config_sessions = self._sessions.get(name, [])
+            try:
+                config_sessions.remove(session)
+            except ValueError:
+                debug("should never end up here")
+                pass
+            path = folder.path if folder else "folderless window"
+            msg = "{} for {} did not initialize properly. Disabling until this window is restarted".format(name, path)
+            self._sublime.status_message(msg)
+            self._blacklist.setdefault(name, set()).add(folder)
+        else:
+            # The process did not even start. Disable the configuration.
+            name = session
+            msg = "\n\n".join(["Could not start {}", "{}", "Server will be disabled for this window"]).format(
+                name, str(ex))
+            sessions = self._sessions.pop(name, [])
+            self._configs.disable_temporarily(name)
+            self._sublime.message_dialog(msg)
+            for session in sessions:
+                session.end()
+        exception_log(msg, ex)
 
     def _start_client(self, config: ClientConfig, file_path: str) -> None:
+        designated_folder = self._workspace.designated(file_path)
+        if designated_folder in self._blacklist.get(config.name, set()):
+            debug(config.name, "failed to start for", designated_folder, "not attempting again until ST is restarted")
+            return
         session = self.get_session(config.name, file_path)
         if session is not None:
             debug(config.name, "was already started")
@@ -494,18 +513,19 @@ class WindowManager(object):
             return
 
         self._window.status_message("Starting " + config.name + "...")
-        workspace_folders = sorted_workspace_folders(self._workspace.folders, file_path)
         try:
             session = self._start_session(
                 self._window,                  # window
-                workspace_folders,             # workspace_folders
+                self._workspace.all(),         # workspace_folders
+                designated_folder,             # designated_folder
                 config,                        # config
                 self._handle_pre_initialize,   # on_pre_initialize
                 self._handle_post_initialize,  # on_post_initialize
                 self._handle_post_exit,        # on_post_exit
                 lambda msg: self._handle_stderr_log(config.name, msg))  # on_stderr_log
         except Exception as e:
-            self._disable_temporarily(config.name, e)
+            self._disable_temporarily(config.name, e, designated_folder)
+            return
 
         if session:
             debug("window {} added session {}".format(self._window.id(), config.name))
@@ -591,7 +611,13 @@ class WindowManager(object):
             "window/logMessage",
             lambda params: self._handle_log_message(session.config.name, params))
 
-    def _handle_post_initialize(self, session: Session) -> None:
+    def _handle_post_initialize(self, session: Session, error: Optional[Dict[str, Any]]) -> None:
+        if error is not None:
+            message = error['message']
+            self._sublime.error_message(message)
+            self._disable_temporarily(session, RuntimeError(message), session.designated_folder)
+            return
+
         client = session.client
 
         # handle server requests and notifications

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -1,7 +1,7 @@
 from .logging import debug
 from .protocol import WorkspaceFolder
 from .types import WindowLike
-from .typing import List, Optional, Any, Callable
+from .typing import List, Optional, Any, Callable, Tuple
 from os.path import commonprefix
 
 
@@ -14,6 +14,19 @@ class ProjectFolders(object):
         self.folders = []  # type: List[str]
         self._current_project_file_name = self._window.project_file_name()
         self._set_folders(window.folders())
+
+    def all(self) -> List[WorkspaceFolder]:
+        return [WorkspaceFolder.from_path(f) for f in self.folders]
+
+    def designated(self, file_path: str) -> Optional[WorkspaceFolder]:
+        try:
+            return WorkspaceFolder.from_path(max(self.folders, key=lambda f: len(f) if file_path.startswith(f) else -1))
+        except ValueError:
+            # folderless window
+            return None
+
+    def all_and_designated(self, file_path: str) -> Tuple[List[WorkspaceFolder], Optional[WorkspaceFolder]]:
+        return self.all(), self.designated(file_path)
 
     def update(self) -> None:
         new_folders = self._window.folders()
@@ -63,16 +76,6 @@ class ProjectFolders(object):
 
 def get_workspace_folders(folders: List[str]) -> List[WorkspaceFolder]:
     return [WorkspaceFolder.from_path(f) for f in folders]
-
-
-def sorted_workspace_folders(folders: List[str], file_path: str) -> List[WorkspaceFolder]:
-    sorted_folders = []  # type: List[WorkspaceFolder]
-    for folder in folders:
-        if file_path and file_path.startswith(folder):
-            sorted_folders.insert(0, WorkspaceFolder.from_path(folder))
-        else:
-            sorted_folders.append(WorkspaceFolder.from_path(folder))
-    return sorted_folders
 
 
 def enable_in_project(window: Any, config_name: str) -> None:

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -39,7 +39,7 @@ class WindowDocumentHandlerTests(unittest.TestCase):
         handler = WindowDocumentHandler(test_sublime, MockSettings(), window, workspace, MockConfigs())
         client = MockClient()
         session = self.assert_if_none(
-            create_session(TEST_CONFIG, folders, dict(), MockSettings(),
+            create_session(TEST_CONFIG, folders, folders[0], dict(), MockSettings(),
                            bootstrap_client=client))
         handler.add_session(session)
 
@@ -102,12 +102,12 @@ class WindowDocumentHandlerTests(unittest.TestCase):
         handler = WindowDocumentHandler(test_sublime, MockSettings(), window, workspace, MockConfigs())
         client = MockClient()
         session = self.assert_if_none(
-            create_session(TEST_CONFIG, folders, dict(), MockSettings(),
+            create_session(TEST_CONFIG, folders, folders[0], dict(), MockSettings(),
                            bootstrap_client=client))
         client2 = MockClient()
         test_config2 = ClientConfig("test2", [], None, languages=[TEST_LANGUAGE])
         session2 = self.assert_if_none(
-            create_session(test_config2, folders, dict(), MockSettings(),
+            create_session(test_config2, folders, folders[0], dict(), MockSettings(),
                            bootstrap_client=client2))
 
         handler.add_session(session)

--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -7,6 +7,7 @@ from LSP.plugin.core.types import LanguageConfig
 from LSP.plugin.core.types import Settings
 from LSP.plugin.core.types import ViewLike
 import os
+import copy
 
 try:
     from typing import Dict, Set, List, Optional, Any, Tuple, Callable
@@ -205,7 +206,7 @@ class TestGlobalConfigs(object):
 
 class MockConfigs(object):
     def __init__(self):
-        self.all = [TEST_CONFIG]
+        self.all = [copy.deepcopy(TEST_CONFIG)]
 
     def is_supported(self, view):
         return any(self.scope_configs(view))
@@ -243,7 +244,8 @@ class MockConfigs(object):
         pass
 
     def disable_temporarily(self, config_name: str) -> None:
-        pass
+        if config_name == self.all[0].name:
+            self.all[0].enabled = False
 
 
 class MockDocuments(object):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -39,6 +39,7 @@ class SessionTest(unittest.TestCase):
             create_session(
                 config=TEST_CONFIG,
                 workspace_folders=folders,
+                designated_folder=folders[0],
                 env=dict(),
                 settings=Settings(),
                 bootstrap_client=bootstrap_client,
@@ -55,7 +56,7 @@ class SessionTest(unittest.TestCase):
         project_path = "/"
         folders = [WorkspaceFolder.from_path(project_path)]
         session = self.assert_if_none(
-            create_session(config, folders, dict(), Settings()))
+            create_session(config, folders, folders[0], dict(), Settings()))
         session.client.transport.close()
 
     def test_can_get_started_session(self):

--- a/tests/test_sublime.py
+++ b/tests/test_sublime.py
@@ -31,6 +31,10 @@ def _run_timeout():
         callback()
 
 
+def status_message(s: str) -> None:
+    pass
+
+
 class Region(object):
     def __init__(self, a, b):
         self.a = a

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -236,3 +236,28 @@ class WindowManagerTests(unittest.TestCase):
             wm.activate_view(another_view)
             _ = wm.get_session(TEST_CONFIG.name, outside_file)
             self.assertEqual(len(wm._sessions), 1)
+
+    def test_disables_server_for_workspace_folder(self):
+        with tempfile.TemporaryDirectory() as folder1:
+            with tempfile.TemporaryDirectory() as folder2:
+                file1 = os.path.join(folder1, "foo.txt")
+                with open(file1, "w") as fp:
+                    print("hello", file=fp)
+                file2 = os.path.join(folder2, "foo.txt")
+                with open(file2, "w") as fp:
+                    print("world", file=fp)
+                _, _, _, wm = self.make([[MockView(file1)]], [folder1, folder2])
+                wm._disable_temporarily(wm.get_session(TEST_CONFIG.name, file1), RuntimeError("bla"),
+                                        WorkspaceFolder.from_path(folder1))
+                self.assertIn(TEST_CONFIG.name, wm._blacklist)
+                self.assertIn(WorkspaceFolder.from_path(folder1), wm._blacklist[TEST_CONFIG.name])
+                # We should be able to start a session in another folder of the project
+                wm._initialize_on_open(MockView(file2))
+                self.assertIsNotNone(wm.get_session(TEST_CONFIG.name, file2))
+
+    def test_disables_server_entirely(self):
+        _, _, _, wm = self.make([[MockView(__file__)]])
+        folder = WorkspaceFolder.from_path(os.path.dirname(__file__))
+        wm._disable_temporarily(TEST_CONFIG.name, RuntimeError("hello"), folder)
+        self.assertEqual(len(wm._configs.all), 1)
+        self.assertFalse(wm._configs.all[0].enabled)

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -32,14 +32,16 @@ except ImportError:
 
 def mock_start_session(window: MockWindow,
                        workspace_folders: 'List[WorkspaceFolder]',
+                       designated_folder: 'Optional[WorkspaceFolder]',
                        config: ClientConfig,
                        on_pre_initialize: 'Callable[[Session], None]',
-                       on_post_initialize: 'Callable[[Session], None]',
+                       on_post_initialize: 'Callable[[Session, Optional[Dict[str, Any]]], None]',
                        on_post_exit: 'Callable[[str], None]',
                        on_stderr_log: 'Optional[Callable[[str], None]]') -> 'Optional[Session]':
     return create_session(
         config=TEST_CONFIG,
         workspace_folders=workspace_folders,
+        designated_folder=designated_folder,
         env=dict(),
         settings=MockSettings(),
         bootstrap_client=MockClient(),


### PR DESCRIPTION
Moreover, account for nested workspace folders.
Added a test for this.
Also, disable a language server if it responds with an error for the initialize request.
Flow returns an error when its version doesn't match with what is stated in .flowconfig.

Tested with Flow language server and a sublime project with the structure /foo, /foo/bar.

This results in the following behavior:
1. Language server is started for some folder /foo
2. It fails somehow. "blacklist" the server name + folder pair
3. A file is opened in another workspace.
4. Language is not blacklisted for this server name + folder pair, so we attempt to start a process
5. It succeeds.
6. User can move on with his/her work.

Thus there are two ways to disable a lang server:

1. Disable locally per workspace folder. We do this if it succeeds to start, but fails to initialize
2. Disable the configuration for the window. We do this if it doesn't start.

close #860 