### PR TITLE
Notify textDocument/willSave, and include text (if needed) in textDocument/didSave

### DIFF
--- a/messages/0.9.4.txt
+++ b/messages/0.9.4.txt
@@ -21,6 +21,12 @@ Fixes:
   two folders in your sublime-project, and one is contained in the other, the
   wrong folder would be reported as the rootUri in the initialize request.
 
+* textDocument/willSave is now sent before saving the view if the language
+  server is interested in this notification.
+
+* textDocument/didSave now includes the content of the view if the language
+  server wants it.
+
 * The tests/ folder is now part of the export-ignore attribute in the
   .gitattributes file, so the .sublime-package file that you installed through
   Package Control will be smaller.

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -2,7 +2,7 @@ import sublime
 import sublime_plugin
 from .core.completion import parse_completion_response, format_completion
 from .core.configurations import is_supported_syntax
-from .core.documents import get_document_position, position_is_word
+from .core.documents import position_is_word
 from .core.edit import parse_text_edit
 from .core.logging import debug
 from .core.protocol import Request
@@ -10,6 +10,7 @@ from .core.registry import session_for_view, client_from_session, LSPViewEventLi
 from .core.sessions import Session
 from .core.settings import settings, client_configs
 from .core.typing import Any, List, Dict, Tuple, Optional, Union
+from .core.views import text_document_position_params
 
 
 class CompletionState(object):
@@ -260,13 +261,12 @@ class CompletionHandler(LSPViewEventListener):
 
         if settings.complete_all_chars or self.is_after_trigger_character(locations[0]):
             self.manager.documents.purge_changes(self.view)
-            document_position = get_document_position(view, locations[0])
-            if document_position:
-                client.send_request(
-                    Request.complete(document_position),
-                    self.handle_response,
-                    self.handle_error)
-                self.state = CompletionState.REQUESTING
+            document_position = text_document_position_params(self.view, locations[0])
+            client.send_request(
+                Request.complete(document_position),
+                self.handle_response,
+                self.handle_error)
+            self.state = CompletionState.REQUESTING
 
     def do_resolve(self, item: dict) -> None:
         view = self.view

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -228,6 +228,10 @@ class Notification:
         return Notification("textDocument/didChange", params)
 
     @classmethod
+    def willSave(cls, params: dict) -> 'Notification':
+        return Notification("textDocument/willSave", params)
+
+    @classmethod
     def didSave(cls, params: dict) -> 'Notification':
         return Notification("textDocument/didSave", params)
 

--- a/plugin/core/rpc.py
+++ b/plugin/core/rpc.py
@@ -65,9 +65,13 @@ class PreformattedPayloadLogger:
     def outgoing_notification(self, method: str, params: Any) -> None:
         if not self.settings.log_debug:
             return
+        # Do not log the payloads if any of these conditions occur because the payloads might contain the entire
+        # content of the view.
         log_payload = self.settings.log_payloads \
             and method != "textDocument/didChange" \
             and method != "textDocument/didOpen"
+        if log_payload and method == "textDocument/didSave" and isinstance(params, dict) and "text" in params:
+            log_payload = False
         self.log(self.format_notification(Direction.Outgoing, method), params, log_payload)
 
     def incoming_response(self, request_id: int, params: Any) -> None:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -25,6 +25,7 @@ def get_initialize_params(workspace_folders: List[WorkspaceFolder], designated_f
             "textDocument": {
                 "synchronization": {
                     "didSave": True,
+                    "willSave": True,
                     "willSaveWaitUntil": True
                 },
                 "hover": {

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1,6 +1,7 @@
 from .logging import debug
 from .process import start_server
 from .protocol import completion_item_kinds, symbol_kinds, WorkspaceFolder, Request, Notification
+from .protocol import TextDocumentSyncKindNone
 from .rpc import Client, attach_stdio_client, Response
 from .transports import start_tcp_transport, start_tcp_listener, TCPTransport, Transport
 from .types import ClientConfig, Settings
@@ -139,6 +140,51 @@ class Session(object):
     def get_capability(self, capability: str) -> Optional[Any]:
         return self.capabilities.get(capability)
 
+    def should_notify_did_open(self) -> bool:
+        textsync = self.capabilities.get('textDocumentSync')
+        if isinstance(textsync, dict):
+            return bool(textsync.get('openClose'))
+        if isinstance(textsync, int):
+            return textsync > TextDocumentSyncKindNone
+        return False
+
+    def text_sync_kind(self) -> int:
+        textsync = self.capabilities.get('textDocumentSync')
+        if isinstance(textsync, dict):
+            return int(textsync.get('change', TextDocumentSyncKindNone))
+        if isinstance(textsync, int):
+            return textsync
+        return TextDocumentSyncKindNone
+
+    def should_notify_did_change(self) -> bool:
+        return self.text_sync_kind() > TextDocumentSyncKindNone
+
+    def should_notify_will_save(self) -> bool:
+        textsync = self.capabilities.get('textDocumentSync')
+        if isinstance(textsync, dict):
+            return bool(textsync.get('willSave'))
+        if isinstance(textsync, int):
+            return textsync > TextDocumentSyncKindNone
+        return False
+
+    def should_request_will_save_wait_until(self) -> bool:
+        textsync = self.capabilities.get('textDocumentSync')
+        if isinstance(textsync, dict):
+            return bool(textsync.get('willSaveWaitUntil'))
+        return False
+
+    def should_notify_did_save(self) -> Tuple[bool, bool]:
+        textsync = self.capabilities.get('textDocumentSync')
+        if isinstance(textsync, dict):
+            options = textsync.get('save')
+            return True, bool(options.get('includeText')) if isinstance(options, dict) else False
+        if isinstance(textsync, int):
+            return textsync > TextDocumentSyncKindNone, False
+        return False, False
+
+    def should_notify_did_close(self) -> bool:
+        return self.should_notify_did_open()
+
     @contextmanager
     def acquire_timeout(self) -> Generator[None, None, None]:
         acquired = self.ready_lock.acquire(True, ACQUIRE_READY_LOCK_TIMEOUT)
@@ -198,7 +244,7 @@ class Session(object):
             self._on_post_initialize(self, error)
 
     def _handle_initialize_result(self, result: Any) -> None:
-        self.capabilities = result.get('capabilities', dict())
+        self.capabilities.update(result.get('capabilities', dict()))
 
         # only keep supported amount of folders
         if self._workspace_folders:
@@ -232,7 +278,7 @@ class Session(object):
     def _handle_shutdown_result(self) -> None:
         self.client.exit()
         self.client = None  # type: ignore
-        self.capabilities = dict()
+        self.capabilities.clear()
         if self._on_post_exit:
             self._on_post_exit(self.config.name)
 

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -1,7 +1,8 @@
 import sublime
 import linecache
-from .protocol import Point, Range
-from .typing import Optional
+from .protocol import Point, Range, Notification, Request
+from .typing import Optional, Dict, Any
+from .url import filename_to_uri
 
 
 def get_line(window: Optional[sublime.Window], file_name: str, row: int) -> str:
@@ -40,3 +41,114 @@ def region_to_range(view: sublime.View, region: sublime.Region) -> Range:
         offset_to_point(view, region.begin()),
         offset_to_point(view, region.end())
     )
+
+
+class MissingFilenameError(Exception):
+
+    def __init__(self, view_id: int) -> None:
+        super().__init__("View {} has no filename".format(view_id))
+        self.view_id = view_id
+
+
+def uri_from_view(view: sublime.View) -> str:
+    file_name = view.file_name()
+    if file_name:
+        return filename_to_uri(file_name)
+    raise MissingFilenameError(view.id())
+
+
+def text_document_identifier(view: sublime.View) -> Dict[str, Any]:
+    return {"uri": uri_from_view(view)}
+
+
+def entire_content(view: sublime.View) -> str:
+    return view.substr(sublime.Region(0, view.size()))
+
+
+def text_document_item(view: sublime.View, language_id: str) -> Dict[str, Any]:
+    return {
+        "uri": uri_from_view(view),
+        "languageId": language_id,
+        "version": view.change_count(),
+        "text": entire_content(view)
+    }
+
+
+def versioned_text_document_identifier(view: sublime.View) -> Dict[str, Any]:
+    return {"uri": uri_from_view(view), "version": view.change_count()}
+
+
+def text_document_position_params(view: sublime.View, location: int) -> Dict[str, Any]:
+    return {"textDocument": text_document_identifier(view), "position": offset_to_point(view, location).to_lsp()}
+
+
+def did_open_text_document_params(view: sublime.View, language_id: str) -> Dict[str, Any]:
+    return {"textDocument": text_document_item(view, language_id)}
+
+
+def did_change_text_document_params(view: sublime.View) -> Dict[str, Any]:
+    return {
+        "textDocument": versioned_text_document_identifier(view),
+        "contentChanges": [{"text": entire_content(view)}]
+    }
+
+
+def will_save_text_document_params(view: sublime.View, reason: int) -> Dict[str, Any]:
+    return {"textDocument": text_document_identifier(view), "reason": reason}
+
+
+def did_save_text_document_params(view: sublime.View, include_text: bool) -> Dict[str, Any]:
+    result = {"textDocument": text_document_identifier(view)}  # type: Dict[str, Any]
+    if include_text:
+        result["text"] = entire_content(view)
+    return result
+
+
+def did_close_text_document_params(view: sublime.View) -> Dict[str, Any]:
+    return {"textDocument": text_document_identifier(view)}
+
+
+def did_open(view: sublime.View, language_id: str) -> Notification:
+    return Notification.didOpen(did_open_text_document_params(view, language_id))
+
+
+def did_change(view: sublime.View) -> Notification:
+    return Notification.didChange(did_change_text_document_params(view))
+
+
+def will_save(view: sublime.View, reason: int) -> Notification:
+    return Notification.willSave(will_save_text_document_params(view, reason))
+
+
+def will_save_wait_until(view: sublime.View, reason: int) -> Request:
+    return Request.willSaveWaitUntil(will_save_text_document_params(view, reason))
+
+
+def did_save(view: sublime.View, include_text: bool) -> Notification:
+    return Notification.didSave(did_save_text_document_params(view, include_text))
+
+
+def did_close(view: sublime.View) -> Notification:
+    return Notification.didClose(did_close_text_document_params(view))
+
+
+def formatting_options(settings: sublime.Settings) -> Dict[str, Any]:
+    return {
+        "tabSize": settings.get("tab_size", 4),
+        "insertSpaces": settings.get("translate_tabs_to_spaces", False)
+    }
+
+
+def text_document_formatting(view: sublime.View) -> Request:
+    return Request.formatting({
+        "textDocument": text_document_identifier(view),
+        "options": formatting_options(view.settings())
+    })
+
+
+def text_document_range_formatting(view: sublime.View, region: sublime.Region) -> Request:
+    return Request.rangeFormatting({
+        "textDocument": text_document_identifier(view),
+        "options": formatting_options(view.settings()),
+        "range": region_to_range(view, region).to_lsp()
+    })

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -13,10 +13,10 @@ from .types import Settings
 from .types import ViewLike
 from .types import WindowLike
 from .typing import Optional, List, Callable, Dict, Any, Protocol, Set, Union
-from .url import filename_to_uri
-from .workspace import get_workspace_folders
+from .views import did_change, did_close, did_open, did_save, will_save
 from .workspace import disable_in_project
 from .workspace import enable_in_project
+from .workspace import get_workspace_folders
 from .workspace import ProjectFolders
 import threading
 
@@ -56,6 +56,9 @@ class DocumentHandler(Protocol):
         ...
 
     def purge_changes(self, view: ViewLike) -> None:
+        ...
+
+    def handle_will_save(self, view: ViewLike, reason: int) -> None:
         ...
 
     def handle_view_saved(self, view: ViewLike) -> None:
@@ -125,14 +128,13 @@ class WindowDocumentHandler(object):
     def has_document_state(self, path: str) -> bool:
         return path in self._document_states
 
-    def _get_applicable_sessions(self, view: ViewLike, notification_type: Optional[str] = None) -> List[Session]:
+    def _get_applicable_sessions(self, view: ViewLike) -> List[Session]:
         sessions = []  # type: List[Session]
         syntax = view.settings().get("syntax")
 
         def conditional_append(session: Session) -> None:
             if config_supports_syntax(session.config, syntax):
-                if not notification_type or self._session_supports_notification(session, notification_type):
-                    sessions.append(session)
+                sessions.append(session)
 
         if view in self._workspace:
             for sessions_per_config_name in self._sessions.values():
@@ -145,25 +147,6 @@ class WindowDocumentHandler(object):
                 conditional_append(sessions_per_config_name[0])
         return sessions
 
-    def _session_supports_notification(self, session: Session, notification_type: str) -> bool:
-        """
-            openClose: boolean
-            change: 0 (none), 1 (full), 2 (incremental)
-            willSave: boolean
-            willSaveWaitUntil: boolean
-            save: {includeText: boolean}
-        """
-        sync_options = session.capabilities.get('textDocumentSync')
-
-        # if a TextDocumentSyncOptions object was sent, we can disable some notifications
-        if isinstance(sync_options, dict):
-            notification = sync_options.get(notification_type)
-            if notification is None or notification is False:
-                return False
-
-        # otherwise we send them all.
-        return True
-
     def _notify_open_documents(self, session: Session) -> None:
         for file_name in self._document_states:
             if session.handles_path(file_name):
@@ -173,7 +156,9 @@ class WindowDocumentHandler(object):
                     if config_supports_syntax(session.config, syntax):
                         sessions = self._get_applicable_sessions(view)
                         self._attach_view(view, sessions)
-                        self._notify_did_open(view, session)
+                        for session in sessions:
+                            if session.should_notify_did_open():
+                                self._notify_did_open(view, session)
 
     def _is_supported_view(self, view: ViewLike) -> bool:
         return self._configs.syntax_supported(view)
@@ -190,9 +175,8 @@ class WindowDocumentHandler(object):
         view.settings().erase("show_definitions")
         view.set_status("lsp_clients", "")
 
-    def _view_language(self, view: ViewLike, config_name: str) -> Optional[str]:
-        languages = view.settings().get('lsp_language')
-        return languages.get(config_name) if languages else None
+    def _view_language(self, view: ViewLike, config_name: str) -> str:
+        return view.settings().get('lsp_language')[config_name]
 
     def _set_view_languages(self, view: ViewLike, config_languages: Dict[str, LanguageConfig]) -> None:
         languages = {}
@@ -215,42 +199,45 @@ class WindowDocumentHandler(object):
                 sessions = self._get_applicable_sessions(view)
                 self._attach_view(view, sessions)
                 for session in sessions:
-                    if self._session_supports_notification(session, 'openClose'):
+                    if session.should_notify_did_open():
                         self._notify_did_open(view, session)
 
     def _notify_did_open(self, view: ViewLike, session: Session) -> None:
-        file_name = view.file_name()
-        if file_name:
-            params = {
-                "textDocument": {
-                    "uri": filename_to_uri(file_name),
-                    "languageId": self._view_language(view, session.config.name),
-                    "text": view.substr(self._sublime.Region(0, view.size())),
-                    "version": view.change_count()
-                }
-            }
-            session.client.send_notification(Notification.didOpen(params))
+        language_id = self._view_language(view, session.config.name)
+        if session.client:
+            # mypy: expected sublime.View, got ViewLike
+            session.client.send_notification(did_open(view, language_id))  # type: ignore
 
     def handle_view_closed(self, view: ViewLike) -> None:
         file_name = view.file_name() or ""
         try:
             self._document_states.remove(file_name)
-        except ValueError:
+        except KeyError:
             return
-        for session in self._get_applicable_sessions(view, 'openClose'):
-            debug('closing', file_name, session.config.name)
-            if session.client:
-                params = {"textDocument": {"uri": filename_to_uri(file_name)}}
-                session.client.send_notification(Notification.didClose(params))
+        # mypy: expected sublime.View, got ViewLike
+        notification = did_close(view)  # type: ignore
+        for session in self._get_applicable_sessions(view):
+            if session.client and session.should_notify_did_close():
+                session.client.send_notification(notification)
+
+    def handle_will_save(self, view: ViewLike, reason: int) -> None:
+        file_name = view.file_name()
+        if file_name in self._document_states:
+            for session in self._get_applicable_sessions(view):
+                if session.client and session.should_notify_will_save():
+                    # mypy: expected sublime.View, got ViewLike
+                    session.client.send_notification(will_save(view, reason))  # type: ignore
 
     def handle_view_saved(self, view: ViewLike) -> None:
         file_name = view.file_name()
         if file_name in self._document_states:
             self.purge_changes(view)
-            for session in self._get_applicable_sessions(view, 'save'):
+            for session in self._get_applicable_sessions(view):
                 if session.client:
-                    params = {"textDocument": {"uri": filename_to_uri(file_name)}}
-                    session.client.send_notification(Notification.didSave(params))
+                    send_did_save, include_text = session.should_notify_did_save()
+                    if send_did_save:
+                        # mypy: expected sublime.View, got ViewLike
+                        session.client.send_notification(did_save(view, include_text))  # type: ignore
             self.saved()
         else:
             debug('document not tracked', file_name)
@@ -287,20 +274,11 @@ class WindowDocumentHandler(object):
 
             if view.buffer_id() in self._pending_buffer_changes:
                 del self._pending_buffer_changes[view.buffer_id()]
-
-                for session in self._get_applicable_sessions(view, 'change'):
-                    if session.client and file_name in self._document_states:
-                        uri = filename_to_uri(file_name)
-                        params = {
-                            "textDocument": {
-                                "uri": uri,
-                                "version": view.change_count(),
-                            },
-                            "contentChanges": [{
-                                "text": view.substr(self._sublime.Region(0, view.size()))
-                            }]
-                        }
-                        session.client.send_notification(Notification.didChange(params))
+                # mypy: expected sublime.View, got ViewLike
+                notification = did_change(view)  # type: ignore
+                for session in self._get_applicable_sessions(view):
+                    if session.client and file_name in self._document_states and session.should_notify_did_change():
+                        session.client.send_notification(notification)
 
 
 def extract_message(params: Any) -> str:

--- a/plugin/highlights.py
+++ b/plugin/highlights.py
@@ -2,12 +2,11 @@ import sublime
 import sublime_plugin
 
 from .core.configurations import is_supported_syntax
-from .core.documents import get_document_position
 from .core.protocol import Request, Range, DocumentHighlightKind
 from .core.registry import session_for_view, client_from_session
 from .core.settings import settings, client_configs
 from .core.typing import List, Dict, Optional
-from .core.views import range_to_region
+from .core.views import range_to_region, text_document_position_params
 
 SUBLIME_WORD_MASK = 515
 NO_HIGHLIGHT_SCOPES = 'comment, string'
@@ -82,10 +81,9 @@ class DocumentHighlightListener(sublime_plugin.ViewEventListener):
                 return
             client = client_from_session(session_for_view(self.view, "documentHighlightProvider"))
             if client:
-                params = get_document_position(self.view, point)
-                if params:
-                    request = Request.documentHighlight(params)
-                    client.send_request(request, self._handle_response)
+                params = text_document_position_params(self.view, point)
+                request = Request.documentHighlight(params)
+                client.send_request(request, self._handle_response)
 
     def _handle_response(self, response: Optional[List]) -> None:
         if not response:

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -8,12 +8,12 @@ from html import escape
 from .code_actions import actions_manager, run_code_action_or_command
 from .code_actions import CodeActionOrCommand
 from .core.configurations import is_supported_syntax
-from .core.documents import get_document_position
 from .core.popups import popups
 from .core.protocol import Request, DiagnosticSeverity, Diagnostic, DiagnosticRelatedInformation, Point
 from .core.registry import session_for_view, LspTextCommand, windows
 from .core.settings import client_configs, settings
 from .core.typing import List, Optional, Any, Dict
+from .core.views import text_document_position_params
 from .diagnostics import filter_by_point, view_diagnostics
 
 
@@ -100,12 +100,11 @@ class LspHoverCommand(LspTextCommand):
         # can we memoize some part (eg. where no point is provided?)
         session = session_for_view(self.view, 'hoverProvider', point)
         if session:
-            document_position = get_document_position(self.view, point)
-            if document_position:
-                if session.client:
-                    session.client.send_request(
-                        Request.hover(document_position),
-                        lambda response: self.handle_response(response, point))
+            document_position = text_document_position_params(self.view, point)
+            if session.client:
+                session.client.send_request(
+                    Request.hover(document_position),
+                    lambda response: self.handle_response(response, point))
 
     def request_code_actions(self, point: int) -> None:
         actions_manager.request(self.view, point, lambda response: self.handle_code_actions(response, point),

--- a/plugin/references.py
+++ b/plugin/references.py
@@ -2,14 +2,14 @@ import os
 import sublime
 import linecache
 
-from .core.documents import is_at_word, get_position, get_document_position
+from .core.documents import is_at_word, get_position
 from .core.panels import ensure_panel
 from .core.protocol import Request, Point
 from .core.registry import LspTextCommand, windows
 from .core.settings import PLUGIN_NAME, settings
 from .core.typing import List, Dict, Optional, Tuple, TypedDict
 from .core.url import uri_to_filename
-from .core.views import get_line
+from .core.views import get_line, text_document_position_params
 
 ReferenceDict = TypedDict('ReferenceDict', {'uri': str, 'range': dict})
 
@@ -47,14 +47,10 @@ class LspSymbolReferencesCommand(LspTextCommand):
                 if os.path.commonprefix([base_dir, file_path]):
                     self.base_dir = base_dir
 
-            document_position = get_document_position(self.view, pos)
-            if document_position:
-                document_position['context'] = {
-                    "includeDeclaration": False
-                }
-                request = Request.references(document_position)
-                client.send_request(
-                    request, lambda response: self.handle_response(response, pos))
+            document_position = text_document_position_params(self.view, pos)
+            document_position['context'] = {"includeDeclaration": False}
+            request = Request.references(document_position)
+            client.send_request(request, lambda response: self.handle_response(response, pos))
 
     def handle_response(self, response: Optional[List[ReferenceDict]], pos: int) -> None:
         window = self.view.window()

--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -1,10 +1,11 @@
 import sublime
 import sublime_plugin
-from .core.documents import get_document_position, get_position, is_at_word
+from .core.documents import get_position, is_at_word
 from .core.edit import parse_workspace_edit
 from .core.protocol import Request
 from .core.registry import LspTextCommand
 from .core.typing import Dict, Optional
+from .core.views import text_document_position_params
 
 
 class RenameSymbolInputHandler(sublime_plugin.TextInputHandler):
@@ -49,10 +50,7 @@ class LspSymbolRenameCommand(LspTextCommand):
             return None
 
     def run(self, edit: sublime.Edit, new_name: str, event: Optional[dict] = None) -> None:
-        pos = get_position(self.view, event)
-        position = get_document_position(self.view, pos)
-        if position:
-            self.request_rename(position, new_name)
+        self.request_rename(text_document_position_params(self.view, get_position(self.view, event)), new_name)
 
     def request_rename(self, params: dict, new_name: str) -> None:
         client = self.client_with_capability('renameProvider')

--- a/plugin/signature_help.py
+++ b/plugin/signature_help.py
@@ -4,13 +4,13 @@ import html
 import webbrowser
 
 from .core.configurations import is_supported_syntax
-from .core.documents import get_document_position
 from .core.popups import popups
 from .core.protocol import Request
 from .core.registry import session_for_view, client_from_session, LSPViewEventListener
 from .core.settings import client_configs, settings
 from .core.signature_help import create_signature_help, SignatureHelp
 from .core.typing import List, Dict, Optional
+from .core.views import text_document_position_params
 
 
 class ColorSchemeScopeRenderer(object):
@@ -97,11 +97,10 @@ class SignatureHelpListener(LSPViewEventListener):
         client = client_from_session(session_for_view(self.view, 'signatureHelpProvider', point))
         if client:
             self.manager.documents.purge_changes(self.view)
-            document_position = get_document_position(self.view, point)
-            if document_position:
-                client.send_request(
-                    Request.signatureHelp(document_position),
-                    lambda response: self.handle_response(response, point))
+            document_position = text_document_position_params(self.view, point)
+            client.send_request(
+                Request.signatureHelp(document_position),
+                lambda response: self.handle_response(response, point))
 
     def handle_response(self, response: Optional[Dict], point: int) -> None:
         if self.view.sel()[0].begin() == self.requested_position:

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -99,13 +99,15 @@ class WindowDocumentHandlerTests(unittest.TestCase):
         folders = [WorkspaceFolder.from_path(project_path)]
         view.set_window(window)
         workspace = ProjectFolders(window)
-        handler = WindowDocumentHandler(test_sublime, MockSettings(), window, workspace, MockConfigs())
+        configs = MockConfigs()
+        handler = WindowDocumentHandler(test_sublime, MockSettings(), window, workspace, configs)
         client = MockClient()
         session = self.assert_if_none(
             create_session(TEST_CONFIG, folders, folders[0], dict(), MockSettings(),
                            bootstrap_client=client))
         client2 = MockClient()
         test_config2 = ClientConfig("test2", [], None, languages=[TEST_LANGUAGE])
+        configs.all.append(test_config2)
         session2 = self.assert_if_none(
             create_session(test_config2, folders, folders[0], dict(), MockSettings(),
                            bootstrap_client=client2))

--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -234,9 +234,7 @@ class MockConfigs(object):
 
     def syntax_config_languages(self, view: ViewLike) -> 'Dict[str, LanguageConfig]':
         if self.syntax_supported(view):
-            return {
-                "test": TEST_LANGUAGE
-            }
+            return {config.name: config.languages[0] for config in self.all}
         else:
             return {}
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,24 +1,20 @@
 from LSP.plugin.core.protocol import WorkspaceFolder
+from LSP.plugin.core.protocol import TextDocumentSyncKindFull, TextDocumentSyncKindNone, TextDocumentSyncKindIncremental
 from LSP.plugin.core.sessions import create_session, Session, InitializeError, ACQUIRE_READY_LOCK_TIMEOUT
 from LSP.plugin.core.types import ClientConfig
 from LSP.plugin.core.types import Settings
+from LSP.plugin.core.typing import Callable, Optional
 from test_mocks import MockClient
 from test_mocks import TEST_CONFIG
 from test_mocks import TEST_LANGUAGE
+import sublime
 import unittest
 import unittest.mock
-import sublime
-
-try:
-    from typing import Any, List, Dict, Tuple, Callable, Optional
-    assert Any and List and Dict and Tuple and Callable and Optional and Session
-except ImportError:
-    pass
 
 
 class SessionTest(unittest.TestCase):
 
-    def assert_if_none(self, session: 'Optional[Session]') -> 'Session':
+    def assert_if_none(self, session: Optional[Session]) -> Session:
         self.assertIsNotNone(session)
         assert session  # mypy
         return session
@@ -104,7 +100,7 @@ class SessionTest(unittest.TestCase):
 
     def test_initialize_failure(self):
 
-        def async_response(f: 'Callable') -> None:
+        def async_response(f: Callable[[], None]) -> None:
             # resolve the request one second after the timeout triggers (so it's always too late).
             timeout_ms = 1000 * (ACQUIRE_READY_LOCK_TIMEOUT + 1)
             sublime.set_timeout(f, timeout_ms=timeout_ms)
@@ -113,3 +109,83 @@ class SessionTest(unittest.TestCase):
         session = self.make_session(client)
         with self.assertRaises(InitializeError):
             session.handles_path("foo")
+
+    def test_document_sync_capabilities(self) -> None:
+        client = MockClient()
+        client.responses = {
+            'initialize': {
+                'capabilities': {
+                    'textDocumentSync': {
+                        "openClose": True,
+                        "change": TextDocumentSyncKindFull,
+                        "save": True}}}}
+        session = Session(TEST_CONFIG, [], None, client)
+        self.assertTrue(session.should_notify_did_open())
+        self.assertTrue(session.should_notify_did_close())
+        self.assertEqual(session.text_sync_kind(), TextDocumentSyncKindFull)
+        self.assertTrue(session.should_notify_did_change())
+        self.assertFalse(session.should_notify_will_save())
+        self.assertFalse(session.should_request_will_save_wait_until())
+        self.assertEqual(session.should_notify_did_save(), (True, False))
+
+        client.responses = {
+            'initialize': {
+                'capabilities': {
+                    'textDocumentSync': {
+                        "openClose": False,
+                        "change": TextDocumentSyncKindNone,
+                        "save": {},
+                        "willSave": True,
+                        "willSaveWaitUntil": False}}}}
+        session = Session(TEST_CONFIG, [], None, client)
+        self.assertFalse(session.should_notify_did_open())
+        self.assertFalse(session.should_notify_did_close())
+        self.assertEqual(session.text_sync_kind(), TextDocumentSyncKindNone)
+        self.assertFalse(session.should_notify_did_change())
+        self.assertTrue(session.should_notify_will_save())
+        self.assertFalse(session.should_request_will_save_wait_until())
+        self.assertEqual(session.should_notify_did_save(), (True, False))
+
+        client.responses = {
+            'initialize': {
+                'capabilities': {
+                    'textDocumentSync': {
+                        "openClose": False,
+                        "change": TextDocumentSyncKindIncremental,
+                        "save": {"includeText": True},
+                        "willSave": False,
+                        "willSaveWaitUntil": True}}}}
+        session = Session(TEST_CONFIG, [], None, client)
+        self.assertFalse(session.should_notify_did_open())
+        self.assertFalse(session.should_notify_did_close())
+        self.assertEqual(session.text_sync_kind(), TextDocumentSyncKindIncremental)
+        self.assertTrue(session.should_notify_did_change())
+        self.assertFalse(session.should_notify_will_save())
+        self.assertTrue(session.should_request_will_save_wait_until())
+        self.assertEqual(session.should_notify_did_save(), (True, True))
+
+        client.responses = {
+            'initialize': {
+                'capabilities': {  # backwards compatible :)
+                    'textDocumentSync': TextDocumentSyncKindIncremental}}}
+        session = Session(TEST_CONFIG, [], None, client)
+        self.assertTrue(session.should_notify_did_open())
+        self.assertTrue(session.should_notify_did_close())
+        self.assertEqual(session.text_sync_kind(), TextDocumentSyncKindIncremental)
+        self.assertTrue(session.should_notify_did_change())
+        self.assertTrue(session.should_notify_will_save())
+        self.assertFalse(session.should_request_will_save_wait_until())
+        self.assertEqual(session.should_notify_did_save(), (True, False))
+
+        client.responses = {
+            'initialize': {
+                'capabilities': {  # backwards compatible :)
+                    'textDocumentSync': TextDocumentSyncKindNone}}}
+        session = Session(TEST_CONFIG, [], None, client)
+        self.assertFalse(session.should_notify_did_open())
+        self.assertFalse(session.should_notify_did_close())
+        self.assertEqual(session.text_sync_kind(), TextDocumentSyncKindNone)
+        self.assertFalse(session.should_notify_did_change())
+        self.assertFalse(session.should_notify_will_save())
+        self.assertFalse(session.should_request_will_save_wait_until())
+        self.assertEqual(session.should_notify_did_save(), (False, False))

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,97 @@
+from LSP.plugin.core.typing import Generator
+from LSP.plugin.core.url import filename_to_uri
+from LSP.plugin.core.views import did_change
+from LSP.plugin.core.views import did_open
+from LSP.plugin.core.views import did_save
+from LSP.plugin.core.views import MissingFilenameError
+from LSP.plugin.core.views import text_document_formatting
+from LSP.plugin.core.views import text_document_position_params
+from LSP.plugin.core.views import text_document_range_formatting
+from LSP.plugin.core.views import uri_from_view
+from LSP.plugin.core.views import will_save
+from LSP.plugin.core.views import will_save_wait_until
+from unittest.mock import MagicMock
+from unittesting import DeferrableTestCase
+import sublime
+
+
+class ViewsTest(DeferrableTestCase):
+
+    def setUp(self) -> Generator:
+        super().setUp()
+        self.view = sublime.active_window().new_file()
+        yield not self.view.is_loading()
+        self.view.set_scratch(True)
+        self.mock_file_name = "C:/Windows" if sublime.platform() == "windows" else "/etc"
+        self.view.file_name = MagicMock(return_value=self.mock_file_name)
+        self.view.run_command("insert", {"characters": "hello world"})
+
+    def tearDown(self) -> None:
+        self.view.close()
+        return super().tearDown()
+
+    def test_missing_filename(self) -> None:
+        self.view.file_name = MagicMock(return_value=None)
+        with self.assertRaises(MissingFilenameError):
+            uri_from_view(self.view)
+
+    def test_did_open(self) -> None:
+        self.assertEqual(did_open(self.view, "python").params, {
+            "textDocument": {
+                "uri": filename_to_uri(self.mock_file_name),
+                "languageId": "python",
+                "text": "hello world",
+                "version": self.view.change_count()
+            }
+        })
+
+    def test_did_change_full(self) -> None:
+        self.assertEqual(did_change(self.view).params, {
+            "textDocument": {
+                "uri": filename_to_uri(self.mock_file_name),
+                "version": self.view.change_count()
+            },
+            "contentChanges": [{"text": "hello world"}]
+        })
+
+    def test_will_save(self) -> None:
+        self.assertEqual(will_save(self.view, 42).params, {
+            "textDocument": {"uri": filename_to_uri(self.mock_file_name)},
+            "reason": 42
+        })
+
+    def test_will_save_wait_until(self) -> None:
+        self.assertEqual(will_save_wait_until(self.view, 1337).params, {
+            "textDocument": {"uri": filename_to_uri(self.mock_file_name)},
+            "reason": 1337
+        })
+
+    def test_did_save(self) -> None:
+        self.assertEqual(did_save(self.view, include_text=False).params, {
+            "textDocument": {"uri": filename_to_uri(self.mock_file_name)}
+        })
+        self.assertEqual(did_save(self.view, include_text=True).params, {
+            "textDocument": {"uri": filename_to_uri(self.mock_file_name)},
+            "text": "hello world"
+        })
+
+    def test_text_document_position_params(self) -> None:
+        self.assertEqual(text_document_position_params(self.view, 2), {
+            "textDocument": {"uri": filename_to_uri(self.mock_file_name)},
+            "position": {"line": 0, "character": 2}
+        })
+
+    def test_text_document_formatting(self) -> None:
+        self.view.settings = MagicMock(return_value={"translate_tabs_to_spaces": False, "tab_size": 1234})
+        self.assertEqual(text_document_formatting(self.view).params, {
+            "textDocument": {"uri": filename_to_uri(self.mock_file_name)},
+            "options": {"tabSize": 1234, "insertSpaces": False}
+        })
+
+    def test_text_document_range_formatting(self) -> None:
+        self.view.settings = MagicMock(return_value={"tab_size": 4321})
+        self.assertEqual(text_document_range_formatting(self.view, sublime.Region(0, 2)).params, {
+            "textDocument": {"uri": filename_to_uri(self.mock_file_name)},
+            "options": {"tabSize": 4321, "insertSpaces": False},
+            "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 2}}
+        })


### PR DESCRIPTION
Also:

- Move some of the boring boilerplate param construction to views.py
- Session gained some knowledge about whether we should send various
  text doc sync notifications
- Add tests for various server text sync capabilities
- Add tests for the various conversion functions in views.py (perhaps we should rename that to conversions.py)