### PR TITLE
Fix accumulation in reference quick panel.

### DIFF
--- a/plugin/references.py
+++ b/plugin/references.py
@@ -76,6 +76,7 @@ class LspSymbolReferencesCommand(LspTextCommand):
     def show_quick_panel(self, references_by_file: Dict[str, List[Tuple[Point, str]]]) -> None:
         selected_index = -1
         current_file_path = self.view.file_name()
+        self.reflist.clear()
         for file_path, references in references_by_file.items():
             for reference in references:
                 point, line = reference


### PR DESCRIPTION
When the `show_references_in_quick_panel` setting is true, references are shown in the quick panel. In `LspSymbolReferencesCommand`, references are stored in the `reflist` variable, which are then passed to `window.show_quick_panel` to display the results. However, at no point is `reflist` emptied. So, as more references are displayed, previous results accumulate in the panel, which gets very noisy.

This PR simply clears `reflist` before it is repopulated.