### PR TITLE
core: Send clientInfo in initialize request

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -14,6 +14,9 @@ def get_initialize_params(workspace_folders: List[WorkspaceFolder], config: Clie
     first_folder = workspace_folders[0] if workspace_folders else None
     initializeParams = {
         "processId": os.getpid(),
+        "clientInfo": {
+            "name": "Sublime Text LSP",
+        },
         "rootUri": first_folder.uri() if first_folder else None,
         "rootPath": first_folder.path if first_folder else None,
         "workspaceFolders": [folder.to_lsp() for folder in workspace_folders] if workspace_folders else None,


### PR DESCRIPTION
The LSP doesn't seem to be defining any guidelines on what goes into each field, but it seems that most clients just put the editor's name and editor's version.

I can imagine some useful additional information such as OS/arch and version of the plugin here, but I'm being intentionally conservative for now and I feel this could this deliver some value to Language Servers that wish to collect some usage data and understand their user base.