### PR TITLE
Remove initialisation lock

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -79,10 +79,6 @@
   // "hover", "completion", "colorProvider", "documentHighlight", "signatureHelp"
   "disabled_capabilities": [],
 
-  // If the server doesn't respond after this many seconds for its initialize
-  // request, we consider the server faulty and disable it for the workspace folder.
-  "initialize_timeout": 3,
-
   // Show verbose debug messages in the sublime console.
   "log_debug": false,
 

--- a/plugin/core/clients.py
+++ b/plugin/core/clients.py
@@ -1,7 +1,7 @@
 from .protocol import WorkspaceFolder
 from .sessions import create_session, Session
 from .settings import ClientConfig, settings
-from .typing import Any, List, Dict, Tuple, Callable, Optional
+from .typing import List, Dict, Tuple, Callable, Optional
 import os
 import sublime
 
@@ -28,17 +28,15 @@ def get_window_env(window: sublime.Window, config: ClientConfig) -> Tuple[List[s
 
 def start_window_config(window: sublime.Window,
                         workspace_folders: List[WorkspaceFolder],
-                        designated_folder: Optional[WorkspaceFolder],
                         config: ClientConfig,
                         on_pre_initialize: Callable[[Session], None],
-                        on_post_initialize: Callable[[Session, Optional[Dict[str, Any]]], None],
+                        on_post_initialize: Callable[[Session], None],
                         on_post_exit: Callable[[str], None],
                         on_stderr_log: Optional[Callable[[str], None]]) -> Optional[Session]:
     args, env = get_window_env(window, config)
     config.binary_args = args
     return create_session(config=config,
                           workspace_folders=workspace_folders,
-                          designated_folder=designated_folder,
                           env=env,
                           settings=settings,
                           on_pre_initialize=on_pre_initialize,

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -439,9 +439,6 @@ class WorkspaceFolder:
             return self.name == other.name and self.path == other.path
         return False
 
-    def __hash__(self) -> int:
-        return hash(self.path)
-
     def to_lsp(self) -> Dict[str, str]:
         return {"name": self.name, "uri": self.uri()}
 

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -7,7 +7,7 @@ from .logging import debug
 from .rpc import Client
 from .sessions import Session
 from .settings import settings, client_configs
-from .types import ClientConfig, WindowLike
+from .types import ClientConfig, ClientStates, WindowLike
 from .windows import WindowRegistry, DocumentHandlerFactory, WindowManager
 from .typing import Optional, Callable, Dict, Any, Iterable
 
@@ -97,10 +97,9 @@ def _sessions_for_view_and_window(view: sublime.View, window: Optional[sublime.W
 
     manager = windows.lookup(window)
     scope_configs = manager._configs.scope_configs(view, point)
-    for config in scope_configs:
-        session = manager.get_session(config.name, file_path)
-        if session:
-            yield session
+    sessions = (manager.get_session(config.name, file_path) for config in scope_configs)
+    ready_sessions = (session for session in sessions if session and session.state == ClientStates.READY)
+    return ready_sessions
 
 
 def unload_sessions(window: sublime.Window) -> None:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -6,6 +6,7 @@ from .rpc import Client, attach_stdio_client, Response
 from .transports import start_tcp_transport, start_tcp_listener, TCPTransport, Transport
 from .types import ClientConfig, ClientStates, Settings
 from .typing import Callable, Dict, Any, Optional, List, Tuple
+from .workspace import is_subpath_of
 import os
 
 
@@ -178,9 +179,8 @@ class Session(object):
         if not self._workspace_folders:
             return True
 
-        # We're in a window with folders, and we're a single-folder session.
         for folder in self._workspace_folders:
-            if file_path.startswith(folder.path):
+            if is_subpath_of(file_path, folder.path):
                 return True
 
         return False

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -4,7 +4,7 @@ from .protocol import completion_item_kinds, symbol_kinds, WorkspaceFolder, Requ
 from .protocol import TextDocumentSyncKindNone
 from .rpc import Client, attach_stdio_client, Response
 from .transports import start_tcp_transport, start_tcp_listener, TCPTransport, Transport
-from .types import ClientConfig, Settings
+from .types import ClientConfig, ClientStates, Settings
 from .typing import Callable, Dict, Any, Optional, List, Tuple, Generator
 from contextlib import contextmanager
 import os
@@ -106,14 +106,6 @@ def diff_folders(old: List[WorkspaceFolder],
     return added, removed
 
 
-class InitializeError(Exception):
-
-    def __init__(self, config_name: str) -> None:
-        super().__init__("The server did not respond to the initialize request within {} seconds".format(
-            ACQUIRE_READY_LOCK_TIMEOUT))
-        self.name = config_name
-
-
 class Session(object):
     def __init__(self,
                  config: ClientConfig,
@@ -123,6 +115,7 @@ class Session(object):
                  on_post_initialize: 'Optional[Callable[[Session], None]]' = None,
                  on_post_exit: Optional[Callable[[str], None]] = None) -> None:
         self.config = config
+        self.state = ClientStates.STARTING
         self._on_post_initialize = on_post_initialize
         self._on_post_exit = on_post_exit
         self.capabilities = dict()  # type: Dict[str, Any]
@@ -188,9 +181,11 @@ class Session(object):
     def acquire_timeout(self) -> Generator[None, None, None]:
         acquired = self.ready_lock.acquire(True, ACQUIRE_READY_LOCK_TIMEOUT)
         if not acquired:
-            raise InitializeError(self.config.name)
+            raise TimeoutError("{} did not respond to the initialize request within {} seconds".format(
+                self.config.name, ACQUIRE_READY_LOCK_TIMEOUT))
         yield
-        self.ready_lock.release()
+        if acquired:
+            self.ready_lock.release()
 
     def handles_path(self, file_path: Optional[str]) -> bool:
         if not file_path:
@@ -244,6 +239,7 @@ class Session(object):
         self.client.on_notification(method, handler)
 
     def _handle_initialize_error(self, error: Any) -> None:
+        self.state = ClientStates.STOPPING
         self.ready_lock.release()  # acquired in _initialize
         self.end()
 
@@ -260,6 +256,7 @@ class Session(object):
         else:
             debug("session with no workspace folders")
 
+        self.state = ClientStates.READY
         self.ready_lock.release()  # acquired in _initialize
 
         self.on_request("workspace/workspaceFolders", self._handle_request_workspace_folders)
@@ -281,6 +278,7 @@ class Session(object):
         self.client.send_response(Response(request_id, items))
 
     def end(self) -> None:
+        self.state = ClientStates.STOPPING
         self.client.send_request(
             Request.shutdown(),
             lambda result: self._handle_shutdown_result(),

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -14,12 +14,12 @@ import threading
 ACQUIRE_READY_LOCK_TIMEOUT = 3
 
 
-def get_initialize_params(workspace_folders: List[WorkspaceFolder], designated_folder: Optional[WorkspaceFolder],
-                          config: ClientConfig) -> dict:
+def get_initialize_params(workspace_folders: List[WorkspaceFolder], config: ClientConfig) -> dict:
+    first_folder = workspace_folders[0] if workspace_folders else None
     initializeParams = {
         "processId": os.getpid(),
-        "rootUri": designated_folder.uri() if designated_folder else None,
-        "rootPath": designated_folder.path if designated_folder else None,
+        "rootUri": first_folder.uri() if first_folder else None,
+        "rootPath": first_folder.path if first_folder else None,
         "workspaceFolders": [folder.to_lsp() for folder in workspace_folders] if workspace_folders else None,
         "capabilities": {
             "textDocument": {
@@ -108,20 +108,19 @@ def diff_folders(old: List[WorkspaceFolder],
 
 class InitializeError(Exception):
 
-    def __init__(self, session: 'Session') -> None:
-        super().__init__("{} did not respond to the initialize request within {} seconds".format(
-            session.config.name, ACQUIRE_READY_LOCK_TIMEOUT))
-        self.session = session
+    def __init__(self, config_name: str) -> None:
+        super().__init__("The server did not respond to the initialize request within {} seconds".format(
+            ACQUIRE_READY_LOCK_TIMEOUT))
+        self.name = config_name
 
 
 class Session(object):
     def __init__(self,
                  config: ClientConfig,
                  workspace_folders: List[WorkspaceFolder],
-                 designated_folder: Optional[WorkspaceFolder],
                  client: Client,
                  on_pre_initialize: 'Optional[Callable[[Session], None]]' = None,
-                 on_post_initialize: 'Optional[Callable[[Session, Optional[Dict[str, Any]]], None]]' = None,
+                 on_post_initialize: 'Optional[Callable[[Session], None]]' = None,
                  on_post_exit: Optional[Callable[[str], None]] = None) -> None:
         self.config = config
         self._on_post_initialize = on_post_initialize
@@ -130,7 +129,6 @@ class Session(object):
         self.client = client
         self.ready_lock = threading.Lock()
         self._workspace_folders = workspace_folders
-        self.designated_folder = designated_folder
         if on_pre_initialize:
             on_pre_initialize(self)
         self._initialize()
@@ -190,7 +188,7 @@ class Session(object):
     def acquire_timeout(self) -> Generator[None, None, None]:
         acquired = self.ready_lock.acquire(True, ACQUIRE_READY_LOCK_TIMEOUT)
         if not acquired:
-            raise InitializeError(self)
+            raise InitializeError(self.config.name)
         yield
         self.ready_lock.release()
 
@@ -223,7 +221,7 @@ class Session(object):
 
     def _initialize(self) -> None:
         self.ready_lock.acquire()  # released in _handle_initialize_result or _handle_initialize_error
-        params = get_initialize_params(self._workspace_folders, self.designated_folder, self.config)
+        params = get_initialize_params(self._workspace_folders, self.config)
         self.client.send_request(
             Request.initialize(params),
             self._handle_initialize_result,
@@ -247,8 +245,7 @@ class Session(object):
 
     def _handle_initialize_error(self, error: Any) -> None:
         self.ready_lock.release()  # acquired in _initialize
-        if self._on_post_initialize:
-            self._on_post_initialize(self, error)
+        self.end()
 
     def _handle_initialize_result(self, result: Any) -> None:
         self.capabilities.update(result.get('capabilities', dict()))
@@ -258,9 +255,8 @@ class Session(object):
             if self._unsafe_supports_workspace_folders():
                 debug('multi folder session:', self._workspace_folders)
             else:
-                assert self.designated_folder  # mypy
-                self._workspace_folders = [self.designated_folder]
-                debug('single folder session:', self._workspace_folders)
+                self._workspace_folders = self._workspace_folders[:1]
+                debug('single folder session:', self._workspace_folders[0])
         else:
             debug("session with no workspace folders")
 
@@ -272,7 +268,7 @@ class Session(object):
             self.client.send_notification(Notification.didChangeConfiguration({'settings': self.config.settings}))
 
         if self._on_post_initialize:
-            self._on_post_initialize(self, None)
+            self._on_post_initialize(self)
 
     def _handle_request_workspace_folders(self, _: Any, request_id: int) -> None:
         self.client.send_response(Response(request_id, [wf.to_lsp() for wf in self._workspace_folders]))
@@ -300,11 +296,10 @@ class Session(object):
 
 def create_session(config: ClientConfig,
                    workspace_folders: List[WorkspaceFolder],
-                   designated_folder: Optional[WorkspaceFolder],
                    env: dict,
                    settings: Settings,
                    on_pre_initialize: Optional[Callable[[Session], None]] = None,
-                   on_post_initialize: Optional[Callable[[Session, Optional[Dict[str, Any]]], None]] = None,
+                   on_post_initialize: Optional[Callable[[Session], None]] = None,
                    on_post_exit: Optional[Callable[[str], None]] = None,
                    on_stderr_log: Optional[Callable[[str], None]] = None,
                    bootstrap_client: Optional[Any] = None) -> Optional[Session]:
@@ -313,7 +308,6 @@ def create_session(config: ClientConfig,
         return Session(
             config=config,
             workspace_folders=workspace_folders,
-            designated_folder=designated_folder,
             client=client,
             on_pre_initialize=on_pre_initialize,
             on_post_initialize=on_post_initialize,

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -186,7 +186,7 @@ class Session(object):
         return False
 
     def update_folders(self, folders: List[WorkspaceFolder]) -> None:
-        if self._unsafe_supports_workspace_folders():
+        if self._supports_workspace_folders():
             added, removed = diff_folders(self._workspace_folders, folders)
             params = {
                 "event": {

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -106,6 +106,14 @@ def diff_folders(old: List[WorkspaceFolder],
     return added, removed
 
 
+@contextmanager
+def acquire_timeout(lock: threading.Lock, timeout: float) -> 'Generator[bool, None, None]':
+    result = lock.acquire(True, timeout)
+    yield result
+    if result:
+        lock.release()
+
+
 class Session(object):
     def __init__(self,
                  config: ClientConfig,
@@ -177,23 +185,13 @@ class Session(object):
     def should_notify_did_close(self) -> bool:
         return self.should_notify_did_open()
 
-    @contextmanager
-    def acquire_timeout(self) -> Generator[None, None, None]:
-        acquired = self.ready_lock.acquire(True, ACQUIRE_READY_LOCK_TIMEOUT)
-        if not acquired:
-            raise TimeoutError("{} did not respond to the initialize request within {} seconds".format(
-                self.config.name, ACQUIRE_READY_LOCK_TIMEOUT))
-        yield
-        if acquired:
-            self.ready_lock.release()
-
     def handles_path(self, file_path: Optional[str]) -> bool:
         if not file_path:
             return False
-        with self.acquire_timeout():
-            # If we're in a window with no folders, or we're a multi-folder session, then we handle any path.
-            if not self._workspace_folders or self._unsafe_supports_workspace_folders():
-                return True
+        with acquire_timeout(self.ready_lock, ACQUIRE_READY_LOCK_TIMEOUT) as acquired:
+            if not acquired:
+                raise TimeoutError("{} did not respond to the initialize request within {} seconds".format(
+                    self.config.name, ACQUIRE_READY_LOCK_TIMEOUT))
         # We're in a window with folders, and we're a single-folder session.
         for folder in self._workspace_folders:
             if file_path.startswith(folder.path):
@@ -201,7 +199,7 @@ class Session(object):
         return False
 
     def update_folders(self, folders: List[WorkspaceFolder]) -> None:
-        with self.acquire_timeout():
+        with self.ready_lock:
             if self._unsafe_supports_workspace_folders():
                 added, removed = diff_folders(self._workspace_folders, folders)
                 params = {
@@ -229,7 +227,7 @@ class Session(object):
         return workspace_folder_cap.get("supported")
 
     def supports_workspace_folders(self) -> bool:
-        with self.acquire_timeout():
+        with self.ready_lock:
             return self._unsafe_supports_workspace_folders()
 
     def on_request(self, method: str, handler: Callable) -> None:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -101,6 +101,7 @@ def diff_folders(old: List[WorkspaceFolder],
             added.append(folder)
     return added, removed
 
+
 def get_dotted_value(current: Any, dotted: str) -> Any:
     keys = dotted.split('.')
     for key in keys:
@@ -109,6 +110,7 @@ def get_dotted_value(current: Any, dotted: str) -> Any:
         else:
             return None
     return current
+
 
 class Session(object):
     def __init__(self,

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -79,7 +79,6 @@ def update_settings(settings: Settings, settings_obj: sublime.Settings) -> None:
     settings.completion_hint_type = read_str_setting(settings_obj, "completion_hint_type", "auto")
     settings.show_references_in_quick_panel = read_bool_setting(settings_obj, "show_references_in_quick_panel", False)
     settings.disabled_capabilities = read_array_setting(settings_obj, "disabled_capabilities", [])
-    settings.initialize_timeout = read_int_setting(settings_obj, "initialize_timeout", 3)
     settings.log_debug = read_bool_setting(settings_obj, "log_debug", False)
     settings.log_server = read_bool_setting(settings_obj, "log_server", True)
     settings.log_stderr = read_bool_setting(settings_obj, "log_stderr", False)

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -26,7 +26,6 @@ class Settings(object):
         self.completion_hint_type = "auto"
         self.show_references_in_quick_panel = False
         self.disabled_capabilities = []  # type: List[str]
-        self.initialize_timeout = 3
         self.log_debug = True
         self.log_server = True
         self.log_stderr = False

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -87,6 +87,9 @@ def config_supports_syntax(config: ClientConfig, syntax: str) -> bool:
 
 
 class ViewLike(Protocol):
+    def id(self) -> int:
+        ...
+
     def file_name(self) -> Optional[str]:
         ...
 

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -32,6 +32,12 @@ class Settings(object):
         self.log_payloads = False
 
 
+class ClientStates(object):
+    STARTING = 0
+    READY = 1
+    STOPPING = 2
+
+
 class LanguageConfig(object):
     def __init__(self, language_id: str, scopes: List[str], syntaxes: List[str]) -> None:
         self.id = language_id

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -408,7 +408,7 @@ class WindowManager(object):
             return
 
         self._window.status_message("Starting " + config.name + "...")
-        session = None  # type: Optional[]
+        session = None  # type: Optional[Session]
         workspace_folders = sorted_workspace_folders(self._workspace.folders, file_path)
         try:
             session = self._start_session(

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -536,12 +536,7 @@ class WindowManager(object):
             "window/logMessage",
             lambda params: self._handle_log_message(session.config.name, params))
 
-    def _handle_post_initialize(self, session: Session, error: Optional[Dict[str, Any]]) -> None:
-        if error is not None:
-            message = error['message']
-            self._sublime.error_message(message)
-            self._disable_temporarily(session, RuntimeError(message), session.designated_folder)
-            return
+    def _handle_post_initialize(self, session: Session) -> None:
 
         # handle server requests and notifications
         session.on_request(

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -373,6 +373,9 @@ class WindowManager(object):
     def _initialize_on_open(self, view: ViewLike) -> None:
         file_path = view.file_name() or ""
 
+        if not self._workspace.includes_path(file_path):
+            return
+
         def needed_configs(configs: 'List[ClientConfig]') -> 'List[ClientConfig]':
             new_configs = []
             for c in configs:
@@ -380,8 +383,8 @@ class WindowManager(object):
                     new_configs.append(c)
                 elif all(not s.handles_path(file_path) for s in self._sessions[c.name]):
                     debug('path not in existing {} session: {}'.format(c.name, file_path))
-                    if self._workspace.includes_path(file_path):
-                        new_configs.append(c)
+                    new_configs.append(c)
+
             return new_configs
 
         # have all sessions for this document been started?

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -380,7 +380,8 @@ class WindowManager(object):
                     new_configs.append(c)
                 elif all(not s.handles_path(file_path) for s in self._sessions[c.name]):
                     debug('path not in existing {} session: {}'.format(c.name, file_path))
-                    new_configs.append(c)
+                    if self._workspace.includes_path(file_path):
+                        new_configs.append(c)
             return new_configs
 
         # have all sessions for this document been started?

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -4,6 +4,11 @@ from .types import WindowLike
 from .typing import List, Optional, Any, Callable
 
 
+def is_subpath_of(file_path: str, potential_subpath: str) -> bool:
+    """ Case insensitive, file paths are not normalized when converted from uri"""
+    return file_path.lower().startswith(potential_subpath.lower())
+
+
 class ProjectFolders(object):
 
     def __init__(self, window: WindowLike) -> None:
@@ -28,7 +33,7 @@ class ProjectFolders(object):
 
     def includes_path(self, file_path: str) -> bool:
         if self.folders:
-            return any(file_path.startswith(folder) for folder in self.folders)
+            return any(is_subpath_of(file_path, folder) for folder in self.folders)
         else:
             return True
 
@@ -57,7 +62,7 @@ def get_workspace_folders(folders: List[str]) -> List[WorkspaceFolder]:
 def sorted_workspace_folders(folders: List[str], file_path: str) -> List[WorkspaceFolder]:
     sorted_folders = []  # type: List[WorkspaceFolder]
     for folder in folders:
-        if file_path and file_path.startswith(folder):
+        if file_path and is_subpath_of(file_path, folder):
             sorted_folders.insert(0, WorkspaceFolder.from_path(folder))
         else:
             sorted_folders.append(WorkspaceFolder.from_path(folder))

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -1,7 +1,7 @@
 from .logging import debug
 from .protocol import WorkspaceFolder
 from .types import WindowLike
-from .typing import List, Optional, Any, Callable, Tuple
+from .typing import List, Optional, Any, Callable
 from os.path import commonprefix
 
 
@@ -14,19 +14,6 @@ class ProjectFolders(object):
         self.folders = []  # type: List[str]
         self._current_project_file_name = self._window.project_file_name()
         self._set_folders(window.folders())
-
-    def all(self) -> List[WorkspaceFolder]:
-        return [WorkspaceFolder.from_path(f) for f in self.folders]
-
-    def designated(self, file_path: str) -> Optional[WorkspaceFolder]:
-        try:
-            return WorkspaceFolder.from_path(max(self.folders, key=lambda f: len(f) if file_path.startswith(f) else -1))
-        except ValueError:
-            # folderless window
-            return None
-
-    def all_and_designated(self, file_path: str) -> Tuple[List[WorkspaceFolder], Optional[WorkspaceFolder]]:
-        return self.all(), self.designated(file_path)
 
     def update(self) -> None:
         new_folders = self._window.folders()
@@ -76,6 +63,16 @@ class ProjectFolders(object):
 
 def get_workspace_folders(folders: List[str]) -> List[WorkspaceFolder]:
     return [WorkspaceFolder.from_path(f) for f in folders]
+
+
+def sorted_workspace_folders(folders: List[str], file_path: str) -> List[WorkspaceFolder]:
+    sorted_folders = []  # type: List[WorkspaceFolder]
+    for folder in folders:
+        if file_path and file_path.startswith(folder):
+            sorted_folders.insert(0, WorkspaceFolder.from_path(folder))
+        else:
+            sorted_folders.append(WorkspaceFolder.from_path(folder))
+    return sorted_folders
 
 
 def enable_in_project(window: Any, config_name: str) -> None:

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -60,13 +60,14 @@ def get_workspace_folders(folders: List[str]) -> List[WorkspaceFolder]:
 
 
 def sorted_workspace_folders(folders: List[str], file_path: str) -> List[WorkspaceFolder]:
-    sorted_folders = []  # type: List[WorkspaceFolder]
+    sorted_paths = []  # type: List[str]
     for folder in folders:
-        if file_path and is_subpath_of(file_path, folder):
-            sorted_folders.insert(0, WorkspaceFolder.from_path(folder))
+        if sorted_paths and file_path and is_subpath_of(file_path, folder) and len(folder) > len(sorted_paths[0]):
+            sorted_paths.insert(0, folder)
         else:
-            sorted_folders.append(WorkspaceFolder.from_path(folder))
-    return sorted_folders
+            sorted_paths.append(folder)
+
+    return [WorkspaceFolder.from_path(path) for path in sorted_paths]
 
 
 def enable_in_project(window: Any, config_name: str) -> None:

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -2,7 +2,6 @@ from .logging import debug
 from .protocol import WorkspaceFolder
 from .types import WindowLike
 from .typing import List, Optional, Any, Callable
-from os.path import commonprefix
 
 
 class ProjectFolders(object):
@@ -27,21 +26,11 @@ class ProjectFolders(object):
                 if self.on_switched:
                     self.on_switched(new_folders)
 
-    # def is_foreign(self, p: str) -> bool:
-    #     """Note that for a folderless window no path is foreign"""
-    #     return all(commonprefix((f, p)) != f for f in self.folders)
-
-    # def is_inside(self, p: str) -> bool:
-    #     """The negation of is_foreign"""
-    #     return not self.is_foreign(p)
-
-    # def __contains__(self, item: 'Any') -> bool:
-    #     if isinstance(item, str):
-    #         return self.is_inside(item)
-    #     elif item is None:
-    #         return True
-    #     else:
-    #         return getattr(item, "file_name")() in self
+    def includes_path(self, file_path: str) -> bool:
+        if self.folders:
+            return any(file_path.startswith(folder) for folder in self.folders)
+        else:
+            return True
 
     def _set_folders(self, folders: List[str]) -> None:
         self.folders = folders

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -27,21 +27,21 @@ class ProjectFolders(object):
                 if self.on_switched:
                     self.on_switched(new_folders)
 
-    def is_foreign(self, p: str) -> bool:
-        """Note that for a folderless window no path is foreign"""
-        return all(commonprefix((f, p)) != f for f in self.folders)
+    # def is_foreign(self, p: str) -> bool:
+    #     """Note that for a folderless window no path is foreign"""
+    #     return all(commonprefix((f, p)) != f for f in self.folders)
 
-    def is_inside(self, p: str) -> bool:
-        """The negation of is_foreign"""
-        return not self.is_foreign(p)
+    # def is_inside(self, p: str) -> bool:
+    #     """The negation of is_foreign"""
+    #     return not self.is_foreign(p)
 
-    def __contains__(self, item: 'Any') -> bool:
-        if isinstance(item, str):
-            return self.is_inside(item)
-        elif item is None:
-            return True
-        else:
-            return getattr(item, "file_name")() in self
+    # def __contains__(self, item: 'Any') -> bool:
+    #     if isinstance(item, str):
+    #         return self.is_inside(item)
+    #     elif item is None:
+    #         return True
+    #     else:
+    #         return getattr(item, "file_name")() in self
 
     def _set_folders(self, folders: List[str]) -> None:
         self.folders = folders

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -150,10 +150,6 @@ class TextDocumentTestCase(DeferrableTestCase):
 
         def condition() -> bool:
             return True
-            # acquired = self.session.ready_lock.acquire(False)
-            # if acquired:
-            #     self.session.ready_lock.release()
-            # return acquired
 
         yield {"condition": condition, "timeout": TIMEOUT_TIME, "period": PERIOD_TIME}
         yield from self.await_boilerplate_begin()

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -149,10 +149,11 @@ class TextDocumentTestCase(DeferrableTestCase):
         self.assertEqual(self.session.config.name, self.config.name)
 
         def condition() -> bool:
-            acquired = self.session.ready_lock.acquire(False)
-            if acquired:
-                self.session.ready_lock.release()
-            return acquired
+            return True
+            # acquired = self.session.ready_lock.acquire(False)
+            # if acquired:
+            #     self.session.ready_lock.release()
+            # return acquired
 
         yield {"condition": condition, "timeout": TIMEOUT_TIME, "period": PERIOD_TIME}
         yield from self.await_boilerplate_begin()

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -3,7 +3,7 @@ from LSP.plugin.core.protocol import Notification, Request, WorkspaceFolder
 from LSP.plugin.core.registry import windows
 from LSP.plugin.core.sessions import Session
 from LSP.plugin.core.settings import client_configs
-from LSP.plugin.core.types import ClientConfig, LanguageConfig
+from LSP.plugin.core.types import ClientConfig, LanguageConfig, ClientStates
 from os import environ
 from os.path import dirname
 from os.path import join
@@ -149,7 +149,7 @@ class TextDocumentTestCase(DeferrableTestCase):
         self.assertEqual(self.session.config.name, self.config.name)
 
         def condition() -> bool:
-            return True
+            return self.session.state == ClientStates.READY
 
         yield {"condition": condition, "timeout": TIMEOUT_TIME, "period": PERIOD_TIME}
         yield from self.await_boilerplate_begin()

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -39,7 +39,7 @@ class WindowDocumentHandlerTests(unittest.TestCase):
         handler = WindowDocumentHandler(test_sublime, MockSettings(), window, workspace, MockConfigs())
         client = MockClient()
         session = self.assert_if_none(
-            create_session(TEST_CONFIG, folders, folders[0], dict(), MockSettings(),
+            create_session(TEST_CONFIG, folders, dict(), MockSettings(),
                            bootstrap_client=client))
         handler.add_session(session)
 
@@ -103,13 +103,13 @@ class WindowDocumentHandlerTests(unittest.TestCase):
         handler = WindowDocumentHandler(test_sublime, MockSettings(), window, workspace, configs)
         client = MockClient()
         session = self.assert_if_none(
-            create_session(TEST_CONFIG, folders, folders[0], dict(), MockSettings(),
+            create_session(TEST_CONFIG, folders, dict(), MockSettings(),
                            bootstrap_client=client))
         client2 = MockClient()
         test_config2 = ClientConfig("test2", [], None, languages=[TEST_LANGUAGE])
         configs.all.append(test_config2)
         session2 = self.assert_if_none(
-            create_session(test_config2, folders, folders[0], dict(), MockSettings(),
+            create_session(test_config2, folders, dict(), MockSettings(),
                            bootstrap_client=client2))
 
         handler.add_session(session)

--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -207,7 +207,7 @@ class TestGlobalConfigs(object):
 
 class MockConfigs(object):
     def __init__(self):
-        self.all = [copy.deepcopy(TEST_CONFIG)]
+        self.all = [TEST_CONFIG]
 
     def is_supported(self, view):
         return any(self.scope_configs(view))
@@ -243,8 +243,7 @@ class MockConfigs(object):
         pass
 
     def disable_temporarily(self, config_name: str) -> None:
-        if config_name == self.all[0].name:
-            self.all[0].enabled = False
+        pass
 
 
 class MockDocuments(DocumentHandler):

--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -8,7 +8,6 @@ from LSP.plugin.core.types import Settings
 from LSP.plugin.core.types import ViewLike
 from LSP.plugin.core.typing import Dict, Set, List, Optional, Any, Tuple, Callable
 from LSP.plugin.core.windows import DocumentHandler
-import copy
 import os
 import test_sublime
 
@@ -289,7 +288,7 @@ class TestDocumentHandlerFactory(object):
         return MockDocuments()
 
 
-class MockClient():
+class MockClient(object):
     def __init__(self, async_response=None) -> None:
         self.responses = basic_responses
         self._notifications = []  # type: List[Notification]

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,7 +1,6 @@
 from LSP.plugin.core.protocol import WorkspaceFolder
 from LSP.plugin.core.protocol import TextDocumentSyncKindFull, TextDocumentSyncKindNone, TextDocumentSyncKindIncremental
 from LSP.plugin.core.sessions import create_session, Session, get_initialize_params
-from LSP.plugin.core.settings import settings as global_settings
 from LSP.plugin.core.types import ClientConfig
 from LSP.plugin.core.types import Settings
 from LSP.plugin.core.typing import Optional
@@ -38,14 +37,14 @@ class SessionTest(unittest.TestCase):
     def test_initialize_params(self) -> None:
         wf = WorkspaceFolder.from_path("/foo/bar/baz")
         params = get_initialize_params(
-            [wf], wf, ClientConfig(name="test", binary_args=[""], tcp_port=None, init_options=None))
+            [wf], ClientConfig(name="test", binary_args=[""], tcp_port=None, init_options=None))
         self.assertNotIn("initializationOptions", params)
         params = get_initialize_params(
-            [wf], wf, ClientConfig(name="test", binary_args=[""], tcp_port=None, init_options={}))
+            [wf], ClientConfig(name="test", binary_args=[""], tcp_port=None, init_options={}))
         self.assertIn("initializationOptions", params)
         self.assertEqual(params["initializationOptions"], {})
         params = get_initialize_params(
-            [wf], wf, ClientConfig(name="test", binary_args=[""], tcp_port=None, init_options={"foo": "bar"}))
+            [wf], ClientConfig(name="test", binary_args=[""], tcp_port=None, init_options={"foo": "bar"}))
         self.assertIn("initializationOptions", params)
         self.assertEqual(params["initializationOptions"], {"foo": "bar"})
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,9 +1,9 @@
 from LSP.plugin.core.protocol import WorkspaceFolder
 from LSP.plugin.core.protocol import TextDocumentSyncKindFull, TextDocumentSyncKindNone, TextDocumentSyncKindIncremental
-from LSP.plugin.core.sessions import create_session, Session, InitializeError, ACQUIRE_READY_LOCK_TIMEOUT
+from LSP.plugin.core.sessions import create_session, Session
 from LSP.plugin.core.types import ClientConfig
 from LSP.plugin.core.types import Settings
-from LSP.plugin.core.typing import Callable, Optional
+from LSP.plugin.core.typing import Optional
 from test_mocks import MockClient
 from test_mocks import TEST_CONFIG
 from test_mocks import TEST_LANGUAGE
@@ -19,13 +19,13 @@ class SessionTest(unittest.TestCase):
         assert session  # mypy
         return session
 
-    def assert_initialized(self, session: Session) -> None:
-        try:
-            with session.acquire_timeout():
-                return
-        except InitializeError:
-            pass
-        self.fail("session failed to initialize")
+    # def assert_initialized(self, session: Session) -> None:
+    #     try:
+    #         with session.acquire_timeout():
+    #             return
+    #     except InitializeError:
+    #         pass
+    #     self.fail("session failed to initialize")
 
     def make_session(self, bootstrap_client, on_pre_initialize=None, on_post_initialize=None,
                      on_post_exit=None) -> Session:
@@ -60,7 +60,7 @@ class SessionTest(unittest.TestCase):
         session = self.make_session(
             MockClient(),
             on_post_initialize=post_initialize_callback)
-        self.assert_initialized(session)
+        # self.assert_initialized(session)
         self.assertIsNotNone(session.client)
         self.assertTrue(session.has_capability("testing"))
         self.assertTrue(session.get_capability("testing"))
@@ -73,7 +73,7 @@ class SessionTest(unittest.TestCase):
             MockClient(),
             on_pre_initialize=pre_initialize_callback,
             on_post_initialize=post_initialize_callback)
-        self.assert_initialized(session)
+        # self.assert_initialized(session)
         self.assertIsNotNone(session.client)
         self.assertTrue(session.has_capability("testing"))
         self.assertTrue(session.get_capability("testing"))
@@ -87,7 +87,7 @@ class SessionTest(unittest.TestCase):
             MockClient(),
             on_post_initialize=post_initialize_callback,
             on_post_exit=post_exit_callback)
-        self.assert_initialized(session)
+        # self.assert_initialized(session)
         self.assertIsNotNone(session.client)
         self.assertTrue(session.has_capability("testing"))
         assert post_initialize_callback.call_count == 1
@@ -97,17 +97,17 @@ class SessionTest(unittest.TestCase):
         self.assertIsNone(session.get_capability("testing"))
         assert post_exit_callback.call_count == 1
 
-    def test_initialize_failure(self):
+    # def test_initialize_failure(self):
 
-        def async_response(f: Callable[[], None]) -> None:
-            # resolve the request one second after the timeout triggers (so it's always too late).
-            timeout_ms = 1000 * (ACQUIRE_READY_LOCK_TIMEOUT + 1)
-            sublime.set_timeout(f, timeout_ms=timeout_ms)
+    #     def async_response(f: Callable[[], None]) -> None:
+    #         # resolve the request one second after the timeout triggers (so it's always too late).
+    #         timeout_ms = 1000 * (ACQUIRE_READY_LOCK_TIMEOUT + 1)
+    #         sublime.set_timeout(f, timeout_ms=timeout_ms)
 
-        client = MockClient(async_response=async_response)
-        session = self.make_session(client)
-        with self.assertRaises(InitializeError):
-            session.handles_path("foo")
+    #     client = MockClient(async_response=async_response)
+    #     session = self.make_session(client)
+    #     with self.assertRaises(InitializeError):
+    #         session.handles_path("foo")
 
     def test_document_sync_capabilities(self) -> None:
         client = MockClient()
@@ -118,7 +118,7 @@ class SessionTest(unittest.TestCase):
                         "openClose": True,
                         "change": TextDocumentSyncKindFull,
                         "save": True}}}}
-        session = Session(TEST_CONFIG, [], None, client)
+        session = Session(TEST_CONFIG, [], client)
         self.assertTrue(session.should_notify_did_open())
         self.assertTrue(session.should_notify_did_close())
         self.assertEqual(session.text_sync_kind(), TextDocumentSyncKindFull)
@@ -136,7 +136,7 @@ class SessionTest(unittest.TestCase):
                         "save": {},
                         "willSave": True,
                         "willSaveWaitUntil": False}}}}
-        session = Session(TEST_CONFIG, [], None, client)
+        session = Session(TEST_CONFIG, [], client)
         self.assertFalse(session.should_notify_did_open())
         self.assertFalse(session.should_notify_did_close())
         self.assertEqual(session.text_sync_kind(), TextDocumentSyncKindNone)
@@ -154,7 +154,7 @@ class SessionTest(unittest.TestCase):
                         "save": {"includeText": True},
                         "willSave": False,
                         "willSaveWaitUntil": True}}}}
-        session = Session(TEST_CONFIG, [], None, client)
+        session = Session(TEST_CONFIG, [], client)
         self.assertFalse(session.should_notify_did_open())
         self.assertFalse(session.should_notify_did_close())
         self.assertEqual(session.text_sync_kind(), TextDocumentSyncKindIncremental)
@@ -167,7 +167,7 @@ class SessionTest(unittest.TestCase):
             'initialize': {
                 'capabilities': {  # backwards compatible :)
                     'textDocumentSync': TextDocumentSyncKindIncremental}}}
-        session = Session(TEST_CONFIG, [], None, client)
+        session = Session(TEST_CONFIG, [], client)
         self.assertTrue(session.should_notify_did_open())
         self.assertTrue(session.should_notify_did_close())
         self.assertEqual(session.text_sync_kind(), TextDocumentSyncKindIncremental)
@@ -180,7 +180,7 @@ class SessionTest(unittest.TestCase):
             'initialize': {
                 'capabilities': {  # backwards compatible :)
                     'textDocumentSync': TextDocumentSyncKindNone}}}
-        session = Session(TEST_CONFIG, [], None, client)
+        session = Session(TEST_CONFIG, [], client)
         self.assertFalse(session.should_notify_did_open())
         self.assertFalse(session.should_notify_did_close())
         self.assertEqual(session.text_sync_kind(), TextDocumentSyncKindNone)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -19,14 +19,6 @@ class SessionTest(unittest.TestCase):
         assert session  # mypy
         return session
 
-    # def assert_initialized(self, session: Session) -> None:
-    #     try:
-    #         with session.acquire_timeout():
-    #             return
-    #     except InitializeError:
-    #         pass
-    #     self.fail("session failed to initialize")
-
     def make_session(self, bootstrap_client, on_pre_initialize=None, on_post_initialize=None,
                      on_post_exit=None) -> Session:
         project_path = "/"
@@ -60,7 +52,6 @@ class SessionTest(unittest.TestCase):
         session = self.make_session(
             MockClient(),
             on_post_initialize=post_initialize_callback)
-        # self.assert_initialized(session)
         self.assertIsNotNone(session.client)
         self.assertTrue(session.has_capability("testing"))
         self.assertTrue(session.get_capability("testing"))
@@ -73,7 +64,6 @@ class SessionTest(unittest.TestCase):
             MockClient(),
             on_pre_initialize=pre_initialize_callback,
             on_post_initialize=post_initialize_callback)
-        # self.assert_initialized(session)
         self.assertIsNotNone(session.client)
         self.assertTrue(session.has_capability("testing"))
         self.assertTrue(session.get_capability("testing"))
@@ -87,7 +77,6 @@ class SessionTest(unittest.TestCase):
             MockClient(),
             on_post_initialize=post_initialize_callback,
             on_post_exit=post_exit_callback)
-        # self.assert_initialized(session)
         self.assertIsNotNone(session.client)
         self.assertTrue(session.has_capability("testing"))
         assert post_initialize_callback.call_count == 1
@@ -96,18 +85,6 @@ class SessionTest(unittest.TestCase):
         self.assertFalse(session.has_capability("testing"))
         self.assertIsNone(session.get_capability("testing"))
         assert post_exit_callback.call_count == 1
-
-    # def test_initialize_failure(self):
-
-    #     def async_response(f: Callable[[], None]) -> None:
-    #         # resolve the request one second after the timeout triggers (so it's always too late).
-    #         timeout_ms = 1000 * (ACQUIRE_READY_LOCK_TIMEOUT + 1)
-    #         sublime.set_timeout(f, timeout_ms=timeout_ms)
-
-    #     client = MockClient(async_response=async_response)
-    #     session = self.make_session(client)
-    #     with self.assertRaises(InitializeError):
-    #         session.handles_path("foo")
 
     def test_document_sync_capabilities(self) -> None:
         client = MockClient()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,7 +1,6 @@
-from LSP.plugin.core.protocol import TextDocumentSyncKindFull, TextDocumentSyncKindNone, TextDocumentSyncKindIncremental
 from LSP.plugin.core.protocol import WorkspaceFolder
-from LSP.plugin.core.sessions import create_session, Session, InitializeError
-from LSP.plugin.core.settings import settings as global_settings
+from LSP.plugin.core.protocol import TextDocumentSyncKindFull, TextDocumentSyncKindNone, TextDocumentSyncKindIncremental
+from LSP.plugin.core.sessions import create_session, Session, InitializeError, ACQUIRE_READY_LOCK_TIMEOUT
 from LSP.plugin.core.types import ClientConfig
 from LSP.plugin.core.types import Settings
 from LSP.plugin.core.typing import Callable, Optional
@@ -103,7 +102,7 @@ class SessionTest(unittest.TestCase):
 
         def async_response(f: Callable[[], None]) -> None:
             # resolve the request one second after the timeout triggers (so it's always too late).
-            timeout_ms = 1000 * (global_settings.initialize_timeout + 1)
+            timeout_ms = 1000 * (ACQUIRE_READY_LOCK_TIMEOUT + 1)
             sublime.set_timeout(f, timeout_ms=timeout_ms)
 
         client = MockClient(async_response=async_response)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -35,7 +35,6 @@ class SessionTest(unittest.TestCase):
             create_session(
                 config=TEST_CONFIG,
                 workspace_folders=folders,
-                designated_folder=folders[0],
                 env=dict(),
                 settings=Settings(),
                 bootstrap_client=bootstrap_client,
@@ -52,7 +51,7 @@ class SessionTest(unittest.TestCase):
         project_path = "/"
         folders = [WorkspaceFolder.from_path(project_path)]
         session = self.assert_if_none(
-            create_session(config, folders, folders[0], dict(), Settings()))
+            create_session(config, folders, dict(), Settings()))
         session.client.transport.close()
 
     def test_can_get_started_session(self):

--- a/tests/test_sublime.py
+++ b/tests/test_sublime.py
@@ -31,10 +31,6 @@ def _run_timeout():
         callback()
 
 
-def status_message(s: str) -> None:
-    pass
-
-
 class Region(object):
     def __init__(self, a, b):
         self.a = a

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -102,10 +102,6 @@ class WindowManagerTests(unittest.TestCase):
             sublime=test_sublime,
             handler_dispatcher=dispatcher)
         wm.start_active_views()
-        for sessions in wm._sessions.values():
-            for session in sessions:
-                with session.ready_lock:
-                    pass
         return window, docs, dispatcher, wm
 
     def test_can_start_active_views(self):

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -218,6 +218,22 @@ class WindowManagerTests(unittest.TestCase):
         _, _, _, wm = self.make([[MockView(__file__)]], [top_folder, parent_folder])
         self.assertEqual(top_folder, wm.get_project_path(file_path))
 
+    def test_opens_second_session_for_workspace_folder(self):
+        file_path = __file__
+        top_folder = os.path.dirname(file_path)
+        parent_folder = os.path.dirname(top_folder)
+        sibling_folder = os.path.join(parent_folder, "plugin")
+        sibling_file = os.path.join(sibling_folder, "test.py")
+
+        window, docs, _, wm = self.make([[MockView(__file__)], [MockView(sibling_file)]], [top_folder, sibling_folder])
+
+        session = wm.get_session(TEST_CONFIG.name, __file__)
+        self.assertIsNotNone(session)
+        session2 = wm.get_session(TEST_CONFIG.name, sibling_file)
+        self.assertIsNotNone(session2)
+
+        self.assertNotEqual(session, session2)
+
     def test_reuses_existing_session_for_foreign_file(self):
         top_folder = os.path.dirname(__file__)
         parent_folder = os.path.dirname(top_folder)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,5 +1,5 @@
 from test_mocks import MockWindow
-from LSP.plugin.core.workspace import ProjectFolders
+from LSP.plugin.core.workspace import ProjectFolders, sorted_workspace_folders
 from LSP.plugin.core.protocol import WorkspaceFolder
 import os
 from unittest import mock
@@ -10,25 +10,13 @@ import tempfile
 class SortedWorkspaceFoldersTest(unittest.TestCase):
 
     def test_get_workspace_from_multi_folder_project(self) -> None:
-        first = os.path.dirname(__file__)
-        with tempfile.TemporaryDirectory() as second:
-            folders = ProjectFolders(MockWindow())
-            folders.folders = [second, first]
-            workspaces, designated = folders.all_and_designated(__file__)
-            self.assertListEqual(workspaces, [WorkspaceFolder.from_path(f) for f in (second, first)])
-            self.assertEqual(designated.path, first)
-
-    def test_nested_folders(self) -> None:
-        with tempfile.TemporaryDirectory() as first:
-            second = os.path.join(first, "foobar")
-            os.makedirs(second, exist_ok=True)
-            with tempfile.TemporaryDirectory() as third:
-                folders = ProjectFolders(MockWindow())
-                folders.folders = [first, second, third]  # [/tmp/asdf, /tmp/asdf/foobar, /tmp/qwerty]
-                file_path = os.path.join(second, "somefile.txt")
-                workspaces, designated = folders.all_and_designated(file_path)
-                self.assertListEqual(workspaces, [WorkspaceFolder.from_path(f) for f in (first, second, third)])
-                self.assertEqual(designated.path, second)
+        first_project_path = os.path.dirname(__file__)
+        second_project_path = tempfile.gettempdir()
+        folders = sorted_workspace_folders([second_project_path, first_project_path], __file__)
+        first_folder = WorkspaceFolder.from_path(first_project_path)
+        second_folder = WorkspaceFolder.from_path(second_project_path)
+        self.assertEqual(folders[0], first_folder)
+        self.assertEqual(folders[1], second_folder)
 
 
 class WorkspaceFolderTest(unittest.TestCase):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -13,7 +13,8 @@ class SortedWorkspaceFoldersTest(unittest.TestCase):
         nearest_project_path = os.path.dirname(__file__)
         unrelated_project_path = tempfile.gettempdir()
         parent_project_path = os.path.abspath(os.path.join(nearest_project_path, '..'))
-        folders = sorted_workspace_folders([unrelated_project_path, parent_project_path, nearest_project_path], __file__)
+        folders = sorted_workspace_folders([unrelated_project_path, parent_project_path, nearest_project_path],
+                                           __file__)
         nearest_folder = WorkspaceFolder.from_path(nearest_project_path)
         parent_folder = WorkspaceFolder.from_path(parent_project_path)
         unrelated_folder = WorkspaceFolder.from_path(unrelated_project_path)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -39,7 +39,8 @@ class WorkspaceFolderTest(unittest.TestCase):
 class IsSubpathOfTest(unittest.TestCase):
 
     def is_subpath_case_differs(self) -> None:
-        self.assertTrue(is_subpath_of(r"e:\WWW\nthu-ee-iframe\public\include\list_faculty_functions.php", r"E:\WWW\nthu-ee-iframe"))
+        self.assertTrue(is_subpath_of(r"e:\WWW\nthu-ee-iframe\public\include\list_faculty_functions.php",
+                                      r"E:\WWW\nthu-ee-iframe"))
 
 
 class WorkspaceFoldersTest(unittest.TestCase):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -10,13 +10,16 @@ import tempfile
 class SortedWorkspaceFoldersTest(unittest.TestCase):
 
     def test_get_workspace_from_multi_folder_project(self) -> None:
-        first_project_path = os.path.dirname(__file__)
-        second_project_path = tempfile.gettempdir()
-        folders = sorted_workspace_folders([second_project_path, first_project_path], __file__)
-        first_folder = WorkspaceFolder.from_path(first_project_path)
-        second_folder = WorkspaceFolder.from_path(second_project_path)
-        self.assertEqual(folders[0], first_folder)
-        self.assertEqual(folders[1], second_folder)
+        nearest_project_path = os.path.dirname(__file__)
+        unrelated_project_path = tempfile.gettempdir()
+        parent_project_path = os.path.abspath(os.path.join(nearest_project_path, '..'))
+        folders = sorted_workspace_folders([unrelated_project_path, parent_project_path, nearest_project_path], __file__)
+        nearest_folder = WorkspaceFolder.from_path(nearest_project_path)
+        parent_folder = WorkspaceFolder.from_path(parent_project_path)
+        unrelated_folder = WorkspaceFolder.from_path(unrelated_project_path)
+        self.assertEqual(folders[0], nearest_folder)
+        self.assertEqual(folders[1], parent_folder)
+        self.assertEqual(folders[2], unrelated_folder)
 
 
 class WorkspaceFolderTest(unittest.TestCase):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -115,14 +115,3 @@ class WorkspaceFoldersTest(unittest.TestCase):
         assert on_switched.call_count == 0
 
         self.assertEqual(wf.folders, [])
-
-    def test_is_foreign(self) -> None:
-        on_changed = mock.Mock()
-        on_switched = mock.Mock()
-        window = MockWindow(folders=["/etc", "/var"])
-        wf = ProjectFolders(window)
-        wf.on_changed = on_changed
-        wf.on_switched = on_switched
-        wf.update()
-        self.assertTrue(wf.is_foreign("/bin/ls"))
-        self.assertTrue(wf.is_inside("/etc/profile"))

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,5 +1,5 @@
 from test_mocks import MockWindow
-from LSP.plugin.core.workspace import ProjectFolders, sorted_workspace_folders
+from LSP.plugin.core.workspace import ProjectFolders, sorted_workspace_folders, is_subpath_of
 from LSP.plugin.core.protocol import WorkspaceFolder
 import os
 from unittest import mock
@@ -34,6 +34,12 @@ class WorkspaceFolderTest(unittest.TestCase):
         workspace = WorkspaceFolder("LSP", "/foo/bar/baz")
         lsp_dict = workspace.to_lsp()
         self.assertEqual(lsp_dict, {"name": "LSP", "uri": "file:///foo/bar/baz"})
+
+
+class IsSubpathOfTest(unittest.TestCase):
+
+    def is_subpath_case_differs(self) -> None:
+        self.assertTrue(is_subpath_of(r"e:\WWW\nthu-ee-iframe\public\include\list_faculty_functions.php", r"E:\WWW\nthu-ee-iframe"))
 
 
 class WorkspaceFoldersTest(unittest.TestCase):


### PR DESCRIPTION
This PR proposes to replace the initialisation lock with necessary checks and state management.
As far as I know there is no requirement for servers to respond to initialise in a certain time, so we should stop punishing our users for using servers like Metals.

Will not attempt to fix other edge cases related to server initialization as they can be solved in future work.

*Bugs to fix*
- [x] https://github.com/sublimelsp/LSP/issues/845
  - Make sure sessions with same but different case paths match files being opened 
  - Stop opening files outside workspace if workspace folders are defined
  - Make sure to not open more files for sessions that are initializing

- [x] https://github.com/sublimelsp/LSP/issues/860
  -  REVERTING Disable a server only for a specific folder of the project, if it fails to init    
     - We don't need complexity to support working with broken setups/servers
  - Do prefer longest workspace path
    - TODO: I didn't check what VSCode does with nested folders but we may want to match their behaviour.

*Issues reintroduced*
- https://github.com/sublimelsp/LSP/issues/844
  - Maybe want to support files outside of workspace path but it has often caused issues.

*Besides locking logic, this was also reverted*
- https://github.com/sublimelsp/LSP/pull/853 (keeping sessions out of dict if not ready, seems helpful but not needed to fix any issues?)
- https://github.com/sublimelsp/LSP/pull/875 (initialize timeout setting)

*To do*
-  [x] restore any valuable tests reverted