### PR TITLE
improve pyls installation command

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -643,7 +643,7 @@ There are at least two language servers, use either one.
 #### Palantir's Python Language Server
 
 ```sh
-pip install python-language-server
+pip install 'python-language-server[all]'
 ```
 
 Make sure you can run `pyls` in your terminal. If you've installed it into a virtualenv, you might need to override the path to `pyls` in global LSP settings (Package Settings -> LSP -> Settings):


### PR DESCRIPTION
`pip install python-language-server` installs only the python language server while `pip install 'python-language-server[all]'` additionally installs optional providers such as pycodestyle and yapf, users would generally want/expect these providers.