### PR TITLE
Support v2 of LanguageHandler that gets Session in on_initialized

### DIFF
--- a/plugin/core/handlers.py
+++ b/plugin/core/handlers.py
@@ -4,6 +4,7 @@ import abc
 
 
 class LanguageHandler(metaclass=abc.ABCMeta):
+    api_version = 1
     on_start = None  # type: Optional[Callable]
     on_initialized = None  # type: Optional[Callable]
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -200,10 +200,15 @@ class Session(object):
             if not self._workspace_folders or self._unsafe_supports_workspace_folders():
                 return True
         # We're in a window with folders, and we're a single-folder session.
+        return self.workspace_folder_from_path(file_path) is not None
+
+    def workspace_folder_from_path(self, file_path: str) -> Optional[WorkspaceFolder]:
+        candidate = None  # type: Optional[WorkspaceFolder]
         for folder in self._workspace_folders:
             if file_path.startswith(folder.path):
-                return True
-        return False
+                if candidate is None or len(folder.path) > len(candidate.path):
+                    candidate = folder
+        return candidate
 
     def update_folders(self, folders: List[WorkspaceFolder]) -> None:
         with self.acquire_timeout():

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -35,7 +35,7 @@ class LanguageHandlerListener(Protocol):
     def on_start(self, config_name: str, window: WindowLike) -> bool:
         ...
 
-    def on_initialized(self, config_name: str, window: WindowLike, client: Client) -> None:
+    def on_initialized(self, session: Session, window: WindowLike) -> None:
         ...
 
 
@@ -572,7 +572,7 @@ class WindowManager(object):
             "textDocument/publishDiagnostics",
             lambda params: self.diagnostics.receive(session.config.name, params))
 
-        self._handlers.on_initialized(session.config.name, self._window, session.client)
+        self._handlers.on_initialized(session, self._window)
 
         session.client.send_notification(Notification.initialized())
 

--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -117,8 +117,8 @@ class MockHandlerDispatcher(object):
     def on_start(self, config_name: str, window) -> bool:
         return self._can_start
 
-    def on_initialized(self, config_name: str, window, client):
-        self._initialized.add(config_name)
+    def on_initialized(self, session: Session, window):
+        self._initialized.add(session.config.name)
 
 
 class MockWindow(object):


### PR DESCRIPTION
Added possibility to opt-in to LanguageHandler v2 which receives
`Session` instance in `on_initialized` handler instead of `Client`.
This allows to get access to WorkspaceFolder's and provide
`workspaceFolder` property in response to workspace/configuration
request.

Related: https://github.com/sublimelsp/LSP-eslint/pull/6