### PR TITLE
Fix point_to_offset() when Position.character > line length

### DIFF
--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -25,7 +25,12 @@ def get_line(window: Optional[sublime.Window], file_name: str, row: int) -> str:
 
 
 def point_to_offset(point: Point, view: sublime.View) -> int:
-    return view.text_point(point.row, point.col)
+    return view.text_point(
+        point.row,
+        # @see https://microsoft.github.io/language-server-protocol/specifications/specification-3-15/#position
+        # If the character value is greater than the line length it defaults back to the line length.
+        min(point.col, len(view.line(view.text_point(point.row, 0))))
+    )
 
 
 def offset_to_point(view: sublime.View, offset: int) -> Point:


### PR DESCRIPTION
# Problem

![image](https://user-images.githubusercontent.com/6594915/76295223-34288d00-62ef-11ea-8746-fb96f4b09656.png)

<details><summary>YAML codes for reproduction</summary>

```yaml
# This file is the entry point to configure your own services.
parameters:
    locale: 'en'
j: ""x
services:
    # default configuration for services in *this* file
    _defaults:
        autowire: true      # Automatically injects dependencies in your services.
        autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
        public: false       # Allows optimizing the container by removing unused services; this also means
                            # fetching services directly from the container via $container->get() won't work.
                            # The best practice is to be explicit about your dependencies anyway.
```

</details>

<details><summary>LSP diagnostic panel</summary>

```text
◌ C:\Users\Clover\Desktop\test.yaml:
        4:115 	None        	error     	can not read a block mapping entry; a multiline key may not be an implicit key
```

</details>

<details><summary>LSP payload log</summary>

```text
:: <-- yaml-lsp textDocument/publishDiagnostics: {'diagnostics': [{'message': 'can not read a block mapping entry; a multiline key may not be an implicit key', 'range': {'end': {'character': 114, 'line': 3}, 'start': {'character': 114, 'line': 3}}, 'severity': 1}], 'uri': 'file:///C:/Users/Clover/Desktop/test.yaml'}
```

</details>

I have [yaml-language-server](https://www.npmjs.com/package/yaml-language-server) installed and sometimes I see weird red underlines (like in line 8) and I don't know why. Today, I open the diagnostic panel. It shows `line 4, character 115`. The `line 4` makes sense since there is an invalid trailing `x`. `character 115` makes me feel it's counted from the 0th line, which is incorrect according to LSP specifications, but even in that case, 115th char is actually on line 6 (not line 4).



# Fix

While ST's `view.text_point(row, col)` says 

> Note that col is interpreted as the number of characters to advance past the beginning of the row.


I checked the [Position](https://microsoft.github.io/language-server-protocol/specifications/specification-3-15/#position) definition in LSP specifications. It says 

> If the character value is greater than the line length it defaults back to the line length.

After this patch, it looks like

![image](https://user-images.githubusercontent.com/6594915/76296918-ed886200-62f1-11ea-992c-81510e2f4c98.png)



# References

- https://www.sublimetext.com/docs/3/api_reference.html
- https://microsoft.github.io/language-server-protocol/specifications/specification-3-15/#position

```ts
interface Position {
	/**
	 * Line position in a document (zero-based).
	 */
	line: number;

	/**
	 * Character offset on a line in a document (zero-based). Assuming that the line is
	 * represented as a string, the `character` value represents the gap between the
	 * `character` and `character + 1`.
	 *
	 * If the character value is greater than the line length it defaults back to the
	 * line length.
	 */
	character: number;
}
```