### PR TITLE
Account for server request ID strings

### DIFF
--- a/Syntaxes/ServerLog.sublime-syntax
+++ b/Syntaxes/ServerLog.sublime-syntax
@@ -41,8 +41,8 @@ contexts:
           - - match: \(
               scope: punctuation.section.parens.begin.lsp
               set:
-                - match: \d+
-                  scope: constant.numeric.integer.decimal.lsp
+                - match: '[^\s)]+'
+                  scope: constant.numeric.lsp
                   set:
                     - match: \)
                       scope: punctuation.section.parens.end.lsp

--- a/Syntaxes/ServerLog.sublime-syntax
+++ b/Syntaxes/ServerLog.sublime-syntax
@@ -6,8 +6,9 @@ hidden: true
 scope: output.lsp.log
 
 variables:
-  method: '[[:alpha:]][[:alnum:]/]*'
+  method: '[[:alnum:]/$]+'
   servername: '[[:alnum:]_-]+'
+  id: '[^\s:]+'
 
 contexts:
   main:
@@ -22,65 +23,59 @@ contexts:
     - match: '^::'
       scope: punctuation.accessor.lsp
       push:
-      - - meta_scope: meta.group.lsp
-        - match: $
-          pop: true
-        # responses
-      - - match: \d+
-          scope: constant.numeric.integer.decimal.lsp
-          set:
-            - match: ':'
-              scope: punctuation.separator.lsp
-              set: maybe-payload
-            - match: ''
-              pop: true
-        # notifications or requests
-        - match: (?=\w)
-          set:
-            # requests
-          - - match: \(
-              scope: punctuation.section.parens.begin.lsp
-              set:
-                - match: '[^\s)]+'
-                  scope: constant.numeric.lsp
-                  set:
-                    - match: \)
-                      scope: punctuation.section.parens.end.lsp
-                      set:
-                        - match: ':'
-                          scope: punctuation.separator.lsp
-                          set: maybe-payload
-                        - match: ''
-                          pop: true
-            # notifications
-            - match: ':'
-              scope: punctuation.separator.lsp
-              set: maybe-payload
-            - match: ''
-              pop: true
-          - - match: '{{method}}'
-              scope: keyword.control.lsp
-              pop: true
-        # language server name
-      - - match: \S+
-          scope: variable.function.lsp
-          pop: true
-        # arrows
-      - - match: -->
+        - meta_scope: meta.group.lsp
+        - match: (?:==|--)>
           scope: storage.modifier.lsp
-          pop: true
+          set: [maybe-payload, request, server-name]
+        - match: ->
+          scope: storage.modifier.lsp
+          set: [maybe-payload, notification, server-name]
+        - match: '>>>'
+          scope: storage.modifier.lsp
+          set: [maybe-payload, response, server-name]
         - match: <--
           scope: storage.modifier.lsp
-          pop: true
-        - match: ==>
+          set: [maybe-payload, request, server-name]
+        - match: <-
           scope: storage.modifier.lsp
-          pop: true
-        - match: unhandled
+          set: [maybe-payload, notification, server-name]
+        - match: <<<
+          scope: storage.modifier.lsp
+          set: [maybe-payload, response, server-name]
+        - match: <\?\?
           scope: invalid.deprecated.lsp
-          pop: true
+          set: [maybe-payload, request, server-name]
+        - match: <\?
+          scope: invalid.deprecated.lsp
+          set: [maybe-payload, notification, server-name]
+
+  server-name:
+    - match: '{{servername}}'
+      scope: variable.function.lsp
+      pop: true
+
+  request:
+    - match: ({{method}})(\()({{id}})(\))
+      captures:
+        1: keyword.control.lsp
+        2: punctuation.section.parens.begin.lsp
+        3: constant.numeric.id.lsp
+        4: punctuation.section.parens.end.lsp
+      pop: true
+
+  notification:
+    - match: '{{method}}'
+      scope: keyword.control.lsp
+      pop: true
+
+  response:
+    - match: '{{id}}'
+      scope: constant.numeric.id.lsp
+      pop: true
 
   maybe-payload:
-    - match: \s*(?=\S)
+    - match: ':'
+      scope: punctuation.separator.lsp
       set:
         - match: $
           pop: true

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -194,7 +194,7 @@ class Response:
 
     __slots__ = ('request_id', 'result')
 
-    def __init__(self, request_id: int, result: Union[None, Mapping[str, Any], Iterable[Any]]) -> None:
+    def __init__(self, request_id: Any, result: Union[None, Mapping[str, Any], Iterable[Any]]) -> None:
         self.request_id = request_id
         self.result = result
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -272,10 +272,10 @@ class Session(object):
         if self._on_post_initialize:
             self._on_post_initialize(self, None)
 
-    def _handle_request_workspace_folders(self, _: Any, request_id: int) -> None:
+    def _handle_request_workspace_folders(self, _: Any, request_id: Any) -> None:
         self.client.send_response(Response(request_id, [wf.to_lsp() for wf in self._workspace_folders]))
 
-    def _handle_request_workspace_configuration(self, params: Dict[str, Any], request_id: int) -> None:
+    def _handle_request_workspace_configuration(self, params: Dict[str, Any], request_id: Any) -> None:
         items = []  # type: List[Any]
         requested_items = params.get("items") or []
         for requested_item in requested_items:

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -484,7 +484,7 @@ class WindowManager(object):
             debug("window {} added session {}".format(self._window.id(), config.name))
             self._sessions.setdefault(config.name, []).append(session)
 
-    def _handle_message_request(self, params: dict, client: Client, request_id: int) -> None:
+    def _handle_message_request(self, params: dict, client: Client, request_id: Any) -> None:
         actions = params.get("actions", [])
         titles = list(action.get("title") for action in actions)
 


### PR DESCRIPTION
Request IDs can be strings or integers.
We, the text editor, always use integers for request IDs.
But some servers may send out e.g. GUIDs as request IDs.
I decided to type-erase the request ID in various places,
because all we're doing in most functions is passing through
the received request ID from the server all the way to our
Response object, finally serializing it back to JSON again.

close #905 

@jwortmann, mind giving this branch a try?