### PR TITLE
Read values for workspace/configuration request from settings

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -453,11 +453,32 @@ Pkg.add("SymbolServer")
 ```js
 "julials": {
   "command": ["bash", "PATH_TO_JULIA_SERVER/LanguageServer/contrib/languageserver.sh"], // on Linux/macOS
-  // "command": ["julia", "--startup-file=no", "--history-file=no", "-e", "using LanguageServer; using SymbolServer; server=LanguageServer.LanguageServerInstance(stdin,stdout,false); run(server);"], // on Windows
+  // "command": ["julia", "--startup-file=no", "--history-file=no", "-e", "using LanguageServer; using LanguageServer.SymbolServer; server=LanguageServer.LanguageServerInstance(stdin,stdout,false); run(server)"], // on Windows
   "languageId": "julia",
   "scopes": ["source.julia"],
   "settings": {
-    "runlinter": true
+    // Default values from VS Code:
+    "julia.format.calls": true,      // Format function calls
+    "julia.format.comments": true,   // Format comments
+    "julia.format.curly": true,      // Format braces
+    "julia.format.docs": true,       // Format inline documentation
+    "julia.format.indent": 4,        // Indent size for formatting
+    "julia.format.indents": true,    // Format file indents
+    "julia.format.iterOps": true,    // Format loop iterators
+    "julia.format.kw": true,         // Remove spaces around = in function keywords
+    "julia.format.lineends": false,  // [undocumented]
+    "julia.format.ops": true,        // Format whitespace around operators
+    "julia.format.tuples": true,     // Format tuples
+    "julia.lint.call": false,        // Check calls against existing methods (experimental)
+    "julia.lint.constif": true,      // Check for constant conditionals of if statements
+    "julia.lint.datadecl": false,    // [undocumented]
+    "julia.lint.iter": true,         // Check iterator syntax of loops
+    "julia.lint.lazy": true,         // Check for deterministic lazy boolean operators
+    "julia.lint.modname": true,      // Check for invalid submodule names
+    "julia.lint.nothingcomp": false, // [undocumented]
+    "julia.lint.pirates": true,      // Check for type piracy
+    "julia.lint.run": true,          // run the linter on active files
+    "julia.lint.typeparam": true     // Check for unused DataType parameters
   },
   "syntaxes": ["Packages/Julia/Julia.sublime-syntax"]
 }
@@ -478,6 +499,11 @@ Pkg.add("SymbolServer")
   "enabled": true,
   "languageId": "kotlin",
   "scopes": ["source.Kotlin"],
+  "settings": {
+    "kotlin": {
+      // put your server settings here
+    }
+  },
   "syntaxes": ["Packages/kotlin/Kotlin.tmLanguage"]
 }
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -458,27 +458,33 @@ Pkg.add("SymbolServer")
   "scopes": ["source.julia"],
   "settings": {
     // Default values from VS Code:
-    "julia.format.calls": true,      // Format function calls
-    "julia.format.comments": true,   // Format comments
-    "julia.format.curly": true,      // Format braces
-    "julia.format.docs": true,       // Format inline documentation
-    "julia.format.indent": 4,        // Indent size for formatting
-    "julia.format.indents": true,    // Format file indents
-    "julia.format.iterOps": true,    // Format loop iterators
-    "julia.format.kw": true,         // Remove spaces around = in function keywords
-    "julia.format.lineends": false,  // [undocumented]
-    "julia.format.ops": true,        // Format whitespace around operators
-    "julia.format.tuples": true,     // Format tuples
-    "julia.lint.call": false,        // Check calls against existing methods (experimental)
-    "julia.lint.constif": true,      // Check for constant conditionals of if statements
-    "julia.lint.datadecl": false,    // [undocumented]
-    "julia.lint.iter": true,         // Check iterator syntax of loops
-    "julia.lint.lazy": true,         // Check for deterministic lazy boolean operators
-    "julia.lint.modname": true,      // Check for invalid submodule names
-    "julia.lint.nothingcomp": false, // [undocumented]
-    "julia.lint.pirates": true,      // Check for type piracy
-    "julia.lint.run": true,          // run the linter on active files
-    "julia.lint.typeparam": true     // Check for unused DataType parameters
+    "julia": {
+      "format": {
+        "calls": true,        // Format function calls
+        "comments": true,     // Format comments
+        "curly": true,        // Format braces
+        "docs": true,         // Format inline documentation
+        "indent": 4,          // Indent size for formatting
+        "indents": true,      // Format file indents
+        "iterOps": true,      // Format loop iterators
+        "kw": true,           // Remove spaces around = in function keywords
+        "lineends": false,    // [undocumented]
+        "ops": true,          // Format whitespace around operators
+        "tuples": true,       // Format tuples
+      },
+      "lint": {
+        "call": false,        // Check calls against existing methods (experimental)
+        "constif": true,      // Check for constant conditionals of if statements
+        "datadecl": false,    // [undocumented]
+        "iter": true,         // Check iterator syntax of loops
+        "lazy": true,         // Check for deterministic lazy boolean operators
+        "modname": true,      // Check for invalid submodule names
+        "nothingcomp": false, // [undocumented]
+        "pirates": true,      // Check for type piracy
+        "run": true,          // run the linter on active files
+        "typeparam": true     // Check for unused DataType parameters
+      }
+    }
   },
   "syntaxes": ["Packages/Julia/Julia.sublime-syntax"]
 }
@@ -493,7 +499,7 @@ Pkg.add("SymbolServer")
 2. Install the [Kotlin Language Server](https://github.com/fwcd/KotlinLanguageServer) (requires [building](https://github.com/fwcd/KotlinLanguageServer/blob/master/BUILDING.md) first).
 3. Add to LSP settings' clients:
 
-```json
+```js
 "kotlinls": {
   "command": ["PATH/TO/KotlinLanguageServer/build/install/kotlin-language-server/bin/kotlin-language-server.bat"],
   "enabled": true,

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -279,12 +279,15 @@ class Session(object):
         items = []  # type: List[Any]
         requested_items = params.get("items") or []
         for requested_item in requested_items:
-            if requested_item['section'] in self.config.settings:
-                items.append(self.config.settings[requested_item['section']])
-            elif requested_item['section'] == '':  # required for ESLint server
-                items.append(self.config.settings)
+            if 'section' in requested_item:
+                if not requested_item['section']:
+                    items.append(self.config.settings)
+                elif requested_item['section'] in self.config.settings:
+                    items.append(self.config.settings[requested_item['section']])
+                else:
+                    items.append(None)
             else:
-                items.append(None)
+                items.append(self.config.settings)
         self.client.send_response(Response(request_id, items))
 
     def end(self) -> None:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -279,7 +279,12 @@ class Session(object):
         items = []  # type: List[Any]
         requested_items = params.get("items") or []
         for requested_item in requested_items:
-            items.append(self.config.settings)  # ???
+            if requested_item['section'] in self.config.settings:
+                items.append(self.config.settings[requested_item['section']])
+            elif requested_item['section'] == '':  # required for ESLint server
+                items.append(self.config.settings)
+            else:
+                items.append(None)
         self.client.send_response(Response(request_id, items))
 
     def end(self) -> None:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -104,6 +104,16 @@ def diff_folders(old: List[WorkspaceFolder],
     return added, removed
 
 
+def get_dotted_value(current: Any, dotted: str) -> Any:
+    keys = dotted.split('.')
+    for key in keys:
+        if isinstance(current, dict):
+            current = current.get(key)
+        else:
+            return None
+    return current
+
+
 class InitializeError(Exception):
 
     def __init__(self, session: 'Session') -> None:
@@ -280,12 +290,11 @@ class Session(object):
         requested_items = params.get("items") or []
         for requested_item in requested_items:
             if 'section' in requested_item:
-                if not requested_item['section']:
-                    items.append(self.config.settings)
-                elif requested_item['section'] in self.config.settings:
-                    items.append(self.config.settings[requested_item['section']])
+                section = requested_item['section']
+                if section:
+                    items.append(get_dotted_value(self.config.settings, section))
                 else:
-                    items.append(None)
+                    items.append(self.config.settings)
             else:
                 items.append(self.config.settings)
         self.client.send_response(Response(request_id, items))


### PR DESCRIPTION
The workspace/configuration request seems to be implemented differently in various servers:

* The Julia server sends multiple configuration keys as `section`
* The ESLint server sends a blank section instead, but expects a single dict of configuration settings.
* According to https://github.com/sublimelsp/LSP/pull/737#issuecomment-536482338 the Kotlin server sends a single "kotlin" as `section`.

This PR makes LSP to read each `section` from the server's settings in LSP.sublime-settings, so for the Julia server they could for example be
```json
"settings": {
    "julia.format.calls": false,
    "julia.format.comments": false,
    "julia.format.curly": false,
    "julia.format.docs": false,
    "julia.format.indent": 4,
    "julia.format.indents": false,
    "julia.format.iterOps": false,
    "julia.format.kw": false,
    "julia.format.lineends": false,
    "julia.format.ops": false,
    "julia.format.tuples": false,
    "julia.lint.call": false,
    "julia.lint.constif": false,
    "julia.lint.datadecl": false,
    "julia.lint.iter": false,
    "julia.lint.lazy": false,
    "julia.lint.modname": false,
    "julia.lint.nothingcomp": false,
    "julia.lint.pirates": false,
    "julia.lint.run": false,
    "julia.lint.typeparam": false
},
```

If a 'section' name is missing in the settings, LSP should use `None` as its value, as described in https://microsoft.github.io/language-server-protocol/specification#workspace_configuration.
A separate fix is needed for the ESLint server, because its 'section' value is blank.

The Kotlin server would require
```javascript
"settings": {
    "kotlin": {
        // specific settings here
    }
}
```
This might require a change for users who use this server, but I think it is better than adding another special case just for that server. I have not tested with the Kotlin server though, perhaps someone could test if it works before merging?

The `scopeURI` described in the specs is still ignored here by LSP (it is not used in the Julia server).

Fixes #907 

Related: #699 