### PR TITLE
Reply to all requests

### DIFF
--- a/Syntaxes/ServerLog.sublime-syntax
+++ b/Syntaxes/ServerLog.sublime-syntax
@@ -33,6 +33,9 @@ contexts:
         - match: '>>>'
           scope: storage.modifier.lsp
           set: [maybe-payload, response, server-name]
+        - match: '~~>'
+          scope: invalid.illegal.lsp
+          set: [maybe-payload, response, server-name]
         - match: <--
           scope: storage.modifier.lsp
           set: [maybe-payload, request, server-name]
@@ -42,9 +45,9 @@ contexts:
         - match: <<<
           scope: storage.modifier.lsp
           set: [maybe-payload, response, server-name]
-        - match: <\?\?
-          scope: invalid.deprecated.lsp
-          set: [maybe-payload, request, server-name]
+        - match: <~~
+          scope: invalid.illegal.lsp
+          set: [maybe-payload, response, server-name]
         - match: <\?
           scope: invalid.deprecated.lsp
           set: [maybe-payload, notification, server-name]

--- a/messages.json
+++ b/messages.json
@@ -26,5 +26,6 @@
     "0.9.3": "messages/0.9.3.txt",
     "0.9.4": "messages/0.9.4.txt",
     "0.9.5": "messages/0.9.5.txt",
-    "0.9.6": "messages/0.9.6.txt"
+    "0.9.6": "messages/0.9.6.txt",
+    "0.9.7": "messages/0.9.7.txt"
 }

--- a/messages/0.9.7.txt
+++ b/messages/0.9.7.txt
@@ -1,0 +1,7 @@
+=> 0.9.7
+
+Fixes:
+
+* Reply to all server requests, as per JSON-RPC spec.
+  This changes mostly nothing, except that we might reply with an
+  error response.

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -190,6 +190,44 @@ class Request:
         }
 
 
+class ErrorCode:
+    # Defined by JSON RPC
+    ParseError = -32700
+    InvalidRequest = -32600
+    MethodNotFound = -32601
+    InvalidParams = -32602
+    InternalError = -32603
+    serverErrorStart = -32099
+    serverErrorEnd = -32000
+    ServerNotInitialized = -32002
+    UnknownErrorCode = -32001
+
+    # Defined by the protocol
+    RequestCancelled = -32800
+    ContentModified = -32801
+
+
+class Error(Exception):
+
+    def __init__(self, code: int, message: str, data: Any = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.data = data
+
+    def to_lsp(self) -> Dict[str, Any]:
+        result = {"code": self.code, "message": super().__str__()}
+        if self.data:
+            result["data"] = self.data
+        return result
+
+    def __str__(self) -> str:
+        return "{} ({})".format(super().__str__(), self.code)
+
+    @classmethod
+    def from_exception(cls, ex: Exception) -> 'Error':
+        return Error(ErrorCode.InternalError, str(ex))
+
+
 class Response:
 
     __slots__ = ('request_id', 'result')

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -197,8 +197,8 @@ class ErrorCode:
     MethodNotFound = -32601
     InvalidParams = -32602
     InternalError = -32603
-    serverErrorStart = -32099
-    serverErrorEnd = -32000
+    ServerErrorStart = -32099
+    ServerErrorEnd = -32000
     ServerNotInitialized = -32002
     UnknownErrorCode = -32001
 

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -174,8 +174,16 @@ class ClientTest(unittest.TestCase):
         transport.receive('{ "id": "abcd-1234-efgh-5678", "method": "ping"}')
         self.assertEqual(len(transport.messages), 1)
         self.assertEqual(
-            transport.messages[0],
-            '{"error":{"message":"ping","code":-32601},"jsonrpc":"2.0","id":"abcd-1234-efgh-5678"}')
+            json.loads(transport.messages[0]),
+            {
+                "error": {
+                    "message": "ping",
+                    "code": -32601
+                },
+                "jsonrpc": "2.0",
+                "id": "abcd-1234-efgh-5678"
+            }
+        )
 
     def test_server_request_exception_during_handler(self):
         transport = MockTransport()
@@ -191,8 +199,16 @@ class ClientTest(unittest.TestCase):
         transport.receive('{ "id": "abcd-1234-efgh-5678", "method": "ping"}')
         self.assertEqual(len(transport.messages), 1)
         self.assertEqual(
-            transport.messages[0],
-            '{"error":{"message":"whoops","code":-32603},"jsonrpc":"2.0","id":"abcd-1234-efgh-5678"}')
+            json.loads(transport.messages[0]),
+            {
+                "error": {
+                    "message": "whoops",
+                    "code": -32603
+                },
+                "jsonrpc": "2.0",
+                "id": "abcd-1234-efgh-5678"
+            }
+        )
 
     def test_server_request_send_error(self):
         transport = MockTransport()
@@ -208,8 +224,16 @@ class ClientTest(unittest.TestCase):
         transport.receive('{ "id": "abcd-1234-efgh-5678", "method": "ping"}')
         self.assertEqual(len(transport.messages), 1)
         self.assertEqual(
-            transport.messages[0],
-            '{"error":{"message":"expected dict, got list","code":-32602},"jsonrpc":"2.0","id":"abcd-1234-efgh-5678"}')
+            json.loads(transport.messages[0]),
+            {
+                "error": {
+                    "message": "expected dict, got list",
+                    "code": -32602
+                },
+                "jsonrpc": "2.0",
+                "id": "abcd-1234-efgh-5678"
+            }
+        )
 
     def test_error_response_handler(self):
         transport = MockTransport(return_error)

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -1,4 +1,6 @@
 from LSP.plugin.core.logging import set_exception_logging
+from LSP.plugin.core.protocol import Error
+from LSP.plugin.core.protocol import ErrorCode
 from LSP.plugin.core.protocol import Notification
 from LSP.plugin.core.protocol import Request
 from LSP.plugin.core.rpc import Client
@@ -162,6 +164,52 @@ class ClientTest(unittest.TestCase):
         self.assertEqual(len(pings), 1)
         self.assertIsInstance(pings[0][0], str)
         self.assertEqual(pings[0][0], "abcd-1234-efgh-5678")
+
+    def test_server_request_unknown(self):
+        transport = MockTransport()
+        settings = MockSettings()
+        client = Client(transport, settings)
+        self.assertIsNotNone(client)
+        self.assertTrue(transport.has_started)
+        transport.receive('{ "id": "abcd-1234-efgh-5678", "method": "ping"}')
+        self.assertEqual(len(transport.messages), 1)
+        self.assertEqual(
+            transport.messages[0],
+            '{"error":{"message":"ping","code":-32601},"jsonrpc":"2.0","id":"abcd-1234-efgh-5678"}')
+
+    def test_server_request_exception_during_handler(self):
+        transport = MockTransport()
+        settings = MockSettings()
+        client = Client(transport, settings)
+        self.assertIsNotNone(client)
+        self.assertTrue(transport.has_started)
+
+        def always_raise_exception(params: Any, request_id: Any) -> None:
+            raise AttributeError("whoops")
+
+        client.on_request("ping", always_raise_exception)
+        transport.receive('{ "id": "abcd-1234-efgh-5678", "method": "ping"}')
+        self.assertEqual(len(transport.messages), 1)
+        self.assertEqual(
+            transport.messages[0],
+            '{"error":{"message":"whoops","code":-32603},"jsonrpc":"2.0","id":"abcd-1234-efgh-5678"}')
+
+    def test_server_request_send_error(self):
+        transport = MockTransport()
+        settings = MockSettings()
+        client = Client(transport, settings)
+        self.assertIsNotNone(client)
+        self.assertTrue(transport.has_started)
+
+        def always_raise_exception(params: Any, request_id: Any) -> None:
+            raise Error(ErrorCode.InvalidParams, "expected dict, got list")
+
+        client.on_request("ping", always_raise_exception)
+        transport.receive('{ "id": "abcd-1234-efgh-5678", "method": "ping"}')
+        self.assertEqual(len(transport.messages), 1)
+        self.assertEqual(
+            transport.messages[0],
+            '{"error":{"message":"expected dict, got list","code":-32602},"jsonrpc":"2.0","id":"abcd-1234-efgh-5678"}')
 
     def test_error_response_handler(self):
         transport = MockTransport(return_error)


### PR DESCRIPTION
- When there's no request handler, reply with an error with code MethodNotFound
- When there's an exception thrown in the request handler, translate that exception to an error response.
- When there's an exception of type Error thrown in the request handler, send that error as-is.

Quoting the JSON-RPC 2.0 spec, which LSP is based on:

    When a rpc call is made, the Server MUST reply with a Response,
    except for in the case of Notifications.

Admittedly this is talking about "the server", but the LSP spec page says every request must be paired with a response, omitting the word "server": https://microsoft.github.io/language-server-protocol/specification#requestMessage

And the wikipedia page also talks about "the receiver" of a request: https://en.wikipedia.org/wiki/JSON-RPC#Usage

In any case, this creates two unhandled exceptions in eslint:

```
lsp-eslint: ESLint server running in node v12.13.1
lsp-eslint: Registering request handler for workspace/didChangeConfiguration failed.
lsp-eslint: (node:20544) UnhandledPromiseRejectionWarning: Error: client/registerCapability
lsp-eslint: at handleResponse (/home/raoul/.config/sublime-text-3/Packages/LSP-eslint/vscode-eslint/node_modules/vscode-jsonrpc/lib/main.js:447:48)
lsp-eslint: Registering request handler for workspace/didChangeWorkspaceFolders failed.
lsp-eslint: at processMessageQueue (/home/raoul/.config/sublime-text-3/Packages/LSP-eslint/vscode-eslint/node_modules/vscode-jsonrpc/lib/main.js:274:17)
lsp-eslint: at Immediate.<anonymous> (/home/raoul/.config/sublime-text-3/Packages/LSP-eslint/vscode-eslint/node_modules/vscode-jsonrpc/lib/main.js:258:13)
lsp-eslint: at processImmediate (internal/timers.js:439:21)
lsp-eslint: (node:20544) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
lsp-eslint: (node:20544) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
lsp-eslint: (node:20544) UnhandledPromiseRejectionWarning: Error: client/registerCapability
lsp-eslint: at handleResponse (/home/raoul/.config/sublime-text-3/Packages/LSP-eslint/vscode-eslint/node_modules/vscode-jsonrpc/lib/main.js:447:48)
lsp-eslint: at processMessageQueue (/home/raoul/.config/sublime-text-3/Packages/LSP-eslint/vscode-eslint/node_modules/vscode-jsonrpc/lib/main.js:274:17)
lsp-eslint: at Immediate.<anonymous> (/home/raoul/.config/sublime-text-3/Packages/LSP-eslint/vscode-eslint/node_modules/vscode-jsonrpc/lib/main.js:258:13)
lsp-eslint: at processImmediate (internal/timers.js:439:21)
lsp-eslint: (node:20544) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 4)
lsp-eslint: ESLint library loaded from: /home/raoul/Documents/Programming/temp/nuxt-i18n/node_modules/eslint/lib/api.js
:: --> lsp-eslint initialize(1): {'rootPath': '/home/raoul/Documents/Programming/temp/nuxt-i18n', 'capabilities': {'workspace': {'executeCommand': {}, 'symbol': {'symbolKind': {'valueSet': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]}}, 'didChangeConfiguration': {}, 'workspaceFolders': True, 'applyEdit': True, 'configuration': True}, 'textDocument': {'completion': {'completionItem': {'snippetSupport': True}, 'completionItemKind': {'valueSet': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]}}, 'documentSymbol': {'symbolKind': {'valueSet': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]}}, 'formatting': {}, 'declaration': {'linkSupport': True}, 'definition': {'linkSupport': True}, 'colorProvider': {}, 'references': {}, 'synchronization': {'willSaveWaitUntil': True, 'didSave': True, 'willSave': True}, 'rangeFormatting': {}, 'implementation': {'linkSupport': True}, 'signatureHelp': {'signatureInformation': {'parameterInformation': {'labelOffsetSupport': True}, 'documentationFormat': ['markdown', 'plaintext']}}, 'publishDiagnostics': {'relatedInformation': True}, 'rename': {}, 'hover': {'contentFormat': ['markdown', 'plaintext']}, 'documentHighlight': {}, 'typeDefinition': {'linkSupport': True}, 'codeAction': {'codeActionLiteralSupport': {'codeActionKind': {'valueSet': []}}}}}, 'processId': 20503, 'workspaceFolders': [{'name': 'nuxt-i18n', 'uri': 'file:///home/raoul/Documents/Programming/temp/nuxt-i18n'}], 'rootUri': 'file:///home/raoul/Documents/Programming/temp/nuxt-i18n'}
:: --> javascript-typescript-langserver initialize(1): {'rootPath': '/home/raoul/Documents/Programming/temp/nuxt-i18n', 'capabilities': {'workspace': {'executeCommand': {}, 'symbol': {'symbolKind': {'valueSet': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]}}, 'didChangeConfiguration': {}, 'workspaceFolders': True, 'applyEdit': True, 'configuration': True}, 'textDocument': {'completion': {'completionItem': {'snippetSupport': True}, 'completionItemKind': {'valueSet': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]}}, 'documentSymbol': {'symbolKind': {'valueSet': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]}}, 'formatting': {}, 'declaration': {'linkSupport': True}, 'definition': {'linkSupport': True}, 'colorProvider': {}, 'references': {}, 'synchronization': {'willSaveWaitUntil': True, 'didSave': True, 'willSave': True}, 'rangeFormatting': {}, 'implementation': {'linkSupport': True}, 'signatureHelp': {'signatureInformation': {'parameterInformation': {'labelOffsetSupport': True}, 'documentationFormat': ['markdown', 'plaintext']}}, 'publishDiagnostics': {'relatedInformation': True}, 'rename': {}, 'hover': {'contentFormat': ['markdown', 'plaintext']}, 'documentHighlight': {}, 'typeDefinition': {'linkSupport': True}, 'codeAction': {'codeActionLiteralSupport': {'codeActionKind': {'valueSet': []}}}}}, 'processId': 20503, 'workspaceFolders': [{'name': 'nuxt-i18n', 'uri': 'file:///home/raoul/Documents/Programming/temp/nuxt-i18n'}], 'rootUri': 'file:///home/raoul/Documents/Programming/temp/nuxt-i18n'}
:: <<< lsp-eslint 1: {'capabilities': {'textDocumentSync': {'openClose': True, 'save': {'includeText': False}, 'change': 1, 'willSaveWaitUntil': True}, 'codeActionProvider': True, 'executeCommandProvider': {'commands': ['eslint.applySingleFix', 'eslint.applySameFixes', 'eslint.applyAllFixes', 'eslint.applyAutoFix', 'eslint.applyDisableLine', 'eslint.applyDisableFile', 'eslint.openRuleDoc']}}}
::  -> lsp-eslint workspace/didChangeConfiguration: {'settings': {'run': 'onType', 'options': {}, 'quiet': False, 'workspaceFolder': None, 'autoFix': True, 'packageManager': 'npm', 'autoFixOnSave': True, 'nodePath': None, 'validate': True, 'codeAction': {'showDocumentation': {'enable': True}, 'disableRuleComment': {'location': 'separateLine', 'enable': True}}}}
::  -> lsp-eslint initialized: {}
::  -> lsp-eslint textDocument/didOpen
:: <-- lsp-eslint client/registerCapability(0): {'registrations': [{'registerOptions': {}, 'method': 'workspace/didChangeConfiguration', 'id': '26587724-6caa-4847-b929-ba795ecc773f'}]}
:: ~~> lsp-eslint 0: {'code': -32601, 'message': 'client/registerCapability'}
:: <-- lsp-eslint client/registerCapability(1): {'registrations': [{'registerOptions': {}, 'method': 'workspace/didChangeWorkspaceFolders', 'id': '87d6f0f6-5264-445a-9010-00d39a6478b0'}]}
:: ~~> lsp-eslint 1: {'code': -32601, 'message': 'client/registerCapability'}
```

(Error responses are prefixed with `~~>` and `<~~`)

However eslint seems to be tugging along just fine.

![Screenshot from 2020-03-14 13-51-38](https://user-images.githubusercontent.com/2431823/76682916-47de3700-6600-11ea-827d-5d2004ce420a.png)
