### PR TITLE
Fix workspace/didChangeConfiguration capability type

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -73,7 +73,7 @@ def get_initialize_params(workspace_folders: List[WorkspaceFolder], designated_f
             },
             "workspace": {
                 "applyEdit": True,
-                "didChangeConfiguration": {},
+                "didChangeConfiguration": True,
                 "executeCommand": {},
                 "workspaceFolders": True,
                 "symbol": {


### PR DESCRIPTION
Capability is defined to be a boolean so shouldn't be a dict.
https://microsoft.github.io/language-server-protocol/specification#workspace_didChangeConfiguration