### PR TITLE
Be more lenient about non-existing folders

### DIFF
--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -419,13 +419,9 @@ class WorkspaceFolder:
     def __init__(self, name: str, path: str) -> None:
         self.name = name
         self.path = path
-        assert self.name
-        assert self.path
 
     @classmethod
     def from_path(cls, path: str) -> 'WorkspaceFolder':
-        assert os.path.isdir(path)
-        assert os.path.isabs(path)
         return cls(os.path.basename(path) or path, path)
 
     def __repr__(self) -> str:


### PR DESCRIPTION
You can put folders in your .sublime-project that don't exist.
For now we can pass-thru those folders.

close #893