### PR TITLE
feat: make diagnostics highlights configurable

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -23,13 +23,21 @@
   // under the cursor in status bar if available.
   "show_diagnostics_in_view_status": true,
 
-  // Show the diagnostics with level less than or equal to
+  // Show the diagnostics in the panel with level less than or equal to
   // the given value.
   // error: 1
   // warning: 2
   // info: 3
   // hint: 4
   "show_diagnostics_severity_level": 2,
+
+  // Highlights the diagnostics in the document with level less than or equal to
+  // the given value.
+  // error: 1
+  // warning: 2
+  // info: 3
+  // hint: 4
+  "show_highlights_severity_level": 3,
 
   // Highlighting style of code diagnostics.
   // Valid values are "underline" or "box"
@@ -533,15 +541,15 @@
     },
     "vscode-css":
     {
-      "command": 
+      "command":
       [
         "css-languageserver", "--stdio"
       ],
-      "scopes": 
+      "scopes":
       [
         "source.css"
       ],
-      "syntaxes": 
+      "syntaxes":
       [
         "Packages/CSS/CSS.sublime-syntax"
       ],

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -67,6 +67,7 @@ def update_settings(settings: Settings, settings_obj: sublime.Settings) -> None:
                                                                        "show_diagnostics_count_in_view_status", False)
     settings.show_diagnostics_in_view_status = read_bool_setting(settings_obj, "show_diagnostics_in_view_status", True)
     settings.show_diagnostics_severity_level = read_int_setting(settings_obj, "show_diagnostics_severity_level", 2)
+    settings.show_highlights_severity_level = read_int_setting(settings_obj, "show_highlights_severity_level", 3)
     settings.diagnostics_highlight_style = read_str_setting(settings_obj, "diagnostics_highlight_style", "underline")
     settings.document_highlight_style = read_str_setting(settings_obj, "document_highlight_style", "stippled")
     settings.document_highlight_scopes = read_dict_setting(settings_obj, "document_highlight_scopes",

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -10,6 +10,7 @@ class Settings(object):
         self.show_diagnostics_count_in_view_status = False
         self.show_diagnostics_in_view_status = True
         self.show_diagnostics_severity_level = 2
+        self.show_highlights_severity_level = 3
         self.only_show_lsp_completions = False
         self.diagnostics_highlight_style = "underline"
         self.document_highlight_style = "stippled"

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -247,7 +247,7 @@ class DiagnosticViewRegions(DiagnosticsUpdateWalk):
         self._relevant_file = False
 
     def end(self) -> None:
-        for severity in range(DiagnosticSeverity.Error, DiagnosticSeverity.Hint):
+        for severity in range(DiagnosticSeverity.Error, settings.show_highlights_severity_level + 1):
             region_name = "lsp_" + format_severity(severity)
             if severity in self._regions:
                 regions = self._regions[severity]


### PR DESCRIPTION
... which allows to display hint diagnostics, which
were previoulsy never displayed.

The default setting is 3 to reflect the current status quo.

Fixes https://github.com/sublimelsp/LSP/issues/891

Are there tests for the highlighting? A quick search hasn't shown anything. I can try to add them, but from scratch is a bit difficult as I've never written tests with python.