### PR TITLE
[erlang-ls/erlang_ls#401] Add Erlang to Sublme LSP Client documentation

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -314,6 +314,13 @@
         "Packages/Elixir/Syntaxes/Elixir.tmLanguage",
       ]
     },
+    "erlang-ls": {
+      "command"   : [ "/path/to/my/erlang_ls", "--transport", "stdio" ],
+      "enabled"   : true,
+      "languageId": "erlang",
+      "scopes"    : [ "source.erlang" ],
+      "syntaxes"  : ["Packages/Erlang/Erlang.sublime-syntax"]
+    },
     "flow":
     {
       "command": ["flow", "lsp"],
@@ -533,15 +540,15 @@
     },
     "vscode-css":
     {
-      "command": 
+      "command":
       [
         "css-languageserver", "--stdio"
       ],
-      "scopes": 
+      "scopes":
       [
         "source.css"
       ],
-      "syntaxes": 
+      "syntaxes":
       [
         "Packages/CSS/CSS.sublime-syntax"
       ],

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -315,8 +315,7 @@
       ]
     },
     "erlang-ls": {
-      "command"   : [ "/path/to/my/erlang_ls", "--transport", "stdio" ],
-      "enabled"   : true,
+      "command"   : [ "erlang_ls", "--transport", "stdio" ],
       "languageId": "erlang",
       "scopes"    : [ "source.erlang" ],
       "syntaxes"  : ["Packages/Erlang/Erlang.sublime-syntax"]

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Documentation is available at [LSP.readthedocs.io](https://LSP.readthedocs.io).
 * [Dart](https://lsp.readthedocs.io/en/latest/#dart)
 * [Elixir](https://lsp.readthedocs.io/en/latest/#elixir)
 * [Elm](https://lsp.readthedocs.io/en/latest/#elm)
+* [Erlang](https://lsp.readthedocs.io/en/latest/#erlang)
 * [Flow (JavaScript)](https://lsp.readthedocs.io/en/latest/#flow)
 * [Fortran](https://lsp.readthedocs.io/en/latest/#fortran)
 * [Go](https://lsp.readthedocs.io/en/latest/#go)

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ Language servers can be provided as standalone executables or might require a ru
 The [list below](index.md#language-servers) shows installation instructions and example configurations for several servers that have been tested and are known to work with the LSP package.
 Visit [Langserver.org](https://langserver.org/) or the [list of language server implementations](https://microsoft.github.io/language-server-protocol/implementors/servers/) maintained by Microsoft for a complete overview of available servers for various programming languages.
 
-For a few languages you can also find dedicated packages on Package Control, which can optionally be installed to simplify the configuration and installation process of a language server and might provide additional features such as automatic updates for the server: 
+For a few languages you can also find dedicated packages on Package Control, which can optionally be installed to simplify the configuration and installation process of a language server and might provide additional features such as automatic updates for the server:
 
 * [LSP-css](https://packagecontrol.io/packages/LSP-css)
 * [LSP-html](https://packagecontrol.io/packages/LSP-html)
@@ -276,6 +276,21 @@ dub run dls:bootstrap
 }
 ```
 
+### Erlang<a name="erlang"></a>
+
+1. See instructions for installing the [Erlang Language Server](https://github.com/erlang-ls/erlang_ls).
+2. Add to LSP settings' clients:
+
+```json
+"erlang-ls": {
+  "command"   : [ "/path/to/my/erlang_ls", "--transport", "stdio" ],
+  "enabled"   : true,
+  "languageId": "erlang",
+  "scopes"    : [ "source.erlang" ],
+  "syntaxes"  : ["Packages/Erlang/Erlang.sublime-syntax"]
+}
+```
+
 ### Flow (JavaScript)<a name="flow"></a>
 
 Official part of [flow-bin](https://github.com/facebook/flow):
@@ -292,7 +307,7 @@ npm install -g flow-language-server
 
 ### Fortran<a name="fortran"></a>
 
-1\. Install the [Fortran](https://packagecontrol.io/packages/Fortran) package from Package Control for syntax highlighting.  
+1\. Install the [Fortran](https://packagecontrol.io/packages/Fortran) package from Package Control for syntax highlighting.
 2\. Install the [Fortran Language Server](https://github.com/hansec/fortran-language-server) (requires Python):
 
 ```sh
@@ -439,7 +454,7 @@ npm install -g javascript-typescript-langserver
 
 ### Julia<a name="julia"></a>
 
-1\. Install the [Julia](https://packagecontrol.io/packages/Julia) package from Package Control for syntax highlighting.  
+1\. Install the [Julia](https://packagecontrol.io/packages/Julia) package from Package Control for syntax highlighting.
 2\. Install the `LanguageServer` and `SymbolServer` packages from the Julia REPL:
 
 ```julia

--- a/docs/index.md
+++ b/docs/index.md
@@ -291,6 +291,12 @@ dub run dls:bootstrap
 }
 ```
 
+3. Sometimes Erlang LS might take a little time to initialize. The default is 3 seconds so it is a good idea to increase the value for `"initialize_timeout"` in the LSP settings' clients:
+
+```json
+"initialize_timeout": 30
+```
+
 ### Flow (JavaScript)<a name="flow"></a>
 
 Official part of [flow-bin](https://github.com/facebook/flow):


### PR DESCRIPTION
Add Erlang to Sublme LSP Client documentation (... and also removes some trailing whitespaces).

Fixes erlang-ls/erlang_ls#401.