### PR TITLE
add sorbet type checker to lsp

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -537,6 +537,12 @@
       //   "diagnostics": true
       // },
     },
+    "sorbet": {
+      "command": ["srb", "tc", "--typed", "true", "--enable-all-experimental-lsp-features", "--lsp", "--disable-watchman"],
+      "languageId": "ruby",
+      "scopes": ["source.ruby"],
+      "syntaxes": ["Packages/Ruby/Ruby.sublime-syntax"]
+    },
     "vscode-css":
     {
       "command":

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -541,7 +541,11 @@
       "command": ["srb", "tc", "--typed", "true", "--enable-all-experimental-lsp-features", "--lsp", "--disable-watchman"],
       "languageId": "ruby",
       "scopes": ["source.ruby"],
-      "syntaxes": ["Packages/Ruby/Ruby.sublime-syntax"]
+      "syntaxes": [
+        "Packages/Ruby/Ruby.sublime-syntax",
+        "Packages/Rails/Ruby on Rails.sublime-syntax",
+        "Packages/Rails/HTML (Rails).sublime-syntax"
+      ]
     },
     "vscode-css":
     {

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -540,7 +540,11 @@
     "sorbet": {
       "command": ["srb", "tc", "--typed", "true", "--enable-all-experimental-lsp-features", "--lsp", "--disable-watchman"],
       "languageId": "ruby",
-      "scopes": ["source.ruby"],
+      "scopes": 
+      [
+        "source.ruby",
+        "source.ruby.rails"
+      ],
       "syntaxes": [
         "Packages/Ruby/Ruby.sublime-syntax",
         "Packages/Rails/Ruby on Rails.sublime-syntax",

--- a/docs/index.md
+++ b/docs/index.md
@@ -745,6 +745,10 @@ install.packages("languageserver")
 
 ### Ruby/Ruby on Rails<a name="ruby"></a>
 
+Different servers are available for Ruby:
+
+Solargraph:
+
 1\. Install the solargraph gem (see [github:castwide/solargraph](https://github.com/castwide/solargraph) for up-to-date installation instructions):
 
 ```sh
@@ -752,6 +756,20 @@ gem install solargraph
 ```
 
 2\. Run "LSP: Enable Language Server Globally" from the Command Palette and choose `ruby`.
+
+Sorbet:
+
+1\. Install the sorbet and sorbet-runtime gem (see [github:sorbet/sorbet](https://github.com/sorbet/sorbet)):
+```sh
+gem install sorbet
+gem install sorbet-runtime
+```
+If you have a Gemfile, using bundler, add sorbet and sorbet-runtime to your Gemfile and run:
+```
+bundle install
+```
+
+2\. Run "LSP:Enable Language Server Globally" from the Command Palette and choose `sorbet`.
 
 ### Rust<a name="rust"></a>
 


### PR DESCRIPTION
Hi,

The scope of this PR is to add default config for Sorbet, static type checker for Ruby (https://github.com/sorbet/sorbet).

![image](https://user-images.githubusercontent.com/22823477/77233582-cb6fc900-6ba8-11ea-9136-4042a8dbe07f.png)

![image](https://user-images.githubusercontent.com/22823477/77233590-d62a5e00-6ba8-11ea-87c0-f458a30ab6a6.png)

