### PR TITLE
Use line-wrapping algorithm provided by mdpopups

### DIFF
--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -196,7 +196,7 @@ class LspHoverCommand(LspTextCommand):
                 formatted.append(value)
 
         if formatted:
-            frontmatter_config = "---\nallow_code_wrap: true\n---\n"
+            frontmatter_config = mdpopups.format_frontmatter({'allow_code_wrap': True})
             return mdpopups.md2html(self.view, frontmatter_config + "\n".join(formatted))
 
         return ""

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -3,7 +3,6 @@ import sublime
 import sublime_plugin
 import webbrowser
 import os
-import textwrap
 from html import escape
 from .code_actions import actions_manager, run_code_action_or_command
 from .code_actions import CodeActionOrCommand
@@ -191,16 +190,14 @@ class LspHoverCommand(LspTextCommand):
                 value = item.get("value")
                 language = item.get("language")
 
-            if '\n' not in value:
-                value = "\n".join(textwrap.wrap(value, 80))
-
             if language:
                 formatted.append("```{}\n{}\n```\n".format(language, value))
             else:
                 formatted.append(value)
 
         if formatted:
-            return mdpopups.md2html(self.view, "\n".join(formatted))
+            frontmatter_config = "---\nallow_code_wrap: true\n---\n"
+            return mdpopups.md2html(self.view, frontmatter_config + "\n".join(formatted))
 
         return ""
 

--- a/stubs/mdpopups.pyi
+++ b/stubs/mdpopups.pyi
@@ -1,6 +1,6 @@
 import sublime
 try:
-    from typing import Callable, Optional
+    from typing import Callable, Dict, Optional
     assert Callable and Optional
 except ImportError:
     pass
@@ -35,6 +35,9 @@ def update_popup(
     nl2br: bool = True,
     allow_code_wrap: bool = False
 ) -> None: ...
+
+
+def format_frontmatter(values: Dict) -> str: ...
 
 
 def md2html(


### PR DESCRIPTION
It seems to only break lines if it finds opportunity to
do so (whitespace). That means that in some cases lines won't
be wrapped where old code would aggressively wrap.

Resolves #859