### PR TITLE
Startup folder selection

### DIFF
--- a/plugin/core/handlers.py
+++ b/plugin/core/handlers.py
@@ -5,6 +5,7 @@ import abc
 
 class LanguageHandler(metaclass=abc.ABCMeta):
     on_start = None  # type: Optional[Callable]
+    can_start = None  # type: Optional[Callable]
     on_initialized = None  # type: Optional[Callable]
 
     @abc.abstractproperty

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -430,19 +430,18 @@ class WindowManager(object):
             debug('Already starting on this window:', config.name)
             return
 
-        workspace_folders = sorted_workspace_paths(self._workspace.folders, file_path)
-        startable_folders = self._handlers.on_start(config.name, self._window, workspace_folders, file_path)
+        workspace_paths = sorted_workspace_paths(self._workspace.folders, file_path)
+        startable_folders = self._handlers.on_start(config.name, self._window, workspace_paths, file_path)
 
         if not startable_folders:
             return
 
         self._window.status_message("Starting " + config.name + "...")
         session = None  # type: Optional[Session]
-        workspace_folders = sorted_workspace_folders(self._workspace.folders, file_path)
         try:
             session = self._start_session(
                 self._window,                  # window
-                [WorkspaceFolder.from_path(path) for path in workspace_folders],             # workspace_folders
+                [WorkspaceFolder.from_path(path) for path in workspace_paths],             # workspace_folders
                 config,                        # config
                 self._handle_pre_initialize,   # on_pre_initialize
                 self._handle_post_initialize,  # on_post_initialize

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -59,7 +59,7 @@ def get_workspace_folders(folders: List[str]) -> List[WorkspaceFolder]:
     return [WorkspaceFolder.from_path(f) for f in folders]
 
 
-def sorted_workspace_folders(folders: List[str], file_path: str) -> List[WorkspaceFolder]:
+def sorted_workspace_paths(folders: List[str], file_path: str) -> List[str]:
     matching_paths = []  # type: List[str]
     other_paths = []  # type: List[str]
 
@@ -73,7 +73,7 @@ def sorted_workspace_folders(folders: List[str], file_path: str) -> List[Workspa
         else:
             other_paths.append(folder)
 
-    return [WorkspaceFolder.from_path(path) for path in matching_paths + other_paths]
+    return matching_paths + other_paths
 
 
 def enable_in_project(window: Any, config_name: str) -> None:

--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -5,7 +5,7 @@ from LSP.plugin.core.sessions import Session
 from LSP.plugin.core.types import ClientConfig
 from LSP.plugin.core.types import LanguageConfig
 from LSP.plugin.core.types import Settings
-from LSP.plugin.core.types import ViewLike
+from LSP.plugin.core.types import ViewLike, WindowLike
 from LSP.plugin.core.typing import Dict, Set, List, Optional, Any, Tuple, Callable
 from LSP.plugin.core.windows import DocumentHandler
 import os
@@ -113,7 +113,7 @@ class MockHandlerDispatcher(object):
         self._can_start = can_start
         self._initialized = set()  # type: Set[str]
 
-    def on_start(self, config_name: str, window) -> bool:
+    def on_start(self, config_name: str, window: WindowLike, workspace_folders: List[str], path: str) -> bool:
         return self._can_start
 
     def on_initialized(self, config_name: str, window, client):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,5 +1,5 @@
 from test_mocks import MockWindow
-from LSP.plugin.core.workspace import ProjectFolders, sorted_workspace_folders, is_subpath_of
+from LSP.plugin.core.workspace import ProjectFolders, sorted_workspace_paths, is_subpath_of
 from LSP.plugin.core.protocol import WorkspaceFolder
 import os
 from unittest import mock
@@ -13,18 +13,15 @@ class SortedWorkspaceFoldersTest(unittest.TestCase):
         nearest_project_path = os.path.dirname(__file__)
         unrelated_project_path = tempfile.gettempdir()
         parent_project_path = os.path.abspath(os.path.join(nearest_project_path, '..'))
-        folders = sorted_workspace_folders([unrelated_project_path, parent_project_path, nearest_project_path],
+        paths = sorted_workspace_paths([unrelated_project_path, parent_project_path, nearest_project_path],
                                            __file__)
-        nearest_folder = WorkspaceFolder.from_path(nearest_project_path)
-        parent_folder = WorkspaceFolder.from_path(parent_project_path)
-        unrelated_folder = WorkspaceFolder.from_path(unrelated_project_path)
-        self.assertEqual(folders[0], nearest_folder)
-        self.assertEqual(folders[1], parent_folder)
-        self.assertEqual(folders[2], unrelated_folder)
+        self.assertEqual(paths[0], nearest_project_path)
+        self.assertEqual(paths[1], parent_project_path)
+        self.assertEqual(paths[2], unrelated_project_path)
 
     def test_longest_prefix(self) -> None:
-        folders = sorted_workspace_folders(["/longer-path", "/short-path"], "/short-path/file.js")
-        self.assertEqual(folders[0].path, "/short-path")
+        paths = sorted_workspace_paths(["/longer-path", "/short-path"], "/short-path/file.js")
+        self.assertEqual(paths[0], "/short-path")
 
 
 class WorkspaceFolderTest(unittest.TestCase):


### PR DESCRIPTION
Adds language handler api for verifying a given folder can be started.
Example usage:

```python
from LSP.plugin.core.handlers import LanguageHandler
from LSP.plugin.core.settings import ClientConfig, LanguageConfig
import shutil
import os

config_name = 'flow'
server_name = 'flow'
flow_config = ClientConfig(
    name=config_name,
    binary_args=[
        "flow", "lsp"
    ],
    tcp_port=None,
    languages=[
        LanguageConfig("javascript", ["source.js"], ["Packages/Babel/JavaScript (Babel).sublime-syntax", "Packages/JavaScript/JavaScript.sublime-syntax"])
    ],
    enabled=True,
    init_options=dict(),
    settings=dict(),
    env=dict())


def flow_is_installed() -> bool:
    return shutil.which("flow") is not None


def has_flow_config(path) -> bool:
    has_config = os.path.exists(os.path.join(path, ".flowconfig"))
    if not has_config:
        print("No .flowconfig found, skipping folder: ", path)
    return has_config

class LspFlowPlugin(LanguageHandler):
    def __init__(self):
        self._name = config_name
        self._config = flow_config

    @property
    def name(self) -> str:
        return self._name

    @property
    def config(self) -> ClientConfig:
        return self._config

    def can_start(self, window, folders, file_path): -> 'List[str]':
        if not flow_is_installed():
            window.status_message(
                "Flow must be installed to run {}".format(server_name))
            return []
        configured_folders = [folder for folder in folders if has_flow_config(folder)]
        if configured_folders:
            if not file_path.startswith(configured_folders[0]):
                print("Folder for file not configured:" + file_path)
                return []
        return configured_folders
```