### PR TITLE
Add support for Swift's sourcekit-lsp

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -570,7 +570,12 @@
         "Packages/R/R.sublime-syntax"
       ],
       "languageId": "r"
-    }
-
+    },
+    "sourcekit-lsp": {
+      "command": ["xcrun", "sourcekit-lsp"],
+      "scopes": ["source.swift"],
+      "syntaxes": ["Packages/Swift/Syntaxes/Swift.tmLanguage"],
+      "languageId": "swift"
+    },
   }
 }

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Documentation is available at [LSP.readthedocs.io](https://LSP.readthedocs.io).
 * [Ruby](https://lsp.readthedocs.io/en/latest/#ruby)
 * [Rust](https://lsp.readthedocs.io/en/latest/#rust)
 * [Scala](https://lsp.readthedocs.io/en/latest/#scala)
+* [Swift](https://lsp.readthedocs.io/en/latest/#swift)
 * [Terraform](https://lsp.readthedocs.io/en/latest/#terraform)
 * [Vue (JavaScript)](https://lsp.readthedocs.io/en/latest/#vue)
 * [XML](https://lsp.readthedocs.io/en/latest/#xml)

--- a/docs/index.md
+++ b/docs/index.md
@@ -790,6 +790,11 @@ At this point LSP should complain in the logs
 Then run `sbt configureIDE` to create the `.dotty-ide.json` file
 Then the LSP plugin should launch as configured in `LSP.sublime-settings` using coursier.
 
+### Swift<a name="swift"></a>
+
+1. Install the [Swift](https://packagecontrol.io/packages/Swift) package from Package Control for syntax highlighting.
+2. Install Xcode 11.4 or later and ensure that `xcrun -find sourcekit-lsp` returns the path to sourcekit-lsp.
+
 ### Terraform<a name="terraform"></a>
 
 1. Download [terraform-lsp](https://github.com/juliosueiras/terraform-lsp/releases) binary and make it available in your PATH.


### PR DESCRIPTION
Just a little thing I whipped up using the SourceKit LSP server that ships with Xcode 11.4. This seems to work, but is this the right way to add support for a new server?