### PR TITLE
Add 'actions' class to hover popup action links.

### DIFF
--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -127,7 +127,7 @@ class LspHoverCommand(LspTextCommand):
             actions.append("<a href='{}'>{}</a>".format('references', 'References'))
         if self.has_client_with_capability('renameProvider'):
             actions.append("<a href='{}'>{}</a>".format('rename', 'Rename'))
-        return "<p>" + " | ".join(actions) + "</p>"
+        return "<p class='actions'>" + " | ".join(actions) + "</p>"
 
     def format_diagnostic_related_info(self, info: DiagnosticRelatedInformation) -> str:
         file_path = info.location.file_path


### PR DESCRIPTION
The popups.css selector uses ".lsp_popups .actions a" which does not
match the generated html. Without this, the links are solid blue without
framing.