### PR TITLE
Restart the server when it fails on exit

### DIFF
--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -244,6 +244,8 @@ class StdioTransport(Transport):
             # We use the stdout thread to block and wait on the exiting process, or zombie processes may be the result.
             returncode = self.process.wait()
             debug("process {} exited with code {}".format(pid, returncode))
+            if returncode != 0:
+                self.close()
         self.send_queue.put(None)
 
     def send(self, content: str) -> None:


### PR DESCRIPTION
Sometimes the server can crash and exit with a non-zero exit code. This allows the server to be restarted if necessary.