### PR TITLE
Add more specific selector for some trigger characters.

### DIFF
--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -171,29 +171,15 @@ class CompletionHandler(LSPViewEventListener):
             # This is to make ST match with labels that have a weird prefix like a space character.
             self.view.settings().set("auto_complete_preserve_order", "none")
 
-    def _view_language(self, config_name: str) -> Optional[str]:
-        languages = self.view.settings().get('lsp_language')
-        return languages.get(config_name) if languages else None
-
     def register_trigger_chars(self, session: Session, trigger_chars: List[str]) -> None:
-        completion_triggers = self.view.settings().get('auto_complete_triggers', []) or []  # type: List[Dict[str, str]]
-        view_language = self._view_language(session.config.name)
-        if view_language:
-            for language in session.config.languages:
-                if language.id == view_language:
-                    for scope in language.scopes:
-                        # debug("registering", trigger_chars, "for", scope)
-                        scope_trigger = next(
-                            (trigger for trigger in completion_triggers if trigger.get('selector', None) == scope),
-                            None
-                        )
-                        if not scope_trigger:  # do not override user's trigger settings.
-                            completion_triggers.append({
-                                'characters': "".join(trigger_chars),
-                                'selector': scope
-                            })
+        completion_triggers = self.view.settings().get('auto_complete_triggers') or []  # type: List[Dict[str, str]]
 
-            self.view.settings().set('auto_complete_triggers', completion_triggers)
+        completion_triggers.append({
+            'characters': "".join(trigger_chars),
+            'selector': "- comment - punctuation.definition.string.end"
+        })
+
+        self.view.settings().set('auto_complete_triggers', completion_triggers)
 
     def on_query_completions(self, prefix: str, locations: List[int]) -> Optional[sublime.CompletionList]:
         if not self.initialized:


### PR DESCRIPTION
closes #933 
For now this will only be added for the `"` char, with the selector punctuation.definition.string.begin.

If we notice more of this cases where the AC is triggering forever,
we could either assign a special selector like we did here,
or fill an issue to the language server that it shouldn't return completions in that case.

That is also an option worth considering.

The server could specify not to return completions when inside comments. (just giving elm language server as an example :) ) https://github.com/elm-tooling/elm-language-server/issues/238