### PR TITLE
Fix off-by-one error

### DIFF
--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -247,7 +247,7 @@ class DiagnosticViewRegions(DiagnosticsUpdateWalk):
         self._relevant_file = False
 
     def end(self) -> None:
-        for severity in range(DiagnosticSeverity.Error, DiagnosticSeverity.Hint):
+        for severity in range(DiagnosticSeverity.Error, DiagnosticSeverity.Hint + 1):
             region_name = "lsp_" + format_severity(severity)
             if severity in self._regions:
                 regions = self._regions[severity]


### PR DESCRIPTION
In commit https://github.com/sublimelsp/LSP/commit/3c267eab898cf43778a1d05e6b582045b8812b4b a change was made to underline all regions for all severities of diagnostics. However `range` isn't inclusive at the upper limit and thus, hints are currently excluded.