### PR TITLE
Set auto_complete_preserve_order to none

### DIFF
--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -225,8 +225,6 @@ class CompletionHandler(LSPViewEventListener):
             if trigger_chars:
                 self.register_trigger_chars(session, trigger_chars)
             # This is to make ST match with labels that have a weird prefix like a space character.
-            # It is unfortunately untestable as this problem will only show up when typing characters, not when
-            # running view.run_command('auto_complete') in a test. See: https://github.com/sublimelsp/LSP/issues/935
             self.view.settings().set("auto_complete_preserve_order", "none")
 
     def _view_language(self, config_name: str) -> Optional[str]:

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -224,6 +224,10 @@ class CompletionHandler(LSPViewEventListener):
                 'triggerCharacters') or []
             if trigger_chars:
                 self.register_trigger_chars(session, trigger_chars)
+            # This is to make ST match with labels that have a weird prefix like a space character.
+            # It is unfortunately untestable as this problem will only show up when typing characters, not when
+            # running view.run_command('auto_complete') in a test. See: https://github.com/sublimelsp/LSP/issues/935
+            self.view.settings().set("auto_complete_preserve_order", "none")
 
     def _view_language(self, config_name: str) -> Optional[str]:
         languages = self.view.settings().get('lsp_language')

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -170,9 +170,6 @@ class TextDocumentTestCase(DeferrableTestCase):
         s("tab_size", 4)
         s("translate_tabs_to_spaces", False)
         s("word_wrap", False)
-        # ST4 removes completion items when "auto_complete_preserve_order" is not "none",
-        # see https://github.com/sublimelsp/LSP/pull/866#discussion_r380249385
-        s("auto_complete_preserve_order", "none")
 
     def get_view_event_listener(self, unique_attribute: str) -> 'Optional[ViewEventListener]':
         for listener in view_event_listeners[self.view.id()]:


### PR DESCRIPTION
This makes the AC show up for labels that have an odd prefix like a space character (e.g. clangd).

close #935 