### PR TITLE
Travel up the dir tree to find .flowconfig

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -9,8 +9,8 @@ from .typing import Callable, Dict, Any, Optional, List, Tuple
 from .workspace import is_subpath_of
 import os
 
-def find_root_folder(workspace_folder: Optional[WorkspaceFolder], config: ClientConfig) -> Optional[WorkspaceFolder]:
-    def find_flow_config(dirname):
+def find_root_folder(workspace_folder: WorkspaceFolder, config: ClientConfig) -> WorkspaceFolder:
+    def find_flow_config(dirname: str) -> str:
         if not dirname or dirname is '/':
             return '/'
 
@@ -28,7 +28,7 @@ def find_root_folder(workspace_folder: Optional[WorkspaceFolder], config: Client
 
 def get_initialize_params(workspace_folders: List[WorkspaceFolder], config: ClientConfig) -> dict:
     first_folder = workspace_folders[0] if workspace_folders else None
-    first_folder = find_root_folder(first_folder, config)
+    first_folder = find_root_folder(first_folder, config) if first_folder else None
 
     initializeParams = {
         "processId": os.getpid(),

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -9,9 +9,27 @@ from .typing import Callable, Dict, Any, Optional, List, Tuple
 from .workspace import is_subpath_of
 import os
 
+def find_root_folder(workspace_folder: Optional[WorkspaceFolder], config: ClientConfig) -> Optional[WorkspaceFolder]:
+    def find_flow_config(dirname):
+        if not dirname or dirname is '/':
+            return '/'
+
+        if os.path.isfile(os.path.join(dirname, '.flowconfig')):
+            return dirname
+
+        return find_flow_config(os.path.dirname(dirname))
+
+    if config.name == "flow":
+        rootpath = find_flow_config(workspace_folder.path)
+        return WorkspaceFolder.from_path(rootpath)
+
+    return workspace_folder
+
 
 def get_initialize_params(workspace_folders: List[WorkspaceFolder], config: ClientConfig) -> dict:
     first_folder = workspace_folders[0] if workspace_folders else None
+    first_folder = find_root_folder(first_folder, config)
+
     initializeParams = {
         "processId": os.getpid(),
         "clientInfo": {

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -9,9 +9,10 @@ from .typing import Callable, Dict, Any, Optional, List, Tuple
 from .workspace import is_subpath_of
 import os
 
+
 def find_root_folder(workspace_folder: WorkspaceFolder, config: ClientConfig) -> WorkspaceFolder:
     def find_flow_config(dirname: str) -> str:
-        if not dirname or dirname is '/':
+        if not dirname or dirname == '/':
             return '/'
 
         if os.path.isfile(os.path.join(dirname, '.flowconfig')):


### PR DESCRIPTION
This is special treat for flow, I am not sure about other language.

Usecase: My sublime workspace contains only a sub-folder of a big project, there is no `.flowconfig` in that directory, but there is one in root big project.

LSP originally doesn't work for that case. This PR is to find and use the `.flowconfig` on the ancestor folders.