### PR TITLE
Compensate for View#set_status eating newlines of diagnostic messages

### DIFF
--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -1,5 +1,6 @@
 import html
 import os
+import re
 import sublime
 import sublime_plugin
 
@@ -96,7 +97,8 @@ class DiagnosticsCursorListener(LSPViewEventListener):
 
     def show_diagnostics_status(self, diagnostic: Diagnostic) -> None:
         self.has_status = True
-        self.view.set_status('lsp_diagnostics', diagnostic.message)
+        spaced_message = re.sub(r'(\S\n)(\S)', r'\1 \2', diagnostic.message)
+        self.view.set_status('lsp_diagnostics', spaced_message)
 
     def clear_diagnostics_status(self) -> None:
         self.view.erase_status('lsp_diagnostics')

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -97,7 +97,7 @@ class DiagnosticsCursorListener(LSPViewEventListener):
 
     def show_diagnostics_status(self, diagnostic: Diagnostic) -> None:
         self.has_status = True
-        spaced_message = re.sub(r'(\S\n)(\S)', r'\1 \2', diagnostic.message)
+        spaced_message = re.sub(r'(\S)\n(\S)', r'\1 \2', diagnostic.message)
         self.view.set_status('lsp_diagnostics', spaced_message)
 
     def clear_diagnostics_status(self) -> None:

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -97,6 +97,8 @@ class DiagnosticsCursorListener(LSPViewEventListener):
 
     def show_diagnostics_status(self, diagnostic: Diagnostic) -> None:
         self.has_status = True
+        # Because set_status eats newlines, newlines that aren't surrounded by any space
+        # need to have some added, to stop words from becoming joined.
         spaced_message = re.sub(r'(\S)\n(\S)', r'\1 \2', diagnostic.message)
         self.view.set_status('lsp_diagnostics', spaced_message)
 


### PR DESCRIPTION
Say a diagnostic with the following message has been published for a source line

```python
'This expression has type bool\nThis is not a function; it cannot be applied.'
```

When the caret is on the line, the diagnostic message is shown in the Status Bar:

<img width="634" alt="78336669-ac4d4000-7587-11ea-90d9-fbe192f16c8d" src="https://user-images.githubusercontent.com/172663/78818104-09a02180-79cc-11ea-94a3-c60769cd0be8.png">

...but the Sublime API function `View#set_status` simply eats the newline that's part of the string, meaning those two words become conjoined.

This PR inserts a space into the string passed to `set_status` where a line in a diagnostic message ends without trailing whitespace and the next line starts without leading whitespace.


