### PR TITLE
Remove unused argument to CodeActionsManager.request

### DIFF
--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -46,16 +46,14 @@ class CodeActionsManager(object):
     def __init__(self) -> None:
         self._requests = {}  # type: Dict[str, CodeActionsAtLocation]
 
-    def request(self, view: sublime.View, point: int, actions_handler: Callable[[CodeActionsByConfigName], None],
-                diagnostics_by_config: Optional[Dict[str, List[Diagnostic]]] = None) -> None:
+    def request(self, view: sublime.View, point: int,
+                actions_handler: Callable[[CodeActionsByConfigName], None]) -> None:
         current_location = self.get_location_key(view, point)
         # debug("requesting actions for {}".format(current_location))
         if current_location in self._requests:
             self._requests[current_location].deliver(actions_handler)
         else:
             self._requests.clear()
-            if diagnostics_by_config is None:
-                diagnostics_by_config = filter_by_point(view_diagnostics(view), Point(*view.rowcol(point)))
             self._requests[current_location] = request_code_actions(view, point, actions_handler)
 
     def get_location_key(self, view: sublime.View, point: int) -> str:

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -106,8 +106,7 @@ class LspHoverCommand(LspTextCommand):
                     lambda response: self.handle_response(response, point))
 
     def request_code_actions(self, point: int) -> None:
-        actions_manager.request(self.view, point, lambda response: self.handle_code_actions(response, point),
-                                self._diagnostics_by_config)
+        actions_manager.request(self.view, point, lambda response: self.handle_code_actions(response, point))
 
     def handle_code_actions(self, responses: Dict[str, List[CodeActionOrCommand]], point: int) -> None:
         self._actions_by_config = responses


### PR DESCRIPTION
It looks the intention of `request` function was to set the value
of passed-in `diagnostics_by_config` but that of course doesn't work as
arguments are not passed by reference in python.

The one place that actually needs diagnostics (modified in this PR)
gets them itself before calling `request` anyway.