### PR TITLE
Use JSON format for server logs

### DIFF
--- a/Syntaxes/ServerLog.sublime-syntax
+++ b/Syntaxes/ServerLog.sublime-syntax
@@ -82,9 +82,7 @@ contexts:
       set:
         - match: $
           pop: true
-        - include: scope:source.python#constants  # e.g. shutdown request
-        - include: scope:source.python#lists
-        - include: scope:source.python#dictionaries-and-sets
+        - include: scope:source.json#main
     - match: ''
       pop: true
 ...

--- a/plugin/core/rpc.py
+++ b/plugin/core/rpc.py
@@ -12,9 +12,9 @@ TCP_CONNECT_TIMEOUT = 5
 DEFAULT_SYNC_REQUEST_TIMEOUT = 1.0
 
 
-def format_request(payload: Dict[str, Any]) -> str:
+def json_format_request(payload: Dict[str, Any], compact: bool = True) -> str:
     """Converts the request into json"""
-    return json.dumps(payload, sort_keys=False, check_circular=False, separators=(',', ':'))
+    return json.dumps(payload, sort_keys=False, check_circular=False, separators=(',', ':') if compact else None)
 
 
 def try_terminate_process(process: subprocess.Popen) -> None:
@@ -33,7 +33,7 @@ class PreformattedPayloadLogger:
 
     def log(self, message: str, params: Any, log_payload: bool) -> None:
         if log_payload:
-            message = "{}: {}".format(message, params)
+            message = "{}: {}".format(message, json_format_request(params, compact=False))
         self.sink(message)
 
     def format_response(self, direction: str, request_id: Any) -> str:
@@ -190,7 +190,7 @@ class Client(object):
 
     def send_payload(self, payload: Dict[str, Any]) -> None:
         if self.transport:
-            message = format_request(payload)
+            message = json_format_request(payload)
             self.transport.send(message)
 
     def receive_payload(self, message: str) -> None:

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -4,7 +4,7 @@ from LSP.plugin.core.protocol import ErrorCode
 from LSP.plugin.core.protocol import Notification
 from LSP.plugin.core.protocol import Request
 from LSP.plugin.core.rpc import Client
-from LSP.plugin.core.rpc import format_request
+from LSP.plugin.core.rpc import json_format_request
 from LSP.plugin.core.transports import Transport
 from LSP.plugin.core.types import Settings
 from LSP.plugin.core.typing import List, Tuple, Dict, Any
@@ -61,7 +61,7 @@ class MockTransport(Transport):
 class FormatTests(unittest.TestCase):
 
     def test_converts_payload_to_string(self):
-        self.assertEqual("{}", format_request(dict()))
+        self.assertEqual("{}", json_format_request(dict()))
 
 
 class ClientTest(unittest.TestCase):


### PR DESCRIPTION
Communication is done in JSON so it doesn't make sense to have
python representation of it in logs.