### PR TITLE
migrate window/showMessageRequest handling to mdpopups.show_popup

### DIFF
--- a/notification.css
+++ b/notification.css
@@ -3,6 +3,7 @@
     padding: 1rem;
 }
 .notification .message {
+    margin-top: 1rem;
     margin-bottom: 3rem;
 }
 

--- a/notification.css
+++ b/notification.css
@@ -1,0 +1,14 @@
+.notification {
+    margin: 0.5rem;
+    padding: 1rem;
+}
+.notification .message {
+    margin-bottom: 3rem;
+}
+
+.notification .actions a {
+    text-decoration: none;
+    padding: 0.5rem;
+    border: 2px solid color(var(--foreground) alpha(0.25));
+    color: var(--foreground);
+}

--- a/plugin/core/message_request_handler.py
+++ b/plugin/core/message_request_handler.py
@@ -6,7 +6,7 @@ import sublime
 
 
 class MessageRequestHandler():
-    def __init__(self, view: sublime.View, client: Client, request_id: Any, params: dict) -> None:
+    def __init__(self, view: sublime.View, client: Client, request_id: Any, params: dict, source: str) -> None:
         self.client = client
         self.request_id = request_id
         self.request_sent = False
@@ -15,6 +15,7 @@ class MessageRequestHandler():
         self.titles = list(action.get("title") for action in actions)
         self.message = params.get('message', '')
         self.message_type = params.get('type', 4)
+        self.source = source
 
     def _send_user_choice(self, href: int = -1) -> None:
         if not self.request_sent:
@@ -31,6 +32,7 @@ class MessageRequestHandler():
     def show(self) -> None:
         show_notification(
             self.view,
+            self.source,
             self.message_type,
             self.message,
             self.titles,
@@ -39,7 +41,7 @@ class MessageRequestHandler():
         )
 
 
-def message_content(message_type: int, message: str, titles: List[str]) -> str:
+def message_content(source: str, message_type: int, message: str, titles: List[str]) -> str:
     formatted = []
     icons = {
         1: '❗',
@@ -48,6 +50,7 @@ def message_content(message_type: int, message: str, titles: List[str]) -> str:
         4: '📝'
     }
     icon = icons.get(message_type, '')
+    formatted.append("<h2>{}</h2>".format(source))
     formatted.append("<p class='message'>{} {}</p>".format(icon, message))
 
     buttons = []
@@ -59,10 +62,10 @@ def message_content(message_type: int, message: str, titles: List[str]) -> str:
     return "".join(formatted)
 
 
-def show_notification(view: sublime.View, message_type: int, message: str, titles: List[str],
+def show_notification(view: sublime.View, source: str, message_type: int, message: str, titles: List[str],
                       on_navigate: Callable, on_hide: Callable) -> None:
     stylesheet = sublime.load_resource("Packages/LSP/notification.css")
-    contents = message_content(message_type, message, titles)
+    contents = message_content(source, message_type, message, titles)
     mdpopups.show_popup(
         view,
         contents,

--- a/plugin/core/message_request_handler.py
+++ b/plugin/core/message_request_handler.py
@@ -1,0 +1,93 @@
+import mdpopups
+from .rpc import Client
+from .typing import Any, List, Callable
+from .protocol import Response
+from sublime import View
+
+
+class MessageRequestHandler(object):
+    def __init__(self, view: View, client: Client, request_id: Any, params: dict) -> None:
+        self.client = client
+        self.request_id = request_id
+        self.request_sent = False
+        self.view = view
+        actions = params.get("actions", [])
+        self.titles = list(action.get("title") for action in actions)
+        self.message = params.get('message', '')
+        self.message_type = params.get('type', 4)
+
+    def _send_user_choice(self, href: int = -1) -> None:
+        if not self.request_sent:
+            self.request_sent = True
+            self.view.hide_popup()
+            # when noop; nothing was selected e.g. the user pressed escape
+            param = None
+            index = int(href)
+            if index != -1:
+                param = {"title": self.titles[index]}
+            response = Response(self.request_id, param)
+            self.client.send_response(response)
+
+    def show(self) -> None:
+        show_notification(
+            self.view,
+            self.message_type,
+            self.message,
+            self.titles,
+            self._send_user_choice,
+            self._send_user_choice
+        )
+
+
+def message_content(message_type: int, message: str, titles: List[str]) -> str:
+    formatted = []
+    icons = {
+      1: '❗',
+      2: '⚠️',
+      3: 'ℹ️',
+      4: '📝'
+    }
+    icon = icons.get(message_type, '')
+    formatted.append("<p class='message'>{} {}</p>".format(icon, message))
+
+    buttons = []
+    for idx, title in enumerate(titles):
+        buttons.append("<a href='{}'>{}</a>".format(idx, title))
+
+    formatted.append("<p class='actions'>" + " ".join(buttons) + "</p>")
+
+    return "".join(formatted)
+
+
+def show_notification(view: View, message_type: int, message: str, titles: List[str],
+                      on_navigate: Callable, on_hide: Callable) -> None:
+    myStyle = """
+    .notification {
+        margin: 0.5rem;
+        padding: 1rem;
+    }
+    .notification .message {
+        margin-bottom: 3rem;
+    }
+
+    .notification .actions a {
+        text-decoration: none;
+        padding: 0.5rem;
+        border: 2px solid color(var(--foreground) alpha(0.25));
+        color: var(--foreground);
+    }
+    """
+
+    contents = message_content(message_type, message, titles)
+    mdpopups.show_popup(
+        view,
+        contents,
+        css=myStyle,
+        md=False,
+        location=-1,
+        wrapper_class='notification',
+        max_width=800,
+        max_height=800,
+        on_navigate=on_navigate,
+        on_hide=on_hide
+    )

--- a/plugin/core/message_request_handler.py
+++ b/plugin/core/message_request_handler.py
@@ -1,12 +1,12 @@
-import mdpopups
+from .protocol import Response
 from .rpc import Client
 from .typing import Any, List, Callable
-from .protocol import Response
-from sublime import View
+import mdpopups
+import sublime
 
 
-class MessageRequestHandler(object):
-    def __init__(self, view: View, client: Client, request_id: Any, params: dict) -> None:
+class MessageRequestHandler():
+    def __init__(self, view: sublime.View, client: Client, request_id: Any, params: dict) -> None:
         self.client = client
         self.request_id = request_id
         self.request_sent = False
@@ -42,10 +42,10 @@ class MessageRequestHandler(object):
 def message_content(message_type: int, message: str, titles: List[str]) -> str:
     formatted = []
     icons = {
-      1: '❗',
-      2: '⚠️',
-      3: 'ℹ️',
-      4: '📝'
+        1: '❗',
+        2: '⚠️',
+        3: 'ℹ️',
+        4: '📝'
     }
     icon = icons.get(message_type, '')
     formatted.append("<p class='message'>{} {}</p>".format(icon, message))
@@ -59,30 +59,14 @@ def message_content(message_type: int, message: str, titles: List[str]) -> str:
     return "".join(formatted)
 
 
-def show_notification(view: View, message_type: int, message: str, titles: List[str],
+def show_notification(view: sublime.View, message_type: int, message: str, titles: List[str],
                       on_navigate: Callable, on_hide: Callable) -> None:
-    myStyle = """
-    .notification {
-        margin: 0.5rem;
-        padding: 1rem;
-    }
-    .notification .message {
-        margin-bottom: 3rem;
-    }
-
-    .notification .actions a {
-        text-decoration: none;
-        padding: 0.5rem;
-        border: 2px solid color(var(--foreground) alpha(0.25));
-        color: var(--foreground);
-    }
-    """
-
+    stylesheet = sublime.load_resource("Packages/LSP/notification.css")
     contents = message_content(message_type, message, titles)
     mdpopups.show_popup(
         view,
         contents,
-        css=myStyle,
+        css=stylesheet,
         md=False,
         location=-1,
         wrapper_class='notification',

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -460,8 +460,8 @@ class WindowManager(object):
             debug("window {} added session {}".format(self._window.id(), config.name))
             self._sessions.setdefault(config.name, []).append(session)
 
-    def _handle_message_request(self, params: dict, client: Client, request_id: Any) -> None:
-        handler = MessageRequestHandler(self._window.active_view(), client, request_id, params)  # type: ignore
+    def _handle_message_request(self, params: dict, source: str, client: Client, request_id: Any) -> None:
+        handler = MessageRequestHandler(self._window.active_view(), client, request_id, params, source)  # type: ignore
         handler.show()
 
     def restart_sessions(self) -> None:
@@ -511,7 +511,7 @@ class WindowManager(object):
 
         client.on_request(
             "window/showMessageRequest",
-            lambda params, request_id: self._handle_message_request(params, client, request_id))
+            lambda params, request_id: self._handle_message_request(params, session.config.name, client, request_id))
 
         client.on_notification(
             "window/showMessage",

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -1,6 +1,7 @@
 from .diagnostics import DiagnosticsStorage
 from .edit import parse_workspace_edit
 from .logging import debug
+from .message_request_handler import MessageRequestHandler
 from .protocol import Notification, Response
 from .rpc import Client, SublimeLogger
 from .sessions import Session
@@ -21,7 +22,6 @@ from .workspace import get_workspace_folders
 from .workspace import ProjectFolders
 from .workspace import sorted_workspace_folders
 import threading
-from .message_request_handler import MessageRequestHandler
 
 
 class SublimeLike(Protocol):

--- a/tests/test_message_request_handler.py
+++ b/tests/test_message_request_handler.py
@@ -17,6 +17,6 @@ class MessageRequestHandlerTest(unittest.TestCase):
                 {'title': "def"}
             ]
         }
-        handler = MessageRequestHandler(view, client, "1", params)
+        handler = MessageRequestHandler(view, client, "1", params, 'lsp server')
         handler.show()
         self.assertTrue(view.is_popup_visible())

--- a/tests/test_message_request_handler.py
+++ b/tests/test_message_request_handler.py
@@ -1,0 +1,22 @@
+import unittest
+from test_mocks import MockClient
+from LSP.plugin.core.message_request_handler import MessageRequestHandler
+import sublime
+
+
+class MessageRequestHandlerTest(unittest.TestCase):
+    def test_show_popup(self):
+        window = sublime.active_window()
+        view = window.active_view()
+        client = MockClient()
+        params = {
+            'type': 1,
+            'message': 'hello',
+            'actions': [
+                {'title': "abc"},
+                {'title': "def"}
+            ]
+        }
+        handler = MessageRequestHandler(view, client, "1", params)
+        handler.show()
+        self.assertTrue(view.is_popup_visible())

--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -1,6 +1,7 @@
 from LSP.plugin.core.logging import debug
 from LSP.plugin.core.protocol import Notification
 from LSP.plugin.core.protocol import Request
+from LSP.plugin.core.protocol import Response
 from LSP.plugin.core.sessions import Session
 from LSP.plugin.core.types import ClientConfig
 from LSP.plugin.core.types import LanguageConfig
@@ -324,4 +325,7 @@ class MockClient(object):
         pass
 
     def exit(self) -> None:
+        pass
+
+    def send_response(self, response: Response) -> None:
         pass


### PR DESCRIPTION
[Previously](https://github.com/sublimelsp/LSP/pull/470) it was handled with show_quick_panel but we couldn't show
the request message to the user. Until ST4 would allow such a feature
we resort to mdpopups.show_popup

![popup](https://user-images.githubusercontent.com/1632384/79688618-b0e44a80-824f-11ea-95a1-f2f3fa6b7a9e.gif)

 - [x] add tests