### PR TITLE
Fix incremental didChange notification

### DIFF
--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -94,6 +94,7 @@ def render_text_change(change: sublime.TextChange) -> Dict[str, Any]:
         "range": {
             "start": {"line": change.a.row, "character": change.a.col_utf16},
             "end":   {"line": change.b.row, "character": change.b.col_utf16}},
+        "rangeLength": abs(change.b.pt - change.a.pt),
         "text": change.str
     }
 


### PR DESCRIPTION
The `rangeLength` is marked deprecated in the specs.

see: https://microsoft.github.io/language-server-protocol/specification.html#textDocument_didChange

Nevertheless it is still required by some language servers such as
RedHat's LemMinX and needs to be passed to make them happy.