### PR TITLE
Normalize server panel message newlines

### DIFF
--- a/plugin/core/panels.py
+++ b/plugin/core/panels.py
@@ -110,7 +110,6 @@ class LspUpdateServerPanelCommand(sublime_plugin.TextCommand):
     def run(self, edit: sublime.Edit, prefix: str, message: str) -> None:
         with mutable(self.view):
             message = message.replace("\r\n", "\n")  # normalize Windows eol
-            message = message.replace("\r", "\n")  # normalize MacOS eol
             self.view.insert(edit, self.view.size(), "{}: {}\n".format(prefix, message))
             total_lines, _ = self.view.rowcol(self.view.size())
             point = 0  # Starting from point 0 in the panel ...

--- a/plugin/core/panels.py
+++ b/plugin/core/panels.py
@@ -109,6 +109,8 @@ class LspUpdatePanelCommand(sublime_plugin.TextCommand):
 class LspUpdateServerPanelCommand(sublime_plugin.TextCommand):
     def run(self, edit: sublime.Edit, prefix: str, message: str) -> None:
         with mutable(self.view):
+            message = message.replace("\r\n", "\n")  # normalize Windows eol
+            message = message.replace("\r", "\n")  # normalize MacOS eol
             self.view.insert(edit, self.view.size(), "{}: {}\n".format(prefix, message))
             total_lines, _ = self.view.rowcol(self.view.size())
             point = 0  # Starting from point 0 in the panel ...


### PR DESCRIPTION
Some servers return OS specific newlines, which need to be normalized to `\n` for proper display. Otherwise ST prints `<0x0d>` at each eol.