### PR TITLE
Use filterText as trigger, if it's present

### DIFF
--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -264,7 +264,8 @@ class CompletionItem:
                            command: str,
                            args: dict = {},
                            annotation: str = "",
-                           kind: Tuple[int, str, str] = KIND_AMBIGUOUS
+                           kind: Tuple[int, str, str] = KIND_AMBIGUOUS,
+                           details: str = ""
                            ) -> 'CompletionItem':
         ...
 

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -329,6 +329,29 @@ class QueryCompletionsTests(TextDocumentTestCase):
             insert_text='e',
             expected_text='def foo: Int \u003d ???\n   def boo: Int \u003d ???')
 
+    def test_additional_edits(self) -> 'Generator':
+        yield from self.verify(
+            completion_items=[{
+                'label': 'asdf',
+                'additionalTextEdits': [
+                    {
+                        'range': {
+                            'start': {
+                                'line': 0,
+                                'character': 0
+                            },
+                            'end': {
+                                'line': 0,
+                                'character': 0
+                            }
+                        },
+                        'newText': 'import asdf;\n'
+                    }
+                ]
+            }],
+            insert_text='',
+            expected_text='import asdf;\nasdf')
+
     def test_resolve_for_additional_edits(self) -> 'Generator':
         self.set_response('textDocument/completion', [{'label': 'asdf'}, {'label': 'efcgh'}])
         self.set_response('completionItem/resolve', additional_edits)

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -364,8 +364,8 @@ class QueryCompletionsTests(TextDocumentTestCase):
                 "insertTextFormat": 2,
                 "textEdit": {
                     "range": {
-                        "start": {"line": 9, "character": 3},
-                        "end": {"line": 9, "character": 4}
+                        "start": {"line": 0, "character": 0},
+                        "end": {"line": 0, "character": 1}
                     },
                     "newText": "def foo: Int \u003d ${0:???}\n   def boo: Int \u003d ${0:???}"
                 },


### PR DESCRIPTION
The LSP-filterText is truly the suitable thing for the ST-trigger.

If an LSP-filterText is present, we have a bit of a problem on where
to stuff all of the interesting things.
I decided to put the LSP-label into the ST-annotation field.
That leaves us with only the ST-details to fill in. If there's an LSP-detail,
use that. Otherwise, use the LSP-documentation for the ST-details.

In case there's no LSP-filterText, we are supposed to use the LSP-label
for the ST-trigger. In that case there are enough fields: the LSP-detail
can go into the ST-annotation, and the LSP-documentation and go into the
ST-details.