### PR TITLE
Use `INHIBIT_REORDER` flag when only showing lsp completions

### DIFF
--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -250,6 +250,7 @@ class CompletionHandler(LSPViewEventListener):
         if settings.only_show_lsp_completions:
             flags |= sublime.INHIBIT_WORD_COMPLETIONS
             flags |= sublime.INHIBIT_EXPLICIT_COMPLETIONS
+            flags |= sublime.INHIBIT_REORDER
         if isinstance(response, dict):
             response_items = response["items"] or []
             if response.get("isIncomplete", False):


### PR DESCRIPTION
This gives us order of items as defined by the server (alphabetical
or otherwise relevant) instead of seemingly random order from
ST's algorithm.