### PR TITLE
Fix hover popup not triggering in some cases when hovering diagnostics

### DIFF
--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -356,8 +356,8 @@ class Range(object):
             (self.end.row > point.row or self.start.col <= point.col <= self.end.col)
 
     def intersects(self, rge: 'Range') -> bool:
-        return rge.start.row <= self.end.row and rge.start.col <= self.end.col and \
-            rge.end.row >= self.start.row and rge.end.col >= self.start.col
+        return self.contains(rge.start) or self.contains(rge.end) or \
+            rge.contains(self.start) or rge.contains(self.end)
 
 
 class ContentChange(object):

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -352,7 +352,7 @@ class Range(object):
         }
 
     def contains(self, point: Point) -> bool:
-        return self.start.row <= point.row and \
+        return self.start.row <= point.row <= self.end.row and \
             (self.end.row > point.row or self.start.col <= point.col <= self.end.col)
 
     def intersects(self, rge: 'Range') -> bool:

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -352,7 +352,8 @@ class Range(object):
         }
 
     def contains(self, point: Point) -> bool:
-        return self.start.row <= point.row <= self.end.row and self.start.col <= point.col <= self.end.col
+        return self.start.row <= point.row and \
+            (self.end.row > point.row or self.start.col <= point.col <= self.end.col)
 
     def intersects(self, rge: 'Range') -> bool:
         return rge.start.row <= self.end.row and rge.start.col <= self.end.col and \

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -44,6 +44,36 @@ class RangeTests(unittest.TestCase):
         self.assertEqual(lsp_range['end']['line'], 11)
         self.assertEqual(lsp_range['end']['character'], 3)
 
+    def test_contains(self):
+        range = Range.from_lsp(LSP_RANGE)
+        point = Point.from_lsp(LSP_START_POSITION)
+        self.assertTrue(range.contains(point))
+        range = Range.from_lsp(LSP_RANGE)
+        point = Point.from_lsp({'line': 10, 'character': 1})
+        self.assertTrue(range.contains(point))
+
+    def test_intersects(self):
+        # range2 fully contained within range1
+        range1 = Range.from_lsp({
+            'start': {'line': 0, 'character': 0},
+            'end': {'line': 1, 'character': 4}
+        })
+        range2 = Range.from_lsp({
+            'start': {'line': 0, 'character': 4},
+            'end': {'line': 0, 'character': 2}
+        })
+        # range2 intersecting end of range 1
+        self.assertTrue(range2.intersects(range1))
+        range1 = Range.from_lsp({
+            'start': {'line': 0, 'character': 0},
+            'end': {'line': 0, 'character': 3}
+        })
+        range2 = Range.from_lsp({
+            'start': {'line': 0, 'character': 2},
+            'end': {'line': 0, 'character': 4}
+        })
+        self.assertTrue(range2.intersects(range1))
+
 
 class DiagnosticTests(unittest.TestCase):
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -77,7 +77,7 @@ class RangeTests(unittest.TestCase):
             'start': {'line': 0, 'character': 2},
             'end': {'line': 0, 'character': 3}
         })
-        self.assertTrue(range2.intersects(range1))
+        self.assertTrue(range1.intersects(range2))
         # range2 intersecting end of range 1
         range1 = Range.from_lsp({
             'start': {'line': 0, 'character': 0},
@@ -87,7 +87,7 @@ class RangeTests(unittest.TestCase):
             'start': {'line': 0, 'character': 2},
             'end': {'line': 0, 'character': 4}
         })
-        self.assertTrue(range2.intersects(range1))
+        self.assertTrue(range1.intersects(range2))
         # range2 fully outside of range 1
         range1 = Range.from_lsp({
             'start': {'line': 0, 'character': 0},
@@ -97,7 +97,7 @@ class RangeTests(unittest.TestCase):
             'start': {'line': 2, 'character': 0},
             'end': {'line': 3, 'character': 0}
         })
-        self.assertFalse(range2.intersects(range1))
+        self.assertFalse(range1.intersects(range2))
         # range2 fully within range 1
         range1 = Range.from_lsp({
             'start': {'line': 0, 'character': 10},

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -59,6 +59,13 @@ class RangeTests(unittest.TestCase):
         })
         point = Point.from_lsp({'line': 12, 'character': 0})
         self.assertFalse(range.contains(point))
+        # Point within first line of range.
+        range = Range.from_lsp({
+            'start': {'line': 0, 'character': 0},
+            'end': {'line': 1, 'character': 4}
+        })
+        point = Point.from_lsp({'line': 0, 'character': 4})
+        self.assertTrue(range.contains(point))
 
     def test_intersects(self):
         # range2 fully contained within range1
@@ -67,11 +74,11 @@ class RangeTests(unittest.TestCase):
             'end': {'line': 1, 'character': 4}
         })
         range2 = Range.from_lsp({
-            'start': {'line': 0, 'character': 4},
-            'end': {'line': 0, 'character': 2}
+            'start': {'line': 0, 'character': 2},
+            'end': {'line': 0, 'character': 3}
         })
-        # range2 intersecting end of range 1
         self.assertTrue(range2.intersects(range1))
+        # range2 intersecting end of range 1
         range1 = Range.from_lsp({
             'start': {'line': 0, 'character': 0},
             'end': {'line': 0, 'character': 3}
@@ -82,7 +89,6 @@ class RangeTests(unittest.TestCase):
         })
         self.assertTrue(range2.intersects(range1))
         # range2 fully outside of range 1
-        self.assertTrue(range2.intersects(range1))
         range1 = Range.from_lsp({
             'start': {'line': 0, 'character': 0},
             'end': {'line': 0, 'character': 3}
@@ -92,6 +98,16 @@ class RangeTests(unittest.TestCase):
             'end': {'line': 3, 'character': 0}
         })
         self.assertFalse(range2.intersects(range1))
+        # range2 fully within range 1
+        range1 = Range.from_lsp({
+            'start': {'line': 0, 'character': 10},
+            'end': {'line': 1, 'character': 20}
+        })
+        range2 = Range.from_lsp({
+            'start': {'line': 0, 'character': 21},
+            'end': {'line': 0, 'character': 22}
+        })
+        self.assertTrue(range1.intersects(range2))
 
 
 class DiagnosticTests(unittest.TestCase):

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -81,6 +81,17 @@ class RangeTests(unittest.TestCase):
             'end': {'line': 0, 'character': 4}
         })
         self.assertTrue(range2.intersects(range1))
+        # range2 fully outside of range 1
+        self.assertTrue(range2.intersects(range1))
+        range1 = Range.from_lsp({
+            'start': {'line': 0, 'character': 0},
+            'end': {'line': 0, 'character': 3}
+        })
+        range2 = Range.from_lsp({
+            'start': {'line': 2, 'character': 0},
+            'end': {'line': 3, 'character': 0}
+        })
+        self.assertFalse(range2.intersects(range1))
 
 
 class DiagnosticTests(unittest.TestCase):

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -48,9 +48,17 @@ class RangeTests(unittest.TestCase):
         range = Range.from_lsp(LSP_RANGE)
         point = Point.from_lsp(LSP_START_POSITION)
         self.assertTrue(range.contains(point))
+        # Point inside of range with character offset lower than range end
         range = Range.from_lsp(LSP_RANGE)
         point = Point.from_lsp({'line': 10, 'character': 1})
         self.assertTrue(range.contains(point))
+        # Point out of range with character offset lower than range end
+        range = Range.from_lsp({
+            'start': {'line': 0, 'character': 0},
+            'end': {'line': 1, 'character': 4}
+        })
+        point = Point.from_lsp({'line': 12, 'character': 0})
+        self.assertFalse(range.contains(point))
 
     def test_intersects(self):
         # range2 fully contained within range1


### PR DESCRIPTION
With content like:
```
const x = 1

```

and error diagnostic at the end of the first line (missing semicolon),
it was impossible to trigger hover popup with code actions when hovering
end of the line due to `Range.contains`' broken logic.

The `Range.contains` logic was broken when range spanned more than one
line and point's column was larger than range's `end` column.