### PR TITLE
Mark CI/CD files as export-ignore 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,12 @@
+.coveragerc export-ignore
+.github/ export-ignore
+.style.yapf export-ignore
+.travis.yml export-ignore
+codecov.yml export-ignore
 docs/ export-ignore
+mkdocs.yml export-ignore
+mypy.ini export-ignore
+stubs/ export-ignore
 tests/ export-ignore
+tox.ini export-ignore
+unittesting.json export-ignore


### PR DESCRIPTION
So they won't be shipped in the .sublime-package
