### PR TITLE
Handle all dynamic capabilities

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -369,8 +369,7 @@ class Session(object):
         self.on_request("workspace/configuration", self._handle_request_workspace_configuration)
         self.on_request("client/registerCapability", self._handle_register_capability)
         self.on_request("client/unregisterCapability", self._handle_unregister_capability)
-
-        if self.config.settings is not None:
+        if self.config.settings:
             self.client.send_notification(Notification.didChangeConfiguration({'settings': self.config.settings}))
 
         if self._on_post_initialize:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -129,7 +129,7 @@ def get_initialize_params(workspace_folders: List[WorkspaceFolder], config: Clie
 
 
 # method -> (capability dotted path, optional registration dotted path)
-# these are the EXCEPTIONS. The general rule is: method foo/bar --> (barProvider, barProvider._id)
+# these are the EXCEPTIONS. The general rule is: method foo/bar --> (barProvider, barProvider.id)
 _method_to_capability_exceptions = {
     'workspace/symbol': ('workspaceSymbolProvider', None),
     'workspace/didChangeWorkspaceFolders': ('workspace.workspaceFolders',
@@ -150,15 +150,18 @@ def method_to_capability(method: str) -> Tuple[str, str]:
 
     Examples:
 
-        textDocument/definition --> (definitionProvider, definitionProvider._id)
-        textDocument/references --> (referencesProvider, referencesProvider._id)
-        textDocument/didOpen --> (textDocumentSync.openClose, textDocumentSync.openClose._id)
+        textDocument/definition --> (definitionProvider, definitionProvider.id)
+        textDocument/references --> (referencesProvider, referencesProvider.id)
+        textDocument/didOpen --> (textDocumentSync.openClose, textDocumentSync.openClose.id)
     """
     capability_path, registration_path = _method_to_capability_exceptions.get(method, (None, None))
     if capability_path is None:
         capability_path = method.split('/')[1] + "Provider"
     if registration_path is None:
-        registration_path = capability_path + "._id"
+        # This path happens to coincide with the StaticRegistrationOptions' id, which is on purpose. As a consequence,
+        # if a server made a "registration" via the initialize response, it can call client/unregisterCapability at
+        # a later date, and the capability will pop from the capabilities dict.
+        registration_path = capability_path + ".id"
     return capability_path, registration_path
 
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -393,7 +393,6 @@ class Session(object):
         self.client.send_response(Response(request_id, items))
 
     def _handle_register_capability(self, params: Any, request_id: Any) -> None:
-        send_did_change_configuration = False
         registrations = params["registrations"]
         for registration in registrations:
             method = registration["method"]

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1,7 +1,7 @@
-from .logging import debug, printf
+from .logging import debug
 from .process import start_server
 from .protocol import completion_item_kinds, symbol_kinds, WorkspaceFolder, Request, Notification
-from .protocol import TextDocumentSyncKindNone
+from .protocol import TextDocumentSyncKindNone, TextDocumentSyncKindIncremental
 from .rpc import Client, attach_stdio_client, Response
 from .transports import start_tcp_transport, start_tcp_listener, TCPTransport, Transport
 from .types import ClientConfig, ClientStates, Settings
@@ -15,14 +15,17 @@ def get_initialize_params(workspace_folders: List[WorkspaceFolder], config: Clie
     capabilities = {
         "textDocument": {
             "synchronization": {
+                "dynamicRegistration": True,  # exceptional
                 "didSave": True,
                 "willSave": True,
                 "willSaveWaitUntil": True
             },
             "hover": {
+                "dynamicRegistration": True,
                 "contentFormat": ["markdown", "plaintext"]
             },
             "completion": {
+                "dynamicRegistration": True,
                 "completionItem": {
                     "snippetSupport": True
                 },
@@ -31,6 +34,7 @@ def get_initialize_params(workspace_folders: List[WorkspaceFolder], config: Clie
                 }
             },
             "signatureHelp": {
+                "dynamicRegistration": True,
                 "signatureInformation": {
                     "documentationFormat": ["markdown", "plaintext"],
                     "parameterInformation": {
@@ -38,28 +42,54 @@ def get_initialize_params(workspace_folders: List[WorkspaceFolder], config: Clie
                     }
                 }
             },
-            "references": {},
-            "documentHighlight": {},
+            "references": {
+                "dynamicRegistration": True
+            },
+            "documentHighlight": {
+                "dynamicRegistration": True
+            },
             "documentSymbol": {
+                "dynamicRegistration": True,
                 "symbolKind": {
                     "valueSet": symbol_kinds
                 }
             },
-            "formatting": {},
-            "rangeFormatting": {},
-            "declaration": {"linkSupport": True},
-            "definition": {"linkSupport": True},
-            "typeDefinition": {"linkSupport": True},
-            "implementation": {"linkSupport": True},
+            "formatting": {
+                "dynamicRegistration": True  # exceptional
+            },
+            "rangeFormatting": {
+                "dynamicRegistration": True
+            },
+            "declaration": {
+                "dynamicRegistration": True,
+                "linkSupport": True
+            },
+            "definition": {
+                "dynamicRegistration": True,
+                "linkSupport": True
+            },
+            "typeDefinition": {
+                "dynamicRegistration": True,
+                "linkSupport": True
+            },
+            "implementation": {
+                "dynamicRegistration": True,
+                "linkSupport": True
+            },
             "codeAction": {
+                "dynamicRegistration": True,
                 "codeActionLiteralSupport": {
                     "codeActionKind": {
                         "valueSet": []
                     }
                 }
             },
-            "rename": {},
-            "colorProvider": {},
+            "rename": {
+                "dynamicRegistration": True
+            },
+            "colorProvider": {
+                "dynamicRegistration": True  # exceptional
+            },
             "publishDiagnostics": {
                 "relatedInformation": True
             }
@@ -70,6 +100,7 @@ def get_initialize_params(workspace_folders: List[WorkspaceFolder], config: Clie
             "executeCommand": {},
             "workspaceFolders": True,
             "symbol": {
+                "dynamicRegistration": True,  # exceptional
                 "symbolKind": {
                     "valueSet": symbol_kinds
                 }
@@ -97,6 +128,40 @@ def get_initialize_params(workspace_folders: List[WorkspaceFolder], config: Clie
     return initializeParams
 
 
+# method -> (capability dotted path, optional registration dotted path)
+# these are the EXCEPTIONS. The general rule is: method foo/bar --> (barProvider, barProvider._id)
+_method_to_capability_exceptions = {
+    'workspace/symbol': ('workspaceSymbolProvider', None),
+    'workspace/didChangeWorkspaceFolders': ('workspace.workspaceFolders',
+                                            'workspace.workspaceFolders.changeNotifications'),
+    'textDocument/didOpen': ('textDocumentSync.openClose', None),
+    'textDocument/didChange': ('textDocumentSync.change', None),
+    'textDocument/didSave': ('textDocumentSync.save', None),
+    'textDocument/willSave': ('textDocumentSync.willSave', None),
+    'textDocument/willSaveWaitUntil': ('textDocumentSync.willSaveWaitUntil', None),
+    'textDocument/formatting': ('documentFormattingProvider', None),
+    'textDocument/documentColor': ('colorProvider', None)
+}  # type: Dict[str, Tuple[str, Optional[str]]]
+
+
+def method_to_capability(method: str) -> Tuple[str, str]:
+    """
+    Given a method, returns the corresponding capability path, and the associated path to stash the registration key.
+
+    Examples:
+
+        textDocument/definition --> (definitionProvider, definitionProvider._id)
+        textDocument/references --> (referencesProvider, referencesProvider._id)
+        textDocument/didOpen --> (textDocumentSync.openClose, textDocumentSync.openClose._id)
+    """
+    capability_path, registration_path = _method_to_capability_exceptions.get(method, (None, None))
+    if capability_path is None:
+        capability_path = method.split('/')[1] + "Provider"
+    if registration_path is None:
+        registration_path = capability_path + "._id"
+    return capability_path, registration_path
+
+
 def diff_folders(old: List[WorkspaceFolder],
                  new: List[WorkspaceFolder]) -> Tuple[List[WorkspaceFolder], List[WorkspaceFolder]]:
     added = []  # type: List[WorkspaceFolder]
@@ -118,6 +183,29 @@ def get_dotted_value(current: Any, dotted: str) -> Any:
         else:
             return None
     return current
+
+
+def set_dotted_value(current: dict, dotted: str, value: Any) -> None:
+    keys = dotted.split('.')
+    for i in range(0, len(keys) - 1):
+        key = keys[i]
+        next_current = current.get(key)
+        if not isinstance(next_current, dict):
+            next_current = {}
+            current[key] = next_current
+        current = next_current
+    current[keys[-1]] = value
+
+
+def clear_dotted_value(current: dict, dotted: str) -> None:
+    keys = dotted.split('.')
+    for i in range(0, len(keys) - 1):
+        key = keys[i]
+        next_current = current.get(key)
+        if not isinstance(next_current, dict):
+            return
+        current = next_current
+    current.pop(keys[-1], None)
 
 
 class Session(object):
@@ -148,7 +236,10 @@ class Session(object):
     def should_notify_did_open(self) -> bool:
         textsync = self.capabilities.get('textDocumentSync')
         if isinstance(textsync, dict):
-            return bool(textsync.get('openClose'))
+            open_close = textsync.get('openClose')
+            if isinstance(open_close, dict):
+                return True  # dynamic registration
+            return bool(open_close)
         if isinstance(textsync, int):
             return textsync > TextDocumentSyncKindNone
         return False
@@ -156,7 +247,11 @@ class Session(object):
     def text_sync_kind(self) -> int:
         textsync = self.capabilities.get('textDocumentSync')
         if isinstance(textsync, dict):
-            return int(textsync.get('change', TextDocumentSyncKindNone))
+            change = textsync.get('change', TextDocumentSyncKindNone)
+            if isinstance(change, dict):
+                # dynamic registration
+                return TextDocumentSyncKindIncremental  # or TextDocumentSyncKindFull?
+            return int(change)
         if isinstance(textsync, int):
             return textsync
         return TextDocumentSyncKindNone
@@ -167,13 +262,19 @@ class Session(object):
     def should_notify_will_save(self) -> bool:
         textsync = self.capabilities.get('textDocumentSync')
         if isinstance(textsync, dict):
-            return bool(textsync.get('willSave'))
+            will_save = textsync.get('willSave')
+            if isinstance(will_save, dict):
+                return True  # dynamic registration
+            return bool(will_save)
         return False
 
     def should_request_will_save_wait_until(self) -> bool:
         textsync = self.capabilities.get('textDocumentSync')
         if isinstance(textsync, dict):
-            return bool(textsync.get('willSaveWaitUntil'))
+            wswu = textsync.get('willSaveWaitUntil')
+            if isinstance(wswu, dict):
+                return True  # dynamic registration
+            return bool(wswu)
         return False
 
     def should_notify_did_save(self) -> Tuple[bool, bool]:
@@ -286,25 +387,19 @@ class Session(object):
     def _handle_register_capability(self, params: Any, request_id: Any) -> None:
         registrations = params["registrations"]
         for registration in registrations:
-            method = registration["method"]
-            if method == "workspace/didChangeWorkspaceFolders":
-                self.capabilities.setdefault(
-                    "workspace", {}).setdefault(
-                        "workspaceFolders", {})["changeNotifications"] = registration["id"]
-            else:
-                printf("WARNING: unknown registration method '{}' from {}".format(method, self.config.name))
+            capability_path, registration_path = method_to_capability(registration["method"])
+            debug("{}: registering capability:".format(self.config.name), capability_path)
+            set_dotted_value(self.capabilities, capability_path, registration["registerOptions"])
+            set_dotted_value(self.capabilities, registration_path, registration["id"])
         self.client.send_response(Response(request_id, None))
 
     def _handle_unregister_capability(self, params: Any, request_id: Any) -> None:
         unregistrations = params["unregisterations"]  # typo in the official specification
         for unregistration in unregistrations:
-            method = unregistration["method"]
-            if method == "workspace/didChangeWorkspaceFolders":
-                workspace = self.capabilities.get("workspace", {})
-                # Who cares about the ID?
-                workspace.get("workspaceFolders", {}).pop("changeNotifications", None)
-            else:
-                printf("WARNING: unknown unregistration method '{}' from {}".format(method, self.config.name))
+            capability_path, registration_path = method_to_capability(unregistration["method"])
+            debug("{}: unregistering capability:".format(self.config.name), capability_path)
+            clear_dotted_value(self.capabilities, capability_path)
+            clear_dotted_value(self.capabilities, registration_path)
         self.client.send_response(Response(request_id, None))
 
     def end(self) -> None:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -130,7 +130,7 @@ def get_initialize_params(workspace_folders: List[WorkspaceFolder], config: Clie
 
 # method -> (capability dotted path, optional registration dotted path)
 # these are the EXCEPTIONS. The general rule is: method foo/bar --> (barProvider, barProvider.id)
-_method_to_capability_exceptions = {
+METHOD_TO_CAPABILITY_EXCEPTIONS = {
     'workspace/symbol': ('workspaceSymbolProvider', None),
     'workspace/didChangeWorkspaceFolders': ('workspace.workspaceFolders',
                                             'workspace.workspaceFolders.changeNotifications'),
@@ -154,7 +154,7 @@ def method_to_capability(method: str) -> Tuple[str, str]:
         textDocument/references --> (referencesProvider, referencesProvider.id)
         textDocument/didOpen --> (textDocumentSync.openClose, textDocumentSync.openClose.id)
     """
-    capability_path, registration_path = _method_to_capability_exceptions.get(method, (None, None))
+    capability_path, registration_path = METHOD_TO_CAPABILITY_EXCEPTIONS.get(method, (None, None))
     if capability_path is None:
         capability_path = method.split('/')[1] + "Provider"
     if registration_path is None:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -14,7 +14,6 @@ import unittest
 import unittest.mock
 
 
-
 class MiscFunctions(unittest.TestCase):
 
     def test_set_and_clear_dotted_values(self) -> None:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,6 +1,8 @@
-from LSP.plugin.core.protocol import WorkspaceFolder
 from LSP.plugin.core.protocol import TextDocumentSyncKindFull, TextDocumentSyncKindNone, TextDocumentSyncKindIncremental
+from LSP.plugin.core.protocol import WorkspaceFolder
+from LSP.plugin.core.sessions import clear_dotted_value
 from LSP.plugin.core.sessions import create_session, Session, get_initialize_params
+from LSP.plugin.core.sessions import set_dotted_value
 from LSP.plugin.core.types import ClientConfig
 from LSP.plugin.core.types import Settings
 from LSP.plugin.core.typing import Optional
@@ -10,6 +12,60 @@ from test_mocks import TEST_LANGUAGE
 import sublime
 import unittest
 import unittest.mock
+
+
+
+class MiscFunctions(unittest.TestCase):
+
+    def test_set_and_clear_dotted_values(self) -> None:
+        d = {"foo": {"bar": "baz"}}
+        set_dotted_value(d, "foo.bar.baz.qux", {"hello": "there"})
+        set_dotted_value(d, "foo.bar.baz.qux.id", "asdf-1234-qwerty")
+        self.assertEqual(d, {
+            "foo": {
+                "bar": {
+                    "baz": {
+                        "qux": {
+                            "hello": "there",
+                            "id": "asdf-1234-qwerty"
+                        }
+                    }
+                }
+            }
+        })
+        d = {"foo": {"bar": 42}}
+        set_dotted_value(d, "foo.bar.baz.qux", {"hello": "there"})
+        set_dotted_value(d, "foo.bar.baz.qux.id", "asdf-1234-qwerty")
+        self.assertEqual(d, {
+            "foo": {
+                "bar": {
+                    "baz": {
+                        "qux": {
+                            "hello": "there",
+                            "id": "asdf-1234-qwerty"
+                        }
+                    }
+                }
+            }
+        })
+        clear_dotted_value(d, "foo.bar.baz.qux")
+        self.assertEqual(d, {
+            "foo": {
+                "bar": {
+                    "baz": {}
+                }
+            }
+        })
+        clear_dotted_value(d, "foo.bar.baz.qux.id")
+        self.assertEqual(d, {
+            "foo": {
+                "bar": {
+                    "baz": {}
+                }
+            }
+        })
+        clear_dotted_value(d, "foo")
+        self.assertEqual(d, {})
 
 
 class SessionTest(unittest.TestCase):


### PR DESCRIPTION
It might need more exceptions, but it should be possible to add those in the "exceptions" dict and that's really all there should be to it.

Note that once a user has typed a char, and then the server registers textDocument/completion, then we still won't do completion because of the `self.initialize()` strategy.
