### PR TITLE
Handle case when registerOptions doesn't exist

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -398,7 +398,7 @@ class Session(object):
             method = registration["method"]
             capability_path, registration_path = method_to_capability(method)
             debug("{}: registering capability:".format(self.config.name), capability_path)
-            set_dotted_value(self.capabilities, capability_path, registration["registerOptions"])
+            set_dotted_value(self.capabilities, capability_path, registration.get("registerOptions"))
             set_dotted_value(self.capabilities, registration_path, registration["id"])
         self.client.send_response(Response(request_id, None))
 


### PR DESCRIPTION
The code has triggered exception with LSP-lemminx as "registerOptions"
is optional.