### PR TITLE
Ignore edit if textDocument.version doesn't match current view

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,4 @@ If you have any problems, see the [troubleshooting](https://lsp.readthedocs.io/e
 - ❌ didChangeWatchedFiles
 - ✅ symbol
 - ✅ executeCommand
+- ✅ documentChanges

--- a/README.md
+++ b/README.md
@@ -128,8 +128,10 @@ If you have any problems, see the [troubleshooting](https://lsp.readthedocs.io/e
 
 - ✅ applyEdit
 - ✅ workspaceEdit
+  - ✅ documentChanges
+  - ❌ resourceOperations
+  - ❌ failureHandling
 - ✅ didChangeConfiguration
 - ❌ didChangeWatchedFiles
 - ✅ symbol
 - ✅ executeCommand
-- ✅ documentChanges

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -192,7 +192,7 @@ class CompletionHandler(LSPViewEventListener):
             edit = item.get('textEdit')
             if edit:
                 parsed_edit = parse_text_edit(edit)
-                start, end, newText = parsed_edit
+                start, end, newText, version = parsed_edit
                 edit_start_loc = self.view.text_point(*start)
 
                 # if the edit started before the word, we need to trim back to the start of the edit.

--- a/plugin/core/edit.py
+++ b/plugin/core/edit.py
@@ -1,3 +1,4 @@
+from .logging import debug
 from .typing import List, Dict, Any, Iterable, Optional, Tuple
 from .url import uri_to_filename
 import operator
@@ -13,6 +14,9 @@ def parse_workspace_edit(workspace_edit: Dict[str, Any]) -> Dict[str, List[TextE
             changes[uri_to_filename(uri)] = list(parse_text_edit(change) for change in file_changes)
     if 'documentChanges' in workspace_edit:
         for document_change in workspace_edit.get('documentChanges', []):
+            if 'kind' in document_change:
+                debug('Ignoring unsupported "resourceOperations" edit type')
+                continue
             uri = document_change.get('textDocument').get('uri')
             version = document_change.get('textDocument').get('version')
             text_edit = list(parse_text_edit(change, version) for change in document_change.get('edits'))

--- a/plugin/core/edit.py
+++ b/plugin/core/edit.py
@@ -1,8 +1,9 @@
-from .typing import List, Dict, Any, Iterable, Tuple
+from .typing import List, Dict, Any, Iterable, Optional, Tuple
 from .url import uri_to_filename
 import operator
 
-TextEdit = Tuple[Tuple[int, int], Tuple[int, int], str]
+# tuple of start, end, newText, version
+TextEdit = Tuple[Tuple[int, int], Tuple[int, int], str, Optional[int]]
 
 
 def parse_workspace_edit(workspace_edit: Dict[str, Any]) -> Dict[str, List[TextEdit]]:
@@ -13,7 +14,9 @@ def parse_workspace_edit(workspace_edit: Dict[str, Any]) -> Dict[str, List[TextE
     if 'documentChanges' in workspace_edit:
         for document_change in workspace_edit.get('documentChanges', []):
             uri = document_change.get('textDocument').get('uri')
-            changes[uri_to_filename(uri)] = list(parse_text_edit(change) for change in document_change.get('edits'))
+            version = document_change.get('textDocument').get('version')
+            text_edit = list(parse_text_edit(change, version) for change in document_change.get('edits'))
+            changes[uri_to_filename(uri)] = text_edit
     return changes
 
 
@@ -21,11 +24,12 @@ def parse_range(range: Dict[str, int]) -> Tuple[int, int]:
     return range['line'], range['character']
 
 
-def parse_text_edit(text_edit: Dict[str, Any]) -> TextEdit:
+def parse_text_edit(text_edit: Dict[str, Any], version: int = None) -> TextEdit:
     return (
         parse_range(text_edit['range']['start']),
         parse_range(text_edit['range']['end']),
-        text_edit.get('newText', '')
+        text_edit.get('newText', ''),
+        version
     )
 
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -100,8 +100,10 @@ def get_initialize_params(workspace_folders: List[WorkspaceFolder], config: Clie
             "didChangeConfiguration": {
                 "dynamicRegistration": True
             },
-            "documentChanges": True,
             "executeCommand": {},
+            "workspaceEdit": {
+                "documentChanges": True,
+            },
             "workspaceFolders": True,
             "symbol": {
                 "dynamicRegistration": True,  # exceptional

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -100,6 +100,7 @@ def get_initialize_params(workspace_folders: List[WorkspaceFolder], config: Clie
             "didChangeConfiguration": {
                 "dynamicRegistration": True
             },
+            "documentChanges": True,
             "executeCommand": {},
             "workspaceFolders": True,
             "symbol": {

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -103,6 +103,7 @@ def get_initialize_params(workspace_folders: List[WorkspaceFolder], config: Clie
             "executeCommand": {},
             "workspaceEdit": {
                 "documentChanges": True,
+                "failureHandling": "abort",
             },
             "workspaceFolders": True,
             "symbol": {

--- a/plugin/edit.py
+++ b/plugin/edit.py
@@ -1,10 +1,8 @@
 import sublime
 import sublime_plugin
-from .core.edit import sort_by_application_order
+from .core.edit import sort_by_application_order, TextEdit
 from .core.logging import debug
-from .core.typing import List, Dict, Optional, Any, Tuple
-
-TextEdit = Tuple[Tuple[int, int], Tuple[int, int], str]
+from .core.typing import List, Dict, Optional, Any
 
 
 class LspApplyWorkspaceEditCommand(sublime_plugin.WindowCommand):
@@ -45,7 +43,10 @@ class LspApplyDocumentEditCommand(sublime_plugin.TextCommand):
         if changes:
             last_row, last_col = self.view.rowcol(self.view.size())
             for change in reversed(sort_by_application_order(changes)):
-                start, end, newText = change
+                start, end, newText, version = change
+                if version is not None and version != self.view.change_count():
+                    debug('ignoring edit due to non-matching document version')
+                    continue
                 region = sublime.Region(self.view.text_point(*start), self.view.text_point(*end))
 
                 if start[0] > last_row and newText[0] != '\n':

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -25,12 +25,13 @@ LSP_EDIT_DOCUMENT_CHANGES = {
 class TextEditTests(unittest.TestCase):
 
     def test_parse_from_lsp(self):
-        (start, end, newText) = parse_text_edit(LSP_TEXT_EDIT)
+        (start, end, newText, version) = parse_text_edit(LSP_TEXT_EDIT, 0)
         self.assertEqual(newText, 'newText')
         self.assertEqual(start[0], 10)
         self.assertEqual(start[1], 4)
         self.assertEqual(end[0], 11)
         self.assertEqual(end[1], 3)
+        self.assertEqual(version, 0)
 
 
 class WorkspaceEditTests(unittest.TestCase):


### PR DESCRIPTION
If version is provided use that to verify that edit can be applied to
current version of the document.