### PR TITLE
Support window/workDoneProgress and $/progress notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,9 @@ If you have any problems, see the [troubleshooting](https://lsp.readthedocs.io/e
 - ❌ didChangeWatchedFiles
 - ✅ symbol
 - ✅ executeCommand
+
+### Window Capabilities
+
+- ✅ workDoneProgress
+  - ✅ create
+  - ❌ cancel

--- a/docs/index.md
+++ b/docs/index.md
@@ -504,7 +504,7 @@ npm install -g javascript-typescript-langserver
 ```js
 "julials": {
   "command": ["bash", "PATH_TO_JULIA_SERVER/LanguageServer/contrib/languageserver.sh"], // on Linux/macOS
-  // "command": ["julia", "--startup-file=no", "--history-file=no", "-e", "using LanguageServer; using LanguageServer.SymbolServer; server=LanguageServer.LanguageServerInstance(stdin,stdout,false); run(server)"], // on Windows
+  // "command": ["julia", "--startup-file=no", "--history-file=no", "-e", "using Pkg; using LanguageServer; using LanguageServer.SymbolServer; env_path=dirname(Pkg.Types.Context().env.project_file); server=LanguageServer.LanguageServerInstance(stdin,stdout,false,env_path); run(server)"], // on Windows
   "languageId": "julia",
   "scopes": ["source.julia"],
   "settings": {

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -113,6 +113,9 @@ def get_initialize_params(workspace_folders: List[WorkspaceFolder], config: Clie
                 }
             },
             "configuration": True
+        },
+        "window": {
+            "workDoneProgress": True
         }
     }
 

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -591,7 +591,7 @@ class WindowManager(object):
             elif value.get('kind') == 'end':
                 self._progress.pop(token, None)  # erase stored title and message for token
 
-    def _progress_string(self, token: str, value: Dict[str, Any]) -> str:
+    def _progress_string(self, token: Any, value: Dict[str, Any]) -> str:
         progress = self._progress.get(token)
         if not progress:
             debug('unknown $/progress token: {}'.format(token))

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -571,22 +571,22 @@ class WindowManager(object):
         client.send_response(Response(request_id, None))
 
     def _handle_progress_notification(self, params: Dict[str, Any]) -> None:
-        token = params.get('token')
+        token = params['token']
         if token not in self._progress:
             debug('unknown $/progress token: {}'.format(token))
             return
-        value = params.get('value')
+        value = params['value']
         if not value:
             return
-        if value.get('kind') == 'begin':
-            self._progress[token]['title'] = value.get('title')  # mandatory
+        if value['kind'] == 'begin':
+            self._progress[token]['title'] = value['title']  # mandatory
             self._progress[token]['message'] = value.get('message')  # optional
             self._sublime.status_message(self._progress_string(token, value))
-        elif value.get('kind') == 'report':
+        elif value['kind'] == 'report':
             self._sublime.status_message(self._progress_string(token, value))
-        elif value.get('kind') == 'end':
+        elif value['kind'] == 'end':
             if value.get('message'):
-                status_msg = self._progress[token]['title'] + ': ' + value.get('message')
+                status_msg = self._progress[token]['title'] + ': ' + value['message']
                 self._sublime.status_message(status_msg)
             self._progress.pop(token, None)
 

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -587,6 +587,10 @@ class WindowManager(object):
                 if status_msg:
                     self._sublime.status_message(status_msg)
             elif value.get('kind') == 'end':
+                if value.get('message'):
+                    status_msg = self._progress_string(token, value)
+                    if status_msg:
+                        self._sublime.status_message(status_msg)
                 self._progress.pop(token, None)  # erase stored title and message for token
 
     def _progress_string(self, token: Any, value: Dict[str, Any]) -> str:

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -577,7 +577,7 @@ class WindowManager(object):
         value = params.get('value')
         if token and value:
             if value.get('kind') == 'begin':
-                if not token in self._progress:
+                if token not in self._progress:
                     self._progress[token] = dict()
                 self._progress[token]['title'] = value.get('title')  # mandatory
                 self._progress[token]['message'] = value.get('message')  # optional

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -589,7 +589,7 @@ class WindowManager(object):
                 if status_msg:
                     self._sublime.status_message(status_msg)
             elif value.get('kind') == 'end':
-                self._progress[token] = dict()  # erase stored title and message for token
+                self._progress.pop(token, None)  # erase stored title and message for token
 
     def _progress_string(self, token: str, value: Dict[str, Any]) -> str:
         progress = self._progress.get(token)

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -576,8 +576,6 @@ class WindowManager(object):
             debug('unknown $/progress token: {}'.format(token))
             return
         value = params['value']
-        if not value:
-            return
         if value['kind'] == 'begin':
             self._progress[token]['title'] = value['title']  # mandatory
             self._progress[token]['message'] = value.get('message')  # optional

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -316,7 +316,7 @@ class WindowManager(object):
         self._workspace = workspace
         self._workspace.on_changed = self._on_project_changed
         self._workspace.on_switched = self._on_project_switched
-        self._progress = dict()
+        self._progress = dict()  # type: Dict[Any, Any]
 
     def _on_project_changed(self, folders: List[str]) -> None:
         workspace_folders = get_workspace_folders(self._workspace.folders)

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -567,9 +567,7 @@ class WindowManager(object):
             self._handle_window_closed()
 
     def _receive_progress_token(self, params: Dict[str, Any], client: Client, request_id: Any) -> None:
-        token = params.get('token')  # number | string
-        if token:
-            self._progress[token] = dict()
+        self._progress[params['token']] = dict()
         client.send_response(Response(request_id, None))
 
     def _show_progress(self, params: Dict[str, Any]) -> None:


### PR DESCRIPTION
This is an enhanced version of PR #902 with support for `window/workDoneProgress/create` from protocol version 3.15.0: [Work Done Progress](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workDoneProgress).

* `$/progress` notifications are displayed for a short period with Sublime's `status_message(string)` method. Alternatively we could use `set_status(key, value)` for permanent status messages and `erase_status(key)` on notifications with `"kind": "end"`, but i think the former option might be better for very long background processes from the server to avoid unnecessary distraction.
* `cancellable?: boolean;` in `$/progress` notification is ignored because Sublime's UI has no simple cancel button. `window/workDoneProgress/cancel` would be used for that.

Tested with the Julia server:

![screenshot](https://user-images.githubusercontent.com/6579999/80926057-fd25a380-8d94-11ea-9f00-83d072e0453c.png)

(This requires to start the server like the following, to make the background indexing and corresponding progress notifications work:)
```json
"command": ["julia", "--startup-file=no", "--history-file=no", "-e", "using Pkg; using LanguageServer; using LanguageServer.SymbolServer; env_path=dirname(Pkg.Types.Context().env.project_file); server=LanguageServer.LanguageServerInstance(stdin,stdout,false,env_path); run(server)"],
```

I've also tried with `rust-analyzer`, but it only sends a single notification with `{'token': 'rustAnalyzer/startup', 'value': {'kind': 'end', 'message': 'rust-analyzer loaded, 1 packages'}}`, which isn't really usefull. Probably because I'm no Rust user and only tried with the syntax_test file from Sublime's Rust package, and the server complains with `rust-analyzer failed to discover workspace, no Cargo.toml found` beforehand.
Perhaps someone knows further servers which support `workDoneProgress` and `$/progress` notifications for testing purposes?