### PR TITLE
Extend test server with $test/sendNotification request handler

### DIFF
--- a/tests/server.py
+++ b/tests/server.py
@@ -283,11 +283,23 @@ class Session:
         self._on_notification("exit", self._on_exit)
 
         self._on_request("$test/getReceived", self._get_received)
+        self._on_request("$test/sendNotification", self._on_send_notification)
         self._on_notification("$test/setResponse", self._on_set_response)
 
     async def _on_set_response(self, params: PayloadLike) -> None:
         if isinstance(params, dict):
             self._responses[params["method"]] = params["response"]
+
+    async def _on_send_notification(self, params: PayloadLike) -> None:
+        if not isinstance(params, dict):
+            raise Error(ErrorCode.InvalidParams, "expected params to be a dictionary")
+        if "method" not in params:
+            raise Error(ErrorCode.InvalidParams, 'expected "method" key')
+        method = params["method"]
+        if not isinstance(method, str):
+            raise Error(ErrorCode.InvalidParams, 'expected "method" key to be a string')
+        self._notify(method, params.get('params'))
+        return None
 
     async def _get_received(self, params: PayloadLike) -> PayloadLike:
         if not isinstance(params, dict):

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -182,6 +182,22 @@ class TextDocumentTestCase(DeferrableTestCase):
         self.session.client.send_notification(
             Notification("$test/setResponse", {"method": method, "response": response}))
 
+    def await_client_notification(self, method: str, params: 'Any' = None) -> 'Generator':
+        self.assertIsNotNone(self.session)
+        assert self.session  # mypy
+        promise = YieldPromise()
+
+        def handler(params: 'Any') -> None:
+            assert params is None
+            promise.fulfill()
+
+        def error_handler(params: 'Any') -> None:
+            debug("Got error:", params, "awaiting timeout :(")
+
+        self.session.client.send_request(
+            Request("$test/sendNotification", {"method": method, "params": params}), handler, error_handler)
+        yield {"condition": promise, "timeout": TIMEOUT_TIME}
+
     def await_boilerplate_begin(self) -> 'Generator':
         yield from self.await_message("initialize")
         yield from self.await_message("initialized")


### PR DESCRIPTION
Part of my work on code actions on save where I will need that functionality to popular document diagnostics. Also might be useful for testing $/progress notifications, I imagine.

Allows to trigger any notification from tests.

For example if we want the server to send a 'textDocument/publishDiagnostics'
notification to populate view's diagnostics we'd do:

yield from self.await_client_notification('textDocument/publishDiagnostics', {'params': {}})

On the server side this is a request handler and not a notification handler
as I wanted to be able to await the result so that I would have guarantee
that the notification has been handled when "await_client_notification" call
returned.