### PR TITLE
Check changes to apply against initial view version (change count)

### DIFF
--- a/plugin/edit.py
+++ b/plugin/edit.py
@@ -41,10 +41,11 @@ class LspApplyDocumentEditCommand(sublime_plugin.TextCommand):
         # Apply the changes in reverse, so that we don't invalidate the range
         # of any change that we haven't applied yet.
         if changes:
+            view_version = self.view.change_count()
             last_row, last_col = self.view.rowcol(self.view.size())
             for change in reversed(sort_by_application_order(changes)):
                 start, end, newText, version = change
-                if version is not None and version != self.view.change_count():
+                if version is not None and version != view_version:
                     debug('ignoring edit due to non-matching document version')
                     continue
                 region = sublime.Region(self.view.text_point(*start), self.view.text_point(*end))

--- a/tests/test_code_actions.py
+++ b/tests/test_code_actions.py
@@ -1,0 +1,60 @@
+from LSP.plugin.core.protocol import Point, Range
+from LSP.plugin.core.url import filename_to_uri
+from LSP.plugin.core.views import entire_content
+from LSP.plugin.code_actions import run_code_action_or_command
+from setup import TextDocumentTestCase
+from test_single_document import TEST_FILE_PATH
+
+try:
+    from typing import Generator, Optional, Iterable, Tuple, List, Dict
+    assert Generator and Optional and Iterable and Tuple and List and Dict
+except ImportError:
+    pass
+
+TEST_FILE_URI = filename_to_uri(TEST_FILE_PATH)
+
+
+def create_test_code_actions(title: str, document_version: int, edits: 'List[Tuple[str, Range]]') -> 'Dict':
+    def edit_to_lsp(edit: 'Tuple[str, Range]') -> 'Dict':
+        new_text, range = edit
+        return {
+            "newText": new_text,
+            "range": range.to_lsp()
+        }
+    return {
+        "title": title,
+        "edit": {
+            "documentChanges": [
+                {
+                    "textDocument": {
+                        "uri": TEST_FILE_URI,
+                        "version": document_version
+                    },
+                    "edits": list(map(edit_to_lsp, edits))
+                }
+            ]
+        }
+    }
+
+
+class CodeActionsTestCase(TextDocumentTestCase):
+    def test_applies_code_actions(self) -> 'Generator':
+        self.insert_characters('a\nb')
+        yield from self.await_message("textDocument/didChange")
+        code_actions = create_test_code_actions("Fix errors", self.view.change_count(), [
+            ("c", Range(Point(0, 0), Point(0, 1))),
+            ("d", Range(Point(1, 0), Point(1, 1))),
+        ])
+        run_code_action_or_command(self.view, self.config.name, code_actions)
+        self.assertEquals(entire_content(self.view), 'c\nd')
+
+    def test_does_not_apply_with_nonmatching_document_version(self) -> 'Generator':
+        initial_content = 'a\nb'
+        self.insert_characters(initial_content)
+        yield from self.await_message("textDocument/didChange")
+        code_actions = create_test_code_actions("Fix errors", 0, [
+            ("c", Range(Point(0, 0), Point(0, 1))),
+            ("d", Range(Point(1, 0), Point(1, 1))),
+        ])
+        run_code_action_or_command(self.view, self.config.name, code_actions)
+        self.assertEquals(entire_content(self.view), initial_content)

--- a/tests/test_code_actions.py
+++ b/tests/test_code_actions.py
@@ -1,21 +1,16 @@
 from LSP.plugin.core.protocol import Point, Range
+from LSP.plugin.core.typing import Dict, Generator, List, Tuple
 from LSP.plugin.core.url import filename_to_uri
 from LSP.plugin.core.views import entire_content
 from LSP.plugin.code_actions import run_code_action_or_command
 from setup import TextDocumentTestCase
 from test_single_document import TEST_FILE_PATH
 
-try:
-    from typing import Generator, Optional, Iterable, Tuple, List, Dict
-    assert Generator and Optional and Iterable and Tuple and List and Dict
-except ImportError:
-    pass
-
 TEST_FILE_URI = filename_to_uri(TEST_FILE_PATH)
 
 
-def create_test_code_actions(document_version: int, edits: 'List[Tuple[str, Range]]') -> 'Dict':
-    def edit_to_lsp(edit: 'Tuple[str, Range]') -> 'Dict':
+def create_test_code_actions(document_version: int, edits: List[Tuple[str, Range]]) -> Dict:
+    def edit_to_lsp(edit: Tuple[str, Range]) -> Dict:
         new_text, range = edit
         return {
             "newText": new_text,
@@ -38,7 +33,7 @@ def create_test_code_actions(document_version: int, edits: 'List[Tuple[str, Rang
 
 
 class CodeActionsTestCase(TextDocumentTestCase):
-    def test_applies_code_actions(self) -> 'Generator':
+    def test_applies_code_actions(self) -> Generator:
         self.insert_characters('a\nb')
         yield from self.await_message("textDocument/didChange")
         code_actions = create_test_code_actions(self.view.change_count(), [
@@ -48,7 +43,7 @@ class CodeActionsTestCase(TextDocumentTestCase):
         run_code_action_or_command(self.view, self.config.name, code_actions)
         self.assertEquals(entire_content(self.view), 'c\nd')
 
-    def test_does_not_apply_with_nonmatching_document_version(self) -> 'Generator':
+    def test_does_not_apply_with_nonmatching_document_version(self) -> Generator:
         initial_content = 'a\nb'
         self.insert_characters(initial_content)
         yield from self.await_message("textDocument/didChange")

--- a/tests/test_code_actions.py
+++ b/tests/test_code_actions.py
@@ -14,7 +14,7 @@ except ImportError:
 TEST_FILE_URI = filename_to_uri(TEST_FILE_PATH)
 
 
-def create_test_code_actions(title: str, document_version: int, edits: 'List[Tuple[str, Range]]') -> 'Dict':
+def create_test_code_actions(document_version: int, edits: 'List[Tuple[str, Range]]') -> 'Dict':
     def edit_to_lsp(edit: 'Tuple[str, Range]') -> 'Dict':
         new_text, range = edit
         return {
@@ -22,7 +22,7 @@ def create_test_code_actions(title: str, document_version: int, edits: 'List[Tup
             "range": range.to_lsp()
         }
     return {
-        "title": title,
+        "title": "Fix errors",
         "edit": {
             "documentChanges": [
                 {
@@ -41,7 +41,7 @@ class CodeActionsTestCase(TextDocumentTestCase):
     def test_applies_code_actions(self) -> 'Generator':
         self.insert_characters('a\nb')
         yield from self.await_message("textDocument/didChange")
-        code_actions = create_test_code_actions("Fix errors", self.view.change_count(), [
+        code_actions = create_test_code_actions(self.view.change_count(), [
             ("c", Range(Point(0, 0), Point(0, 1))),
             ("d", Range(Point(1, 0), Point(1, 1))),
         ])
@@ -52,7 +52,7 @@ class CodeActionsTestCase(TextDocumentTestCase):
         initial_content = 'a\nb'
         self.insert_characters(initial_content)
         yield from self.await_message("textDocument/didChange")
-        code_actions = create_test_code_actions("Fix errors", 0, [
+        code_actions = create_test_code_actions(0, [
             ("c", Range(Point(0, 0), Point(0, 1))),
             ("d", Range(Point(1, 0), Point(1, 1))),
         ])


### PR DESCRIPTION
With multiple changes to apply, first change would change view version
and later changes would not longer apply.

I've played myself here before. This really made code-actions-on-save unusable. :)