### PR TITLE
Code actions on save - WIP

### DIFF
--- a/Keymaps/Default (Linux).sublime-keymap
+++ b/Keymaps/Default (Linux).sublime-keymap
@@ -62,4 +62,7 @@
 
     // Symbol Hover
     // {"keys": ["UNBOUND"], "command": "lsp_hover", "context": [{"key": "setting.lsp_active"}]},
+
+    // Code actions on save
+    { "keys": ["ctrl+s"], "command": "lsp_save", "context": [{ "key": "setting.lsp_active"}] },
 ]

--- a/Keymaps/Default (OSX).sublime-keymap
+++ b/Keymaps/Default (OSX).sublime-keymap
@@ -62,4 +62,7 @@
 
     // Symbol Hover
     // {"keys": ["UNBOUND"], "command": "lsp_hover", "context": [{"key": "setting.lsp_active"}]},
+
+    // Code actions on save
+    { "keys": ["super+s"], "command": "lsp_save", "context": [{ "key": "setting.lsp_active"}] },
 ]

--- a/Keymaps/Default (Windows).sublime-keymap
+++ b/Keymaps/Default (Windows).sublime-keymap
@@ -62,4 +62,7 @@
 
     // Symbol Hover
     // {"keys": ["UNBOUND"], "command": "lsp_hover", "context": [{"key": "setting.lsp_active"}]},
+
+    // Code actions on save
+    { "keys": ["ctrl+s"], "command": "lsp_save", "context": [{ "key": "setting.lsp_active"}] },
 ]

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -8,6 +8,19 @@
   // Valid values are "never", "always" and "saved"
   "auto_show_diagnostics_panel": "saved",
 
+  // A dictionary of code action identifiers that should be triggered on save.
+  //
+  // Code action identifiers are not officially standardized so refer to specific
+  // server's documentation on what is supported but `source.fixAll` is commonly
+  // used to apply fix-on-save code action.
+  //
+  // It's also supported to set this in project-specific settings in which case
+  // it will only apply in the that project. Setting it here will apply globally
+  // unless overridden by project-specific settings.
+  //
+  // Only "source.*" actions are supported.
+  "lsp_code_actions_on_save": {},
+
   // Open the diagnostics panel automatically
   // when diagnostics level is equal to or less than:
   // error: 1

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -21,6 +21,9 @@
   // Only "source.*" actions are supported.
   "lsp_code_actions_on_save": {},
 
+  // The amount of time the code actions on save are allowed to run for.
+  "code_action_on_save_timeout_ms": 2000,
+
   // Open the diagnostics panel automatically
   // when diagnostics level is equal to or less than:
   // error: 1

--- a/boot.py
+++ b/boot.py
@@ -1,7 +1,7 @@
 # Please keep this list sorted (Edit -> Sort Lines)
 from .plugin.code_actions import LspCodeActionBulbListener
-from .plugin.code_actions import LspCodeActionsOnSaveListener
 from .plugin.code_actions import LspCodeActionsCommand
+from .plugin.code_actions import LspSaveCommand
 from .plugin.color import LspColorListener
 from .plugin.completion import CompletionHandler
 from .plugin.completion import CompletionHelper

--- a/boot.py
+++ b/boot.py
@@ -1,5 +1,6 @@
 # Please keep this list sorted (Edit -> Sort Lines)
 from .plugin.code_actions import LspCodeActionBulbListener
+from .plugin.code_actions import LspCodeActionsOnSaveListener
 from .plugin.code_actions import LspCodeActionsCommand
 from .plugin.color import LspColorListener
 from .plugin.completion import CompletionHandler

--- a/docs/features.md
+++ b/docs/features.md
@@ -99,6 +99,7 @@ https://stackoverflow.com/questions/16235706/sublime-3-set-key-map-for-function-
 Add these settings to your Sublime settings, Syntax-specific settings and/or in Project files.
 
 * `lsp_format_on_save` `false` *run the server's formatProvider (if supported) on a document before saving.*
+* `lsp_code_actions_on_save` `{}` *request code actions with specified identifiers to trigger before saving.*
 
 ### Package settings (LSP)
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -105,6 +105,7 @@ Add these settings to your Sublime settings, Syntax-specific settings and/or in 
 
 * `complete_all_chars` `true` *request completions for all characters, not just trigger characters*
 * `only_show_lsp_completions` `false` *disable sublime word completion and snippets from autocomplete lists*
+* `code_action_on_save_timeout_ms` `2000` *the amount of time the code actions on save are allowed to run for*
 * `completion_hint_type` `"auto"` *override automatic completion hints with "detail", "kind" or "none"*
 * `show_references_in_quick_panel` `false` *show symbol references in Sublime's quick panel instead of the bottom panel*
 * `show_view_status` `true` *show permanent language server status in the status bar*

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -129,8 +129,8 @@ def request_code_actions_on_save(
                 if matching_kinds:
                     params = _create_code_action_request_params(view, file_name, [], matching_kinds)
                     request = Request.codeAction(params)
-                    session.client.send_request(
-                        request, filtering_collector(session.config.name, matching_kinds, actions_collector))
+                    session_collector = filtering_collector(session.config.name, matching_kinds, actions_collector)
+                    session.client.send_request(request, session_collector, lambda error: session_collector([]))
     return actions_collector
 
 

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -240,14 +240,13 @@ class CodeActionTask():
     def _handle_response(self, responses: CodeActionsByConfigName) -> None:
         if self._canceled:
             return
-        ran_code_action_or_command = False
+        document_version = self._view.change_count()
         for config_name, code_actions in responses.items():
             if code_actions:
                 print('CODE_ACTIONS (config: {})'.format(config_name), code_actions)
                 for code_action in code_actions:
-                    ran_code_action_or_command = True
                     run_code_action_or_command(self._view, config_name, code_action)
-        if ran_code_action_or_command:
+        if document_version != self._view.change_count():
             self._run_code_actions()
         else:
             self._on_complete()

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -1,60 +1,68 @@
 import sublime
-import sublime_plugin
 from .core.edit import parse_workspace_edit
 from .core.protocol import Diagnostic
 from .core.protocol import Request, Point
-from .core.registry import LspTextCommand
+from .core.registry import LspTextCommand, LSPViewEventListener
 from .core.registry import sessions_for_view, client_from_session
 from .core.settings import settings
 from .core.typing import Any, List, Dict, Callable, Optional, Union, Tuple, Mapping, TypedDict
 from .core.url import filename_to_uri
-from .core.views import region_to_range
+from .core.views import entire_content_range, region_to_range
 from .diagnostics import filter_by_point, view_diagnostics
 
 CodeActionOrCommand = TypedDict('CodeActionOrCommand', {
     'title': str,
     'command': Union[dict, str],
-    'edit': dict
+    'edit': dict,
+    'kind': Optional[str]
 }, total=False)
 CodeActionsResponse = Optional[List[CodeActionOrCommand]]
 CodeActionsByConfigName = Dict[str, List[CodeActionOrCommand]]
 
 
-class CodeActionsAtLocation(object):
-
-    def __init__(self, on_complete_handler: Callable[[CodeActionsByConfigName], None]) -> None:
+class CodeActionsCollector(object):
+    def __init__(self, on_complete_handler: Callable[[CodeActionsByConfigName], None]):
+        self._on_complete_handler = on_complete_handler
         self._commands_by_config = {}  # type: CodeActionsByConfigName
         self._requested_configs = []  # type: List[str]
-        self._on_complete_handler = on_complete_handler
 
-    def collect(self, config_name: str) -> Callable[[CodeActionsResponse], None]:
-        self._requested_configs.append(config_name)
-        return lambda actions: self.store(config_name, actions)
+    def create_sync_collector(self, config_name: str) -> Callable[[CodeActionsResponse], None]:
+        return lambda actions: self._collect(config_name, actions)
 
-    def store(self, config_name: str, actions: CodeActionsResponse) -> None:
+    def _collect(self, config_name: str, actions: CodeActionsResponse) -> None:
         self._commands_by_config[config_name] = actions or []
-        if len(self._requested_configs) == len(self._commands_by_config):
-            self._on_complete_handler(self._commands_by_config)
 
-    def deliver(self, recipient_handler: Callable[[CodeActionsByConfigName], None]) -> None:
-        recipient_handler(self._commands_by_config)
+    def create_async_collector(self, config_name: str) -> Callable[[CodeActionsResponse], None]:
+        self._requested_configs.append(config_name)
+        return lambda actions: self._collect_async(config_name, actions)
+
+    def _collect_async(self, config_name: str, actions: CodeActionsResponse) -> None:
+        self._collect(config_name, actions)
+        if len(self._requested_configs) == len(self._commands_by_config):
+            self.deliver()
+
+    def get_actions(self) -> CodeActionsByConfigName:
+        return self._commands_by_config
+
+    def deliver(self) -> None:
+        self._on_complete_handler(self._commands_by_config)
 
 
 class CodeActionsManager(object):
     """ Collects and caches code actions"""
 
     def __init__(self) -> None:
-        self._requests = {}  # type: Dict[str, CodeActionsAtLocation]
+        self._requests = {}  # type: Dict[str, CodeActionsCollector]
 
-    def request(self, view: sublime.View, point: int,
-                actions_handler: Callable[[CodeActionsByConfigName], None]) -> None:
+    def request(self, view: sublime.View,
+                actions_handler: Callable[[CodeActionsByConfigName], None], point: int) -> None:
         current_location = self.get_location_key(view, point)
         # debug("requesting actions for {}".format(current_location))
         if current_location in self._requests:
-            self._requests[current_location].deliver(actions_handler)
+            actions_handler(self._requests[current_location].get_actions())
         else:
             self._requests.clear()
-            self._requests[current_location] = request_code_actions(view, point, actions_handler)
+            self._requests[current_location] = request_code_actions(view, actions_handler, point)
 
     def get_location_key(self, view: sublime.View, point: int) -> str:
         return "{}#{}:{}".format(view.file_name(), view.change_count(), point)
@@ -63,43 +71,145 @@ class CodeActionsManager(object):
 actions_manager = CodeActionsManager()
 
 
-def request_code_actions(view: sublime.View, point: int,
-                         actions_handler: Callable[[CodeActionsByConfigName], None]) -> CodeActionsAtLocation:
-    diagnostics_by_config = filter_by_point(view_diagnostics(view), Point(*view.rowcol(point)))
-    return request_code_actions_with_diagnostics(view, diagnostics_by_config, actions_handler)
-
-
-def request_code_actions_with_diagnostics(
+def request_code_actions(
     view: sublime.View,
-    diagnostics_by_config: Dict[str, List[Diagnostic]],
-    actions_handler: Callable[[CodeActionsByConfigName], None]
-) -> CodeActionsAtLocation:
-    actions_at_location = CodeActionsAtLocation(actions_handler)
-    for session in sessions_for_view(view, 'codeActionProvider'):
-        if session.config.name in diagnostics_by_config:
-            point_diagnostics = diagnostics_by_config[session.config.name]
-            file_name = view.file_name()
-            relevant_range = point_diagnostics[0].range if point_diagnostics else region_to_range(
-                view,
-                view.sel()[0])
-            if file_name:
-                params = {
-                    "textDocument": {
-                        "uri": filename_to_uri(file_name)
-                    },
-                    "range": relevant_range.to_lsp(),
-                    "context": {
-                        "diagnostics": list(diagnostic.to_lsp() for diagnostic in point_diagnostics)
-                    }
-                }
-                if session.client:
-                    session.client.send_request(
-                        Request.codeAction(params),
-                        actions_at_location.collect(session.config.name))
-    return actions_at_location
+    actions_handler: Callable[[CodeActionsByConfigName], None],
+    point: int,
+) -> CodeActionsCollector:
+    actions_collector = CodeActionsCollector(actions_handler)
+    file_name = view.file_name()
+    if file_name:
+        diagnostics_by_config = filter_by_point(view_diagnostics(view), Point(*view.rowcol(point)))
+        sessions = [session for session in sessions_for_view(view, 'codeActionProvider') if session.client]
+        for session in sessions:
+            config_name = session.config.name
+            if config_name in diagnostics_by_config:
+                diagnostics = diagnostics_by_config[config_name]
+                request = Request.codeAction(_create_code_action_request_params(view, file_name, diagnostics))
+                session.client.send_request(request, actions_collector.create_async_collector(config_name))
+    return actions_collector
 
 
-class LspCodeActionBulbListener(sublime_plugin.ViewEventListener):
+def request_code_actions_on_save(
+    view: sublime.View,
+    actions_handler: Callable[[CodeActionsByConfigName], None],
+    on_save_actions: Dict[str, bool]
+) -> CodeActionsCollector:
+    def actions_filter(config_name: str, kinds: List[str], actions: CodeActionsResponse) -> None:
+        """
+        Filters actions returned from server so that only matching kinds are collected.
+
+        Since older servers don't support the "context.only" property, they will return all
+        actions regardless of what is requested.
+        """
+        matching_actions = [a for a in (actions or []) if a.get('kind') in kinds]
+        actions_collector.create_sync_collector(session.config.name)(matching_actions)
+
+    actions_collector = CodeActionsCollector(actions_handler)
+    file_name = view.file_name()
+    if file_name:
+        sessions = [session for session in sessions_for_view(view, 'codeActionProvider') if session.client]
+        for session in sessions:
+            supported_kinds = session.get_capability('codeActionProvider.codeActionKinds')
+            matching_kinds = get_matching_kinds(on_save_actions, supported_kinds or [])
+            if matching_kinds:
+                params = _create_code_action_request_params(view, file_name, [], matching_kinds)
+                request = Request.codeAction(params)
+                session.client.execute_request(
+                    request, lambda actions: actions_filter(session.config.name, matching_kinds, actions))
+    return actions_collector
+
+
+def _create_code_action_request_params(
+    view: sublime.View,
+    file_name: str,
+    diagnostics: List[Diagnostic],
+    on_save_actions: Optional[List[str]] = None
+) -> Dict:
+    if on_save_actions:
+        relevant_range = entire_content_range(view)
+    else:
+        relevant_range = diagnostics[0].range if diagnostics else region_to_range(view, view.sel()[0])
+    params = {
+        "textDocument": {
+            "uri": filename_to_uri(file_name)
+        },
+        "range": relevant_range.to_lsp(),
+        "context": {
+            "diagnostics": list(diagnostic.to_lsp() for diagnostic in diagnostics)
+        }
+    }
+    if on_save_actions:
+        params['context']['only'] = on_save_actions
+    return params
+
+
+def get_matching_kinds(user_actions: Dict[str, bool], session_actions: List[str]) -> List[str]:
+    """
+    Filters user-enabled or disabled actions so that only ones matching the session actions
+    are returned. Returned actions are those that are enabled and are not overridden by more
+    specific disabled actions.
+
+    Filtering only returns actions that exactly match ones supported by given session.
+    If user has enabled a generic action that matches more specific session action
+    (for example user's a.b matching session's a.b.c), then the more specific (a.b.c) must be
+    returned as servers must receive only actions that they advertise support for.
+    """
+    matching_kinds = []
+    for session_action in session_actions:
+        enabled = False
+        action_parts = session_action.split('.')
+        for i in range(len(action_parts)):
+            current_part = '.'.join(action_parts[0:i + 1])
+            user_value = user_actions.get(current_part, None)
+            if isinstance(user_value, bool):
+                enabled = user_value
+        if enabled:
+            matching_kinds.append(session_action)
+    return matching_kinds
+
+
+class LspCodeActionsOnSaveListener(LSPViewEventListener):
+    @classmethod
+    def is_applicable(cls, view_settings: dict) -> bool:
+        return cls.has_enabled_code_actions_on_save(view_settings)
+
+    @classmethod
+    def has_enabled_code_actions_on_save(cls, view_settings: Union[dict, sublime.Settings]) -> bool:
+        actions = cls.get_code_actions_on_save(view_settings)
+        return any(enabled for action, enabled in actions.items())
+
+    @classmethod
+    def get_code_actions_on_save(cls, view_settings: Union[dict, sublime.Settings]) -> Dict[str, bool]:
+        view_code_actions = view_settings.get('lsp_code_actions_on_save') or {}
+        code_actions = settings.lsp_code_actions_on_save.copy()
+        code_actions.update(view_code_actions)
+        allowed_code_actions = dict()
+        for key, value in code_actions.items():
+            if key.startswith('source.'):
+                allowed_code_actions[key] = value
+        return allowed_code_actions
+
+    def on_pre_save(self) -> None:
+        if self.view.file_name():
+            self.trigger_code_actions()
+
+    def trigger_code_actions(self) -> None:
+        on_save_actions = self.get_code_actions_on_save(self.view.settings())
+        if on_save_actions:
+            self.manager.documents.purge_changes(self.view)
+            collector = request_code_actions_on_save(self.view, self.handle_response, on_save_actions)
+            collector.deliver()
+
+    def handle_response(self, responses: CodeActionsByConfigName) -> None:
+        for config_name, code_actions in responses.items():
+            if code_actions:
+                print('CODE_ACTIONS (config: {})'.format(config_name), code_actions)
+                for code_action in code_actions:
+                    run_code_action_or_command(self.view, config_name, code_action)
+
+
+class LspCodeActionBulbListener(LSPViewEventListener):
     def __init__(self, view: sublime.View) -> None:
         super().__init__(view)
         self._stored_region = sublime.Region(-1, -1)
@@ -107,9 +217,7 @@ class LspCodeActionBulbListener(sublime_plugin.ViewEventListener):
 
     @classmethod
     def is_applicable(cls, _settings: dict) -> bool:
-        if settings.show_code_actions_bulb:
-            return True
-        return False
+        return settings.show_code_actions_bulb
 
     def on_selection_modified_async(self) -> None:
         self.hide_bulb()
@@ -127,7 +235,7 @@ class LspCodeActionBulbListener(sublime_plugin.ViewEventListener):
     def fire_request(self, current_region: sublime.Region) -> None:
         if current_region == self._stored_region:
             self._actions = []
-            actions_manager.request(self.view, current_region.begin(), self.handle_responses)
+            actions_manager.request(self.view, self.handle_responses, current_region.begin())
 
     def handle_responses(self, responses: CodeActionsByConfigName) -> None:
         for _, items in responses.items():
@@ -186,7 +294,7 @@ class LspCodeActionsCommand(LspTextCommand):
     def run(self, edit: sublime.Edit) -> None:
         self.commands = []  # type: List[Tuple[str, str, CodeActionOrCommand]]
         self.commands_by_config = {}  # type: CodeActionsByConfigName
-        actions_manager.request(self.view, self.view.sel()[0].begin(), self.handle_responses)
+        actions_manager.request(self.view, self.handle_responses, self.view.sel()[0].begin())
 
     def combine_commands(self) -> 'List[Tuple[str, str, CodeActionOrCommand]]':
         results = []

--- a/plugin/core/rpc.py
+++ b/plugin/core/rpc.py
@@ -356,14 +356,18 @@ class Client(object):
         elif self._sync_request_result.is_requesting():
             if self._sync_request_result.request_id() == response_id:
                 if is_error:
+                    print('DEFERRED is_error', is_error, result)
                     self._sync_request_result.set_error(response_id, result)
                 else:
+                    print('DEFERRED set result', result)
                     self._sync_request_result.set(response_id, result)
                 self._sync_request_cvar.notify()
             else:
+                print('DEFERRED defer response (is_requesting)', response_id, result)
                 self._deferred_responses.append((handler, result))
             return (None, result)
         else:  # self._sync_request_result.is_ready()
+            print('DEFERRED defer response (is_ready)', response_id, result)
             self._deferred_responses.append((handler, result))
             return (None, None)
         if handler:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -82,7 +82,7 @@ def get_initialize_params(workspace_folders: List[WorkspaceFolder], config: Clie
                 "dynamicRegistration": True,
                 "codeActionLiteralSupport": {
                     "codeActionKind": {
-                        "valueSet": []
+                        "valueSet": ["quickfix", "refactor"]
                     }
                 }
             },
@@ -367,6 +367,10 @@ class Session(object):
         execute_commands = self.get_capability('executeCommandProvider.commands')
         if execute_commands:
             debug("{}: Supported execute commands: {}".format(self.config.name, execute_commands))
+
+        code_action_kinds = self.get_capability('codeActionProvider.codeActionKinds')
+        if code_action_kinds:
+            debug('{}: supported code action kinds: {}'.format(self.config.name, code_action_kinds))
 
     def _handle_request_workspace_folders(self, _: Any, request_id: Any) -> None:
         self.client.send_response(Response(request_id, [wf.to_lsp() for wf in self._workspace_folders]))

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -83,6 +83,7 @@ def update_settings(settings: Settings, settings_obj: sublime.Settings) -> None:
     settings.log_server = read_bool_setting(settings_obj, "log_server", True)
     settings.log_stderr = read_bool_setting(settings_obj, "log_stderr", False)
     settings.log_payloads = read_bool_setting(settings_obj, "log_payloads", False)
+    settings.lsp_code_actions_on_save = read_dict_setting(settings_obj, "lsp_code_actions_on_save", {})
 
 
 class ClientConfigs(object):

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -84,6 +84,7 @@ def update_settings(settings: Settings, settings_obj: sublime.Settings) -> None:
     settings.log_stderr = read_bool_setting(settings_obj, "log_stderr", False)
     settings.log_payloads = read_bool_setting(settings_obj, "log_payloads", False)
     settings.lsp_code_actions_on_save = read_dict_setting(settings_obj, "lsp_code_actions_on_save", {})
+    settings.code_action_on_save_timeout_ms = read_int_setting(settings_obj, "code_action_on_save_timeout_ms", 2000)
 
 
 class ClientConfigs(object):

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -30,6 +30,7 @@ class Settings(object):
         self.log_server = True
         self.log_stderr = False
         self.log_payloads = False
+        self.lsp_code_actions_on_save = {}  # type: Dict[str, bool]
 
 
 class ClientStates(object):

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -31,6 +31,7 @@ class Settings(object):
         self.log_stderr = False
         self.log_payloads = False
         self.lsp_code_actions_on_save = {}  # type: Dict[str, bool]
+        self.code_action_on_save_timeout_ms = 2000
 
 
 class ClientStates(object):

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -82,6 +82,10 @@ def entire_content(view: sublime.View) -> str:
     return view.substr(sublime.Region(0, view.size()))
 
 
+def entire_content_range(view: sublime.View) -> Range:
+    return region_to_range(view, sublime.Region(0, view.size()))
+
+
 def text_document_item(view: sublime.View, language_id: str) -> Dict[str, Any]:
     return {
         "uri": uri_from_view(view),

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -107,7 +107,7 @@ class LspHoverCommand(LspTextCommand):
                     lambda response: self.handle_response(response, point))
 
     def request_code_actions(self, point: int) -> None:
-        actions_manager.request(self.view, point, lambda response: self.handle_code_actions(response, point))
+        actions_manager.request(self.view, lambda response: self.handle_code_actions(response, point), point)
 
     def handle_code_actions(self, responses: Dict[str, List[CodeActionOrCommand]], point: int) -> None:
         self._actions_by_config = responses

--- a/tests/adjust_unittesting_config_for_ci.py
+++ b/tests/adjust_unittesting_config_for_ci.py
@@ -14,6 +14,7 @@ if __name__ == '__main__':
             "start_coverage_after_reload": False,
             "show_reload_progress": False,
             "output": None,
+            "pattern": "test_code_actions.py",
             "generate_html_report": False
         }
         json.dump(config, fp, indent=4)

--- a/tests/server.py
+++ b/tests/server.py
@@ -226,7 +226,7 @@ class Session:
                 self._reply(request_id, self._responses.pop(method))
             elif request_id is not None:
                 self._error(request_id, Error(
-                    ErrorCode.MethodNotFound, "method not found"))
+                    ErrorCode.MethodNotFound, "method '{}' not found".format(method)))
             else:
                 if unhandled:
                     self._log(f"unhandled {typestr} {method}")

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -1,12 +1,11 @@
 from LSP.plugin.core.documents import DocumentSyncListener
 from LSP.plugin.core.logging import debug
-from LSP.plugin.core.protocol import Notification, Request, WorkspaceFolder
+from LSP.plugin.core.protocol import Notification, Request
 from LSP.plugin.core.registry import windows
 from LSP.plugin.core.sessions import Session
 from LSP.plugin.core.settings import client_configs
 from LSP.plugin.core.types import ClientConfig, LanguageConfig, ClientStates
 from os import environ
-from os.path import dirname
 from os.path import join
 from sublime_plugin import view_event_listeners
 from test_mocks import basic_responses
@@ -16,9 +15,6 @@ import sublime
 
 CI = any(key in environ for key in ("TRAVIS", "CI", "GITHUB_ACTIONS"))
 
-project_path = dirname(__file__)
-test_file_path = join(project_path, "testfile.txt")
-workspace_folders = [WorkspaceFolder.from_path(project_path)]
 TIMEOUT_TIME = 10000 if CI else 2000
 SUPPORTED_SCOPE = "text.plain"
 SUPPORTED_SYNTAX = "Packages/Text/Plain text.tmLanguage"

--- a/tests/test_code_actions.py
+++ b/tests/test_code_actions.py
@@ -79,6 +79,7 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
         self.view.run_command('lsp_save')
         yield from self.await_message('textDocument/codeAction')
         self.assertEquals(entire_content(self.view), 'const x = 1;')
+        self.assertEquals(self.view.is_dirty(), False)
 
     def test_applies_immediately_after_text_change(self) -> Generator:
         self.insert_characters('const x = 1')
@@ -92,12 +93,14 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
         self.view.run_command('lsp_save')
         yield from self.await_message('textDocument/codeAction')
         self.assertEquals(entire_content(self.view), 'const x = 1;')
+        self.assertEquals(self.view.is_dirty(), False)
 
     def test_no_fix_on_non_matching_kind(self) -> Generator:
         yield from self._setup_document_with_missing_semicolon()
         initial_content = 'const x = 1'
         self.view.run_command('lsp_save')
         self.assertEquals(entire_content(self.view), initial_content)
+        self.assertEquals(self.view.is_dirty(), True)
 
     def test_does_not_apply_unsupported_kind(self) -> Generator:
         yield from self._setup_document_with_missing_semicolon()

--- a/tests/test_code_actions.py
+++ b/tests/test_code_actions.py
@@ -167,6 +167,7 @@ class CodeActionsTestCase(TextDocumentTestCase):
         self.assertEquals(entire_content(self.view), initial_content)
 
     # Keep this test last as it breaks pyls!
+    @unittest.skip("not compatible with ST3")
     def test_applies_correctly_after_emoji(self) -> Generator:
         self.insert_characters('🕵️hi')
         yield from self.await_message("textDocument/didChange")

--- a/tests/test_code_actions.py
+++ b/tests/test_code_actions.py
@@ -76,7 +76,7 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
             code_action_kind
         )
         self.set_response('textDocument/codeAction', [code_action])
-        self.view.run_command('save')
+        self.view.run_command('lsp_save')
         yield from self.await_message('textDocument/codeAction')
         self.assertEquals(entire_content(self.view), 'const x = 1;')
 
@@ -89,14 +89,14 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
             code_action_kind
         )
         self.set_response('textDocument/codeAction', [code_action])
-        self.view.run_command('save')
+        self.view.run_command('lsp_save')
         yield from self.await_message('textDocument/codeAction')
         self.assertEquals(entire_content(self.view), 'const x = 1;')
 
     def test_no_fix_on_non_matching_kind(self) -> Generator:
         yield from self._setup_document_with_missing_semicolon()
         initial_content = 'const x = 1'
-        self.view.run_command('save')
+        self.view.run_command('lsp_save')
         self.assertEquals(entire_content(self.view), initial_content)
 
     def test_does_not_apply_unsupported_kind(self) -> Generator:
@@ -108,7 +108,7 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
             code_action_kind
         )
         self.set_response('textDocument/codeAction', [code_action])
-        self.view.run_command('save')
+        self.view.run_command('lsp_save')
         self.assertEquals(entire_content(self.view), 'const x = 1')
 
     def _setup_document_with_missing_semicolon(self) -> Generator:

--- a/tests/test_code_actions.py
+++ b/tests/test_code_actions.py
@@ -1,22 +1,25 @@
+from copy import deepcopy
+import unittest
 from LSP.plugin.core.protocol import Point, Range
 from LSP.plugin.core.typing import Dict, Generator, List, Tuple
 from LSP.plugin.core.url import filename_to_uri
 from LSP.plugin.core.views import entire_content
 from LSP.plugin.code_actions import run_code_action_or_command
+from LSP.plugin.code_actions import get_matching_kinds
 from setup import TextDocumentTestCase
 from test_single_document import TEST_FILE_PATH
 
 TEST_FILE_URI = filename_to_uri(TEST_FILE_PATH)
 
 
-def create_test_code_actions(document_version: int, edits: List[Tuple[str, Range]]) -> Dict:
+def create_test_code_action(document_version: int, edits: List[Tuple[str, Range]], kind: str = None) -> Dict:
     def edit_to_lsp(edit: Tuple[str, Range]) -> Dict:
         new_text, range = edit
         return {
             "newText": new_text,
             "range": range.to_lsp()
         }
-    return {
+    action = {
         "title": "Fix errors",
         "edit": {
             "documentChanges": [
@@ -30,26 +33,145 @@ def create_test_code_actions(document_version: int, edits: List[Tuple[str, Range
             ]
         }
     }
+    if kind:
+        action['kind'] = kind
+    return action
+
+
+def create_test_diagnostics(diagnostics: List[Tuple[str, Range]]) -> Dict:
+    def diagnostic_to_lsp(diagnostic: Tuple[str, Range]) -> Dict:
+        message, range = diagnostic
+        return {
+            "message": message,
+            "range": range.to_lsp()
+        }
+    return {
+        "uri": TEST_FILE_URI,
+        "diagnostics": list(map(diagnostic_to_lsp, diagnostics))
+    }
+
+
+class CodeActionsOnSaveTestCase(TextDocumentTestCase):
+    def setUp(self) -> Generator:
+        yield from super().setUp()
+        # "quickfix" is not supported but its here for testing purposes
+        self.view.settings().set('lsp_code_actions_on_save', {'source.fixAll': True, 'quickfix': True})
+
+    def tearDown(self) -> Generator:
+        yield from self.await_clear_view_and_save()
+        self.view.settings().set('lsp_code_actions_on_save', {})
+        yield from super().tearDown()
+
+    def get_test_server_capabilities(self) -> dict:
+        capabilities = deepcopy(super().get_test_server_capabilities())
+        capabilities['capabilities']['codeActionProvider'] = {'codeActionKinds': ['quickfix', 'source.fixAll']}
+        return capabilities
+
+    def test_applies_matching_kind(self) -> Generator:
+        yield from self._setup_document_with_missing_semicolon()
+        code_action_kind = 'source.fixAll'
+        code_action = create_test_code_action(
+            self.view.change_count(),
+            [(';', Range(Point(0, 11), Point(0, 11)))],
+            code_action_kind
+        )
+        self.set_response('textDocument/codeAction', [code_action])
+        self.view.run_command('save')
+        yield from self.await_message('textDocument/codeAction')
+        self.assertEquals(entire_content(self.view), 'const x = 1;')
+
+    def test_applies_immediately_after_text_change(self) -> Generator:
+        self.insert_characters('const x = 1')
+        code_action_kind = 'source.fixAll'
+        code_action = create_test_code_action(
+            self.view.change_count(),
+            [(';', Range(Point(0, 11), Point(0, 11)))],
+            code_action_kind
+        )
+        self.set_response('textDocument/codeAction', [code_action])
+        self.view.run_command('save')
+        yield from self.await_message('textDocument/codeAction')
+        self.assertEquals(entire_content(self.view), 'const x = 1;')
+
+    def test_no_fix_on_non_matching_kind(self) -> Generator:
+        yield from self._setup_document_with_missing_semicolon()
+        initial_content = 'const x = 1'
+        self.view.run_command('save')
+        self.assertEquals(entire_content(self.view), initial_content)
+
+    def test_does_not_apply_unsupported_kind(self) -> Generator:
+        yield from self._setup_document_with_missing_semicolon()
+        code_action_kind = 'quickfix'
+        code_action = create_test_code_action(
+            self.view.change_count(),
+            [(';', Range(Point(0, 11), Point(0, 11)))],
+            code_action_kind
+        )
+        self.set_response('textDocument/codeAction', [code_action])
+        self.view.run_command('save')
+        self.assertEquals(entire_content(self.view), 'const x = 1')
+
+    def _setup_document_with_missing_semicolon(self) -> Generator:
+        self.insert_characters('const x = 1')
+        yield from self.await_message("textDocument/didChange")
+        yield from self.await_client_notification(
+            "textDocument/publishDiagnostics",
+            create_test_diagnostics([
+                ('Missing semicolon', Range(Point(0, 11), Point(0, 11))),
+            ])
+        )
+
+
+class CodeActionMatchingTestCase(unittest.TestCase):
+    def test_does_not_match(self) -> None:
+        actual = get_matching_kinds({'a.x': True}, ['a.b'])
+        expected = []  # type: List[str]
+        self.assertEquals(actual, expected)
+
+    def test_matches_exact_action(self) -> None:
+        actual = get_matching_kinds({'a.b': True}, ['a.b'])
+        expected = ['a.b']
+        self.assertEquals(actual, expected)
+
+    def test_matches_more_specific_action(self) -> None:
+        actual = get_matching_kinds({'a.b': True}, ['a.b.c'])
+        expected = ['a.b.c']
+        self.assertEquals(actual, expected)
+
+    def test_does_not_match_disabled_action(self) -> None:
+        actual = get_matching_kinds({'a.b': True, 'a.b.c': False}, ['a.b.c'])
+        expected = []  # type: List[str]
+        self.assertEquals(actual, expected)
 
 
 class CodeActionsTestCase(TextDocumentTestCase):
     def test_applies_code_actions(self) -> Generator:
         self.insert_characters('a\nb')
         yield from self.await_message("textDocument/didChange")
-        code_actions = create_test_code_actions(self.view.change_count(), [
+        code_action = create_test_code_action(self.view.change_count(), [
             ("c", Range(Point(0, 0), Point(0, 1))),
             ("d", Range(Point(1, 0), Point(1, 1))),
         ])
-        run_code_action_or_command(self.view, self.config.name, code_actions)
+        run_code_action_or_command(self.view, self.config.name, code_action)
         self.assertEquals(entire_content(self.view), 'c\nd')
 
     def test_does_not_apply_with_nonmatching_document_version(self) -> Generator:
         initial_content = 'a\nb'
         self.insert_characters(initial_content)
         yield from self.await_message("textDocument/didChange")
-        code_actions = create_test_code_actions(0, [
+        code_action = create_test_code_action(0, [
             ("c", Range(Point(0, 0), Point(0, 1))),
             ("d", Range(Point(1, 0), Point(1, 1))),
         ])
-        run_code_action_or_command(self.view, self.config.name, code_actions)
+        run_code_action_or_command(self.view, self.config.name, code_action)
         self.assertEquals(entire_content(self.view), initial_content)
+
+    # Keep this test last as it breaks pyls!
+    def test_applies_correctly_after_emoji(self) -> Generator:
+        self.insert_characters('🕵️hi')
+        yield from self.await_message("textDocument/didChange")
+        code_action = create_test_code_action(self.view.change_count(), [
+            ("bye", Range(Point(0, 3), Point(0, 5))),
+        ])
+        run_code_action_or_command(self.view, self.config.name, code_action)
+        self.assertEquals(entire_content(self.view), '🕵️bye')

--- a/unittesting.json
+++ b/unittesting.json
@@ -1,11 +1,11 @@
 {
     "deferred": true,
-    "verbosity": 0,
+    "verbosity": 2,
     "capture_console": true,
     "failfast": false,
-    "reload_package_on_testing": true,
+    "reload_package_on_testing": false,
     "start_coverage_after_reload": false,
     "show_reload_progress": false,
     "output": null,
-    "generate_html_report": true
+    "generate_html_report": false
 }


### PR DESCRIPTION
This is a very early work-in-progress. There are many issues to address.

## TODO
 - [x] 1. On triggering CAOS (Code Actions On Save), only request code actions from servers that report `codeActionProvider.codeActionKinds` and only request those specific kinds. ESlint reacts very weirdly if we send `source.fixAll.stylelint` to it, for example.
 - [x] 2. Implement more sophisticated `lsp_code_actions_on_save` setting handling. There are various combinations of that setting that can be applied by the user. There is a couple of examples in [vscode-stylelint readme](https://github.com/stylelint/vscode-stylelint#editorcodeactionsonsave). And while having `source.fixAll` set, we have to send that one to ESlint as its own, more specific kind, matches this more-generic `source.fixAll` one. When having both `source.fixAll: true` and `source.fixAll.eslint: false` we must not send the request.
 - [x] 3. Making a change and saving quickly fails to correct fixes. That's because, on a change, we clear diagnostics and send `didChange` notification, then find no diagnostics so we don't fire code action request. Only after that, we get diagnostics but it's too late.
 - [x] 4. Abandon sync handling in favor of overriding `save` (and `save_all`) command. Sync request blocks the main thread which is not an ideal experience. Especially if the fix takes a second or more.
 - [x] 5. Request and apply fixes from all servers on saving. That means we have to re-request code actions (which also means we have to wait for diagnostics) between each batch of fixes. And we need to request them until we exhaust all fixes or we time out...
 - [ ] 6. More that I forgot... Will add later.

## Questions/doubts
 - [ ] Should we only apply fixes with TextEdit. `Command`s need extra round-trip.
 - [ ] When we get fixes from multiple servers then what do we do? It's possible that fixes from one server will invalidate fixes from another server. It's fine if the fixes were versioned with `VersionedTextDocumentIdentifier` but otherwise, they might apply to a document that has already changed.

## Related links
[Code Action Request Spec](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction)