### PR TITLE
Support capability argument for sessions_for_view

### DIFF
--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -75,29 +75,27 @@ def request_code_actions_with_diagnostics(view: sublime.View, diagnostics_by_con
 
     actions_at_location = CodeActionsAtLocation(actions_handler)
 
-    for session in sessions_for_view(view, point):
-
-        if session.has_capability('codeActionProvider'):
-            if session.config.name in diagnostics_by_config:
-                point_diagnostics = diagnostics_by_config[session.config.name]
-                file_name = view.file_name()
-                relevant_range = point_diagnostics[0].range if point_diagnostics else region_to_range(
-                    view,
-                    view.sel()[0])
-                if file_name:
-                    params = {
-                        "textDocument": {
-                            "uri": filename_to_uri(file_name)
-                        },
-                        "range": relevant_range.to_lsp(),
-                        "context": {
-                            "diagnostics": list(diagnostic.to_lsp() for diagnostic in point_diagnostics)
-                        }
+    for session in sessions_for_view(view, 'codeActionProvider', point):
+        if session.config.name in diagnostics_by_config:
+            point_diagnostics = diagnostics_by_config[session.config.name]
+            file_name = view.file_name()
+            relevant_range = point_diagnostics[0].range if point_diagnostics else region_to_range(
+                view,
+                view.sel()[0])
+            if file_name:
+                params = {
+                    "textDocument": {
+                        "uri": filename_to_uri(file_name)
+                    },
+                    "range": relevant_range.to_lsp(),
+                    "context": {
+                        "diagnostics": list(diagnostic.to_lsp() for diagnostic in point_diagnostics)
                     }
-                    if session.client:
-                        session.client.send_request(
-                            Request.codeAction(params),
-                            actions_at_location.collect(session.config.name))
+                }
+                if session.client:
+                    session.client.send_request(
+                        Request.codeAction(params),
+                        actions_at_location.collect(session.config.name))
     return actions_at_location
 
 

--- a/plugin/color.py
+++ b/plugin/color.py
@@ -40,12 +40,11 @@ class LspColorListener(sublime_plugin.ViewEventListener):
         configs = configs_for_scope(self.view)
         if not configs:
             self.initialized = True  # no server enabled, re-open file to activate feature.
-        sessions = list(sessions_for_view(self.view))
+        sessions = list(sessions_for_view(self.view, 'colorProvider'))
         if sessions:
             self.initialized = True
-            if any(session.has_capability('colorProvider') for session in sessions):
-                self.enabled = True
-                self.send_color_request()
+            self.enabled = True
+            self.send_color_request()
         elif not is_retry:
             # session may be starting, try again once in a second.
             sublime.set_timeout_async(lambda: self.initialize(is_retry=True), 1000)

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -73,12 +73,14 @@ def client_from_session(session: Optional[Session]) -> Optional[Client]:
     return session.client if session else None
 
 
-def sessions_for_view(view: sublime.View, capability: str = None, point: int = None) -> Iterable[Session]:
+def sessions_for_view(view: sublime.View, capability: Optional[str] = None,
+                      point: Optional[int] = None) -> Iterable[Session]:
     return (session for session in _sessions_for_view_and_window(view, view.window(), point)
             if not capability or session.has_capability(capability))
 
 
-def session_for_view(view: sublime.View, capability: str, point: int = None) -> Optional[Session]:
+def session_for_view(view: sublime.View, capability: Optional[str],
+                     point: Optional[int] = None) -> Optional[Session]:
     return next((session for session in sessions_for_view(view, capability, point)), None)
 
 

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -73,15 +73,13 @@ def client_from_session(session: Optional[Session]) -> Optional[Client]:
     return session.client if session else None
 
 
-def sessions_for_view(view: sublime.View, point: Optional[int] = None) -> Iterable[Session]:
-    return _sessions_for_view_and_window(view, view.window(), point)
+def sessions_for_view(view: sublime.View, capability: str = None, point: int = None) -> Iterable[Session]:
+    return (session for session in _sessions_for_view_and_window(view, view.window(), point)
+            if not capability or session.has_capability(capability))
 
 
-def session_for_view(view: sublime.View,
-                     capability: str,
-                     point: Optional[int] = None) -> Optional[Session]:
-    return next((session for session in sessions_for_view(view, point)
-                 if session.has_capability(capability)), None)
+def session_for_view(view: sublime.View, capability: str, point: int = None) -> Optional[Session]:
+    return next((session for session in sessions_for_view(view, capability, point)), None)
 
 
 def _sessions_for_view_and_window(view: sublime.View, window: Optional[sublime.Window],

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -386,7 +386,7 @@ class Session(object):
             method = registration["method"]
             capability_path, registration_path = method_to_capability(method)
             debug("{}: registering capability:".format(self.config.name), capability_path)
-            set_dotted_value(self.capabilities, capability_path, registration.get("registerOptions"))
+            set_dotted_value(self.capabilities, capability_path, registration.get("registerOptions", {}))
             set_dotted_value(self.capabilities, registration_path, registration["id"])
         self.client.send_response(Response(request_id, None))
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -242,21 +242,17 @@ class Session(object):
         self._initialize()
 
     def has_capability(self, capability: str) -> bool:
-        return capability in self.capabilities and self.capabilities[capability] is not False
+        value = self.get_capability(capability)
+        return value is not False and value is not None
 
     def get_capability(self, capability: str) -> Optional[Any]:
-        return self.capabilities.get(capability)
+        return get_dotted_value(self.capabilities, capability)
 
     def should_notify_did_open(self) -> bool:
-        textsync = self.capabilities.get('textDocumentSync')
-        if isinstance(textsync, dict):
-            open_close = textsync.get('openClose')
-            if isinstance(open_close, dict):
-                return True  # dynamic registration
-            return bool(open_close)
-        if isinstance(textsync, int):
-            return textsync > TextDocumentSyncKindNone
-        return False
+        if self.has_capability('textDocumentSync.openClose'):
+            return True
+        textsync = self.get_capability('textDocumentSync')
+        return isinstance(textsync, int) and textsync > TextDocumentSyncKindNone
 
     def text_sync_kind(self) -> int:
         textsync = self.capabilities.get('textDocumentSync')
@@ -274,22 +270,7 @@ class Session(object):
         return self.text_sync_kind() > TextDocumentSyncKindNone
 
     def should_notify_will_save(self) -> bool:
-        textsync = self.capabilities.get('textDocumentSync')
-        if isinstance(textsync, dict):
-            will_save = textsync.get('willSave')
-            if isinstance(will_save, dict):
-                return True  # dynamic registration
-            return bool(will_save)
-        return False
-
-    def should_request_will_save_wait_until(self) -> bool:
-        textsync = self.capabilities.get('textDocumentSync')
-        if isinstance(textsync, dict):
-            wswu = textsync.get('willSaveWaitUntil')
-            if isinstance(wswu, dict):
-                return True  # dynamic registration
-            return bool(wswu)
-        return False
+        return self.has_capability('textDocumentSync.willSave')
 
     def should_notify_did_save(self) -> Tuple[bool, bool]:
         textsync = self.capabilities.get('textDocumentSync')
@@ -305,10 +286,10 @@ class Session(object):
         return self.should_notify_did_open()
 
     def should_notify_did_change_workspace_folders(self) -> bool:
-        return bool(self.capabilities.get("workspace", {}).get("workspaceFolders", {}).get("changeNotifications"))
+        return self.has_capability("workspace.workspaceFolders.changeNotifications")
 
     def should_notify_did_change_configuration(self) -> bool:
-        return "didChangeConfigurationProvider" in self.capabilities
+        return self.has_capability("didChangeConfigurationProvider")
 
     def handles_path(self, file_path: Optional[str]) -> bool:
         if not file_path:
@@ -345,9 +326,7 @@ class Session(object):
             self._handle_initialize_error)
 
     def _supports_workspace_folders(self) -> bool:
-        workspace_cap = self.capabilities.get("workspace", {})
-        workspace_folder_cap = workspace_cap.get("workspaceFolders", {})
-        return workspace_folder_cap.get("supported")
+        return self.has_capability("workspace.workspaceFolders.supported")
 
     def on_request(self, method: str, handler: Callable) -> None:
         self.client.on_request(method, handler)

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -545,8 +545,7 @@ class WindowManager(object):
 
         session.client.send_notification(Notification.initialized())
 
-        document_sync = session.capabilities.get("textDocumentSync")
-        if document_sync:
+        if session.has_capability("textDocumentSync"):
             self.documents.add_session(session)
         self._window.status_message("{} initialized".format(session.config.name))
 

--- a/plugin/formatting.py
+++ b/plugin/formatting.py
@@ -31,10 +31,9 @@ class FormatOnSaveListener(LSPViewEventListener):
             return
 
         self._view_maybe_dirty = True
-        for session in sessions_for_view(self.view):
-            if session.should_request_will_save_wait_until():
-                self._purge_changes_if_needed()
-                self._will_save_wait_until(session)
+        for session in sessions_for_view(self.view, 'textDocumentSync.willSaveWaitUntil'):
+            self._purge_changes_if_needed()
+            self._will_save_wait_until(session)
 
         if self.view.settings().get("lsp_format_on_save"):
             self._purge_changes_if_needed()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -142,7 +142,6 @@ class SessionTest(unittest.TestCase):
         session.client.transport.close()
 
     def test_can_get_started_session(self):
-
         post_initialize_callback = unittest.mock.Mock()
         session = self.make_session(
             MockClient(),
@@ -196,7 +195,6 @@ class SessionTest(unittest.TestCase):
         self.assertEqual(session.text_sync_kind(), TextDocumentSyncKindFull)
         self.assertTrue(session.should_notify_did_change())
         self.assertFalse(session.should_notify_will_save())
-        self.assertFalse(session.should_request_will_save_wait_until())
         self.assertEqual(session.should_notify_did_save(), (True, False))
 
         client.responses = {
@@ -214,8 +212,13 @@ class SessionTest(unittest.TestCase):
         self.assertEqual(session.text_sync_kind(), TextDocumentSyncKindNone)
         self.assertFalse(session.should_notify_did_change())
         self.assertTrue(session.should_notify_will_save())
-        self.assertFalse(session.should_request_will_save_wait_until())
         self.assertEqual(session.should_notify_did_save(), (True, False))
+        # Nested capabilities.
+        self.assertTrue(session.has_capability('textDocumentSync.change'))
+        self.assertTrue(session.has_capability('textDocumentSync.save'))
+        self.assertTrue(session.has_capability('textDocumentSync.willSave'))
+        self.assertFalse(session.has_capability('textDocumentSync.willSaveUntil'))
+        self.assertFalse(session.has_capability('textDocumentSync.aintthere'))
 
         client.responses = {
             'initialize': {
@@ -232,7 +235,6 @@ class SessionTest(unittest.TestCase):
         self.assertEqual(session.text_sync_kind(), TextDocumentSyncKindIncremental)
         self.assertTrue(session.should_notify_did_change())
         self.assertFalse(session.should_notify_will_save())
-        self.assertTrue(session.should_request_will_save_wait_until())
         self.assertEqual(session.should_notify_did_save(), (True, True))
 
         client.responses = {
@@ -245,7 +247,6 @@ class SessionTest(unittest.TestCase):
         self.assertEqual(session.text_sync_kind(), TextDocumentSyncKindIncremental)
         self.assertTrue(session.should_notify_did_change())
         self.assertFalse(session.should_notify_will_save())  # old-style text sync will never send willSave
-        self.assertFalse(session.should_request_will_save_wait_until())
         self.assertEqual(session.should_notify_did_save(), (False, False))
 
         client.responses = {
@@ -258,7 +259,6 @@ class SessionTest(unittest.TestCase):
         self.assertEqual(session.text_sync_kind(), TextDocumentSyncKindNone)
         self.assertFalse(session.should_notify_did_change())
         self.assertFalse(session.should_notify_will_save())
-        self.assertFalse(session.should_request_will_save_wait_until())
         self.assertEqual(session.should_notify_did_save(), (False, False))
 
         client.responses = {
@@ -274,5 +274,4 @@ class SessionTest(unittest.TestCase):
         self.assertEqual(session.text_sync_kind(), TextDocumentSyncKindIncremental)
         self.assertTrue(session.should_notify_did_change())
         self.assertFalse(session.should_notify_will_save())
-        self.assertFalse(session.should_request_will_save_wait_until())
         self.assertEqual(session.should_notify_did_save(), (False, False))


### PR DESCRIPTION
- Allow passed capability to be in 'dotted' format like 'textDocumentSync.change'
- Replace some checks to use get_dotted_value to make code more compact

The logic of changed code is not necessarily 100% identical to the old
one (empty dicts will return True now) but I think it shouldn't make
a difference in practice.

This change merges cleanly with st4000-exploration branch also.