### PR TITLE
Use a WeakValueDictionary for storing the window managers

### DIFF
--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -21,6 +21,8 @@ from .workspace import enable_in_project
 from .workspace import get_workspace_folders
 from .workspace import ProjectFolders
 from .workspace import sorted_workspace_folders
+from weakref import WeakValueDictionary
+from weakref import ref
 import threading
 
 
@@ -295,7 +297,6 @@ class WindowManager(object):
         session_starter: Callable,
         sublime: Any,
         handler_dispatcher: LanguageHandlerListener,
-        on_closed: Optional[Callable] = None,
         server_panel_factory: Optional[Callable] = None
     ) -> None:
         self._window = window
@@ -310,12 +311,27 @@ class WindowManager(object):
         self._sublime = sublime
         self._handlers = handler_dispatcher
         self._restarting = False
-        self._on_closed = on_closed
         self._is_closing = False
         self._initialization_lock = threading.Lock()
         self._workspace = workspace
-        self._workspace.on_changed = self._on_project_changed
-        self._workspace.on_switched = self._on_project_switched
+        weakself = ref(self)
+
+        # A weak reference is needed, otherwise self._workspace will have a strong reference to self, meaning a
+        # cyclic dependency.
+        def on_changed(folders: List[str]) -> None:
+            this = weakself()
+            if this is not None:
+                this._on_project_changed(folders)
+
+        # A weak reference is needed, otherwise self._workspace will have a strong reference to self, meaning a
+        # cyclic dependency.
+        def on_switched(folders: List[str]) -> None:
+            this = weakself()
+            if this is not None:
+                this._on_project_switched(folders)
+
+        self._workspace.on_changed = on_changed
+        self._workspace.on_switched = on_switched
         self._progress = dict()  # type: Dict[Any, Any]
 
     def _on_project_changed(self, folders: List[str]) -> None:
@@ -611,10 +627,6 @@ class WindowManager(object):
         if self._restarting:
             debug('window {} sessions unloaded - restarting'.format(self._window.id()))
             self.start_active_views()
-        elif not self._window.is_valid():
-            debug('window {} closed and sessions unloaded'.format(self._window.id()))
-            if self._on_closed:
-                self._on_closed()
 
     def _handle_post_exit(self, config_name: str) -> None:
         self.documents.remove_session(config_name)
@@ -655,7 +667,7 @@ class WindowManager(object):
 class WindowRegistry(object):
     def __init__(self, configs: GlobalConfigs, documents: Any,
                  session_starter: Callable, sublime: Any, handler_dispatcher: LanguageHandlerListener) -> None:
-        self._windows = {}  # type: Dict[int, WindowManager]
+        self._windows = WeakValueDictionary()  # type: WeakValueDictionary[int, WindowManager]
         self._configs = configs
         self._documents = documents
         self._session_starter = session_starter
@@ -694,11 +706,6 @@ class WindowRegistry(object):
                 session_starter=self._session_starter,
                 sublime=self._sublime,
                 handler_dispatcher=self._handler_dispatcher,
-                on_closed=lambda: self._on_closed(window),
                 server_panel_factory=self._server_panel_factory)
             self._windows[window.id()] = state
         return state
-
-    def _on_closed(self, window: WindowLike) -> None:
-        if window.id() in self._windows:
-            del self._windows[window.id()]

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -71,10 +71,11 @@ class WindowRegistryTests(unittest.TestCase):
 
         self.assertIsNotNone(wm)
 
-        # closing views triggers window unload detection
         test_window.close()
         wm.handle_view_closed(MockView(__file__))
         test_sublime._run_timeout()
+        test_window = None
+        wm = None
 
         self.assertEqual(len(windows._windows), 0)
 


### PR DESCRIPTION
This allows us to forget about the on_closed callback.
The self._workspace (ProjectFolders class) had a strong reference
to its containing WindowManager.

To check what the referrers are of a Python object, you can do:

    import gc
    import pprint
    pprint.pprint(gc.get_referrers(some_object))