### PR TITLE
Support MarkupContent in function signatures and hover content

### DIFF
--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -45,8 +45,8 @@ completion_kinds = {
 class LspResolveDocsCommand(sublime_plugin.TextCommand):
     def run(self, edit: sublime.Edit, index: int) -> None:
         item = CompletionHandler.completions[index]
-        detail = minihtml(self.view, item.get('detail') or "")
-        documentation = minihtml(self.view, item.get("documentation") or "")
+        detail = minihtml(self.view, item.get('detail') or "", prefer_plain_text=True)
+        documentation = minihtml(self.view, item.get("documentation") or "", prefer_plain_text=True)
 
         # don't show the detail in the cooperate AC popup if it is already shown in the AC details filed.
         self.is_detail_shown = bool(detail)
@@ -90,8 +90,8 @@ class LspResolveDocsCommand(sublime_plugin.TextCommand):
     def handle_resolve_response(self, item: Optional[dict]) -> None:
         if not item:
             return
-        detail = minihtml(self.view, item.get('detail') or "")
-        documentation = minihtml(self.view, item.get("documentation") or "")
+        detail = minihtml(self.view, item.get('detail') or "", prefer_plain_text=True)
+        documentation = minihtml(self.view, item.get("documentation") or "", prefer_plain_text=True)
         minihtml_content = self.get_content(documentation, detail)
         if self.view.is_popup_visible():
             self.update_popup(minihtml_content)

--- a/plugin/core/signature_help.py
+++ b/plugin/core/signature_help.py
@@ -1,6 +1,6 @@
 import html
 from .logging import debug
-from .typing import Tuple, Optional, Dict, List, Any, Protocol
+from .typing import Tuple, Optional, List, Protocol
 
 
 class ScopeRenderer(Protocol):
@@ -16,22 +16,6 @@ class ScopeRenderer(Protocol):
 
     def markdown(self, content: str) -> str:
         ...
-
-
-def get_documentation(d: Dict[str, Any]) -> Optional[str]:
-    docs = d.get('documentation', None)
-    if docs is None:
-        return None
-    elif isinstance(docs, str):
-        # In older version of the protocol, documentation was just a string.
-        return docs
-    elif isinstance(docs, dict):
-        # This can be either "plaintext" or "markdown" format. For now, we can dump it into the popup box. It would
-        # be nice to handle the markdown in a special way.
-        return docs.get('value', None)
-    else:
-        debug('unknown documentation type:', str(d))
-        return None
 
 
 class ParameterInformation(object):
@@ -105,7 +89,7 @@ def parse_parameter_information(parameter: dict) -> ParameterInformation:
         label = label_or_range
     else:
         label_range = label_or_range
-    return ParameterInformation(label, label_range, get_documentation(parameter))
+    return ParameterInformation(label, label_range, parameter.get('documentation'))
 
 
 def parse_signature_information(signature: dict) -> SignatureInformation:
@@ -117,7 +101,7 @@ def parse_signature_information(signature: dict) -> SignatureInformation:
         param_infos = list(parse_parameter_information(param) for param in parameters)
         paren_bounds = parse_signature_label(signature_label, param_infos)
 
-    return SignatureInformation(signature_label, get_documentation(signature), paren_bounds, param_infos)
+    return SignatureInformation(signature_label, signature.get('documentation'), paren_bounds, param_infos)
 
 
 class SignatureHelp(object):

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -182,7 +182,7 @@ def minihtml(view: sublime.View, content: Union[str, dict, list], prefer_plain_t
 
     Content can be in one of those formats:
      - string: treated as plain text
-     - MarkedString: string | { language: string; value: string }
+     - MarkedString: string or { language: string; value: string }
      - MarkedString[]
      - MarkupContent: { kind: MarkupKind, value: string }
 
@@ -196,8 +196,10 @@ def minihtml(view: sublime.View, content: Union[str, dict, list], prefer_plain_t
     :returns: Formatted string
     """
     if isinstance(content, str):
+        # plain text string or MarkedString
         return text2html(content) if prefer_plain_text else mdpopups.md2html(view, content)
     if isinstance(content, list):
+        # MarkedString[]
         formatted = []
         for item in content:
             value = ""
@@ -216,6 +218,7 @@ def minihtml(view: sublime.View, content: Union[str, dict, list], prefer_plain_t
         frontmatter_config = mdpopups.format_frontmatter({'allow_code_wrap': True})
         return mdpopups.md2html(view, frontmatter_config + "\n".join(formatted))
     if isinstance(content, dict):
+        # MarkupContent or MarkedString (dict)
         language = content.get("language")
         kind = content.get("kind")
         value = content.get("value") or ""
@@ -225,8 +228,6 @@ def minihtml(view: sublime.View, content: Union[str, dict, list], prefer_plain_t
         if language:
             # MarkedString (dict)
             return mdpopups.md2html(view, "```{}\n{}\n```\n".format(language, value))
-        # MarkedString (string)
-        return mdpopups.md2html(view, value)
     return ''
 
 

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -171,7 +171,7 @@ class LspHoverCommand(LspTextCommand):
         return "".join(formatted)
 
     def hover_content(self) -> str:
-        content = self._hover if isinstance(self._hover, dict) else ''
+        content = (self._hover.get('contents') or '') if isinstance(self._hover, dict) else ''
         return minihtml(self.view, content, allowed_formats=FORMAT_MARKED_STRING | FORMAT_MARKUP_CONTENT)
 
     def request_show_hover(self, point: int) -> None:

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -12,7 +12,8 @@ from .core.protocol import Request, DiagnosticSeverity, Diagnostic, DiagnosticRe
 from .core.registry import session_for_view, LspTextCommand, windows
 from .core.settings import client_configs, settings
 from .core.typing import List, Optional, Any, Dict
-from .core.views import text_document_position_params, minihtml
+from .core.views import text_document_position_params
+from .core.views import FORMAT_MARKED_STRING, FORMAT_MARKUP_CONTENT, minihtml
 from .diagnostics import filter_by_point, view_diagnostics
 
 
@@ -170,10 +171,8 @@ class LspHoverCommand(LspTextCommand):
         return "".join(formatted)
 
     def hover_content(self) -> str:
-        if isinstance(self._hover, dict):
-            # Can be: MarkedString | MarkedString[] | MarkupContent
-            return minihtml(self.view, self._hover.get('contents') or "", prefer_plain_text=False)
-        return ''
+        content = self._hover if isinstance(self._hover, dict) else ''
+        return minihtml(self.view, content, allowed_formats=FORMAT_MARKED_STRING | FORMAT_MARKUP_CONTENT)
 
     def request_show_hover(self, point: int) -> None:
         sublime.set_timeout(lambda: self.show_hover(point), 50)

--- a/plugin/signature_help.py
+++ b/plugin/signature_help.py
@@ -10,7 +10,8 @@ from .core.registry import session_for_view, client_from_session, LSPViewEventLi
 from .core.settings import client_configs, settings
 from .core.signature_help import create_signature_help, SignatureHelp
 from .core.typing import List, Dict, Optional
-from .core.views import minihtml, text_document_position_params
+from .core.views import text_document_position_params
+from .core.views import FORMAT_STRING, FORMAT_MARKUP_CONTENT, minihtml
 
 
 class ColorSchemeScopeRenderer(object):
@@ -30,8 +31,7 @@ class ColorSchemeScopeRenderer(object):
         return self._wrap_with_scope_style(content, "variable.parameter", emphasize)
 
     def markdown(self, content: str) -> str:
-        # Can be: string | MarkupContent
-        return minihtml(self._view, content, prefer_plain_text=True)
+        return minihtml(self._view, content, allowed_formats=FORMAT_STRING | FORMAT_MARKUP_CONTENT)
 
     def _wrap_with_scope_style(self, content: str, scope: str, emphasize: bool = False, escape: bool = True) -> str:
         color = self._scope_styles[scope]["color"]

--- a/plugin/signature_help.py
+++ b/plugin/signature_help.py
@@ -10,7 +10,7 @@ from .core.registry import session_for_view, client_from_session, LSPViewEventLi
 from .core.settings import client_configs, settings
 from .core.signature_help import create_signature_help, SignatureHelp
 from .core.typing import List, Dict, Optional
-from .core.views import text_document_position_params
+from .core.views import minihtml, text_document_position_params
 
 
 class ColorSchemeScopeRenderer(object):
@@ -30,7 +30,8 @@ class ColorSchemeScopeRenderer(object):
         return self._wrap_with_scope_style(content, "variable.parameter", emphasize)
 
     def markdown(self, content: str) -> str:
-        return mdpopups.md2html(self._view, content)
+        # Can be: string | MarkupContent
+        return minihtml(self._view, content, prefer_plain_text=True)
 
     def _wrap_with_scope_style(self, content: str, scope: str, emphasize: bool = False, escape: bool = True) -> str:
         color = self._scope_styles[scope]["color"]

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -138,7 +138,13 @@ class ViewsTest(DeferrableTestCase):
 
     def test_minihtml_handles_marked_content(self) -> None:
         content = {'value': 'import json', 'language': 'python'}
-        expect = '<div class="highlight"><pre><span>import</span><span>&nbsp;</span><span>json</span><br></pre></div>'
+        expect = '<div class="highlight"><pre><span>import</span><span> </span><span>json</span><br></pre></div>'
+        formatted = minihtml(self.view, content, prefer_plain_text=True)
+        self.assertEqual(self._strip_style_attributes(formatted), expect)
+
+    def test_minihtml_handles_marked_content_mutiple_spaces(self) -> None:
+        content = {'value': 'import  json', 'language': 'python'}
+        expect = '<div class="highlight"><pre><span>import</span><span>&nbsp; </span><span>json</span><br></pre></div>'
         formatted = minihtml(self.view, content, prefer_plain_text=True)
         self.assertEqual(self._strip_style_attributes(formatted), expect)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -5,16 +5,18 @@ from LSP.plugin.core.views import did_change
 from LSP.plugin.core.views import did_open
 from LSP.plugin.core.views import did_save
 from LSP.plugin.core.views import MissingFilenameError
+from LSP.plugin.core.views import minihtml
 from LSP.plugin.core.views import point_to_offset
+from LSP.plugin.core.views import text2html
 from LSP.plugin.core.views import text_document_formatting
 from LSP.plugin.core.views import text_document_position_params
 from LSP.plugin.core.views import text_document_range_formatting
 from LSP.plugin.core.views import uri_from_view
 from LSP.plugin.core.views import will_save
 from LSP.plugin.core.views import will_save_wait_until
-from LSP.plugin.core.views import text2html
 from unittest.mock import MagicMock
 from unittesting import DeferrableTestCase
+import re
 import sublime
 
 
@@ -113,6 +115,47 @@ class ViewsTest(DeferrableTestCase):
         # When we move two UTF-16 points further, we should encompass the beer emoji.
         # So that means that the code point offsets should have a difference of 1.
         self.assertEqual(point_to_offset(Point(1, foobarbaz_length + 2), self.view) - offset, 1)
+
+    def test_minihtml_prefers_plaintext(self) -> None:
+        content = "<div>text\n</div>"
+        expect = "&lt;div&gt;text<br>&lt;/div&gt;"
+        self.assertEqual(minihtml(self.view, content, prefer_plain_text=True), expect)
+
+    def test_minihtml_prefers_markdown(self) -> None:
+        content = "<div>text\n</div>"
+        expect = "<div>text</div>"
+        self.assertEqual(minihtml(self.view, content, prefer_plain_text=False), expect)
+
+    def test_minihtml_handles_markup_content_plaintext(self) -> None:
+        content = {'value': 'type TVec2i = specialize TGVec2<Integer>', 'kind': 'plaintext'}
+        expect = "type TVec2i = specialize TGVec2&lt;Integer&gt;"
+        self.assertEqual(minihtml(self.view, content, prefer_plain_text=True), expect)
+
+    def test_minihtml_handles_markup_content_markdown(self) -> None:
+        content = {'value': 'This is **bold** text', 'kind': 'markdown'}
+        expect = "<p>This is <strong>bold</strong> text</p>"
+        self.assertEqual(minihtml(self.view, content, prefer_plain_text=True), expect)
+
+    def test_minihtml_handles_marked_content(self) -> None:
+        content = {'value': 'import json', 'language': 'python'}
+        expect = '<div class="highlight"><pre><span>import</span><span>&nbsp;</span><span>json</span><br></pre></div>'
+        formatted = minihtml(self.view, content, prefer_plain_text=True)
+        self.assertEqual(self._strip_style_attributes(formatted), expect)
+
+    def test_minihtml_handles_marked_content_array(self) -> None:
+        content = [
+            {'value': 'import sys', 'language': 'python'},
+            {'value': 'let x', 'language': 'js'}
+        ]
+        expect = ''.join([
+            '<div class="highlight"><pre><span>import</span><span> </span><span>sys</span><br></pre></div>'
+            '<div class="highlight"><pre><span>let</span><span> </span><span>x</span><br></pre></div>'
+        ])
+        formatted = minihtml(self.view, content, prefer_plain_text=True)
+        self.assertEqual(self._strip_style_attributes(formatted), expect)
+
+    def _strip_style_attributes(self, content: str) -> str:
+        return re.sub(r'\s+style="[^"]+"', '', content)
 
     def test_text2html_replaces_tabs_with_br(self) -> None:
         self.assertEqual(text2html("Hello,\t world "), "Hello,&nbsp;&nbsp;&nbsp;&nbsp; world ")


### PR DESCRIPTION
Those two, together with documentation for completion items covers all
places where MarkupContent is currently supported.

Resolves #991