### PR TITLE
Expand variables for workspace/executeCommand request arguments

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -41,7 +41,7 @@ Example:
     "command": "lsp_execute",
     "args": { 
       "command_name": "thread-first",
-      "command_args": ["${file}", 0, 0]
+      "command_args": ["${file_uri}", 0, 0]
     }
   }
 ]
@@ -51,11 +51,13 @@ The following variables will be expanded, but only if they are top-level array i
 
 | Variable | Type | Description |
 | -------- | ---- | ----------- |
-| `"${file}"` | string | File URI of the active view |
+| `"${file_uri}"` | string | File URI of the active view |
+| `"${selection}"` | string | Content of the (rearmost) selection |
 | `"${offset}"` | int | Character offset of the (rearmost) cursor position |
 | `"${selection_begin}"` | int | Character offset of the begin of the (rearmost) selection |
 | `"${selection_end}"` | int | Character offset of the end of the (rearmost) selection |
-| `"${selection}"` | string | Content of the (rearmost) selection |
+| `"${position}"` | object | Mapping `{ 'line': int, 'character': int }` of the (rearmost) cursor position, see [Position](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#position) |
+| `"${range}` | object | Mapping with `'start'` and `'end'` positions of the (rearmost) selection, see [Range](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#range) |
 
 **Overriding keybindings**
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -51,13 +51,13 @@ The following variables will be expanded, but only if they are top-level array i
 
 | Variable | Type | Description |
 | -------- | ---- | ----------- |
-| `"${file_uri}"` | string | File URI of the active view |
-| `"${selection}"` | string | Content of the (rearmost) selection |
-| `"${offset}"` | int | Character offset of the (rearmost) cursor position |
-| `"${selection_begin}"` | int | Character offset of the begin of the (rearmost) selection |
-| `"${selection_end}"` | int | Character offset of the end of the (rearmost) selection |
-| `"${position}"` | object | Mapping `{ 'line': int, 'character': int }` of the (rearmost) cursor position, see [Position](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#position) |
-| `"${range}` | object | Mapping with `'start'` and `'end'` positions of the (rearmost) selection, see [Range](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#range) |
+| `"$file_uri"` or `"${file_uri}"` | string | File URI of the active view |
+| `"$selection"` or `"${selection}"` | string | Content of the (rearmost) selection |
+| `"$offset"` or `"${offset}"` | int | Character offset of the (rearmost) cursor position |
+| `"$selection_begin"` or `"${selection_begin}"` | int | Character offset of the begin of the (rearmost) selection |
+| `"$selection_end"` or `"${selection_end}"` | int | Character offset of the end of the (rearmost) selection |
+| `"$position"` or `"${position}"` | object | Mapping `{ 'line': int, 'character': int }` of the (rearmost) cursor position, see [Position](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#position) |
+| `"$range"` or `"${range}` | object | Mapping with `'start'` and `'end'` positions of the (rearmost) selection, see [Range](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#range) |
 
 **Overriding keybindings**
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -52,12 +52,12 @@ The following variables will be expanded, but only if they are top-level array i
 | Variable | Type | Description |
 | -------- | ---- | ----------- |
 | `"$file_uri"` or `"${file_uri}"` | string | File URI of the active view |
-| `"$selection"` or `"${selection}"` | string | Content of the (rearmost) selection |
-| `"$offset"` or `"${offset}"` | int | Character offset of the (rearmost) cursor position |
-| `"$selection_begin"` or `"${selection_begin}"` | int | Character offset of the begin of the (rearmost) selection |
-| `"$selection_end"` or `"${selection_end}"` | int | Character offset of the end of the (rearmost) selection |
-| `"$position"` or `"${position}"` | object | Mapping `{ 'line': int, 'character': int }` of the (rearmost) cursor position, see [Position](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#position) |
-| `"$range"` or `"${range}` | object | Mapping with `'start'` and `'end'` positions of the (rearmost) selection, see [Range](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#range) |
+| `"$selection"` or `"${selection}"` | string | Content of the (topmost) selection |
+| `"$offset"` or `"${offset}"` | int | Character offset of the (topmost) cursor position |
+| `"$selection_begin"` or `"${selection_begin}"` | int | Character offset of the begin of the (topmost) selection |
+| `"$selection_end"` or `"${selection_end}"` | int | Character offset of the end of the (topmost) selection |
+| `"$position"` or `"${position}"` | object | Mapping `{ 'line': int, 'character': int }` of the (topmost) cursor position, see [Position](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#position) |
+| `"$range"` or `"${range}` | object | Mapping with `'start'` and `'end'` positions of the (topmost) selection, see [Range](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#range) |
 
 **Overriding keybindings**
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -40,13 +40,22 @@ Example:
     "caption": "Thread First",
     "command": "lsp_execute",
     "args": { 
-    	"command_name": "thread-first",
-    	"command_args":["file:///tmp/foo.clj", 0, 0] 
+      "command_name": "thread-first",
+      "command_args": ["${file}", 0, 0]
     }
   }
 ]
 ```
-Note: `command_args` is optional depending on the `workspace/executeCommand` that are supported by the LSP server. 
+Note: `command_args` is optional depending on the `workspace/executeCommand` that are supported by the LSP server.
+The following variables will be expanded, but only if they are top-level array items and not within nested arrays or objects:
+
+| Variable | Type | Description |
+| -------- | ---- | ----------- |
+| `"${file}"` | string | File URI of the active view |
+| `"${offset}"` | int | Character offset of the (rearmost) cursor position |
+| `"${selection_begin}"` | int | Character offset of the begin of the (rearmost) selection |
+| `"${selection_end}"` | int | Character offset of the end of the (rearmost) selection |
+| `"${selection}"` | string | Content of the (rearmost) selection |
 
 **Overriding keybindings**
 

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -3,7 +3,7 @@ from .core.protocol import Request
 from .core.registry import LspTextCommand
 from .core.rpc import Client
 from .core.typing import List, Optional, Dict, Any
-from .core.views import uri_from_view
+from .core.views import uri_from_view, offset_to_point, region_to_range
 
 
 class LspExecuteCommand(LspTextCommand):
@@ -37,15 +37,9 @@ class LspExecuteCommand(LspTextCommand):
             elif arg in ["$selection_end", "${selection_end}"]:
                 command_args[i] = region.end()
             elif arg in ["$position", "${position}"]:
-                position = self.view.rowcol(region.b)
-                command_args[i] = {"line": position[0], "character": position[1]}
+                command_args[i] = offset_to_point(self.view, region.b).to_lsp()
             elif arg in ["$range", "${range}"]:
-                start = self.view.rowcol(region.begin())
-                end = self.view.rowcol(region.end())
-                command_args[i] = {
-                    "start": {"line": start[0], "character": start[1]},
-                    "end": {"line": end[0], "character": end[1]}
-                }
+                command_args[i] = region_to_range(self.view, region).to_lsp()
         return command_args
 
     def _handle_response(self, command: str, response: Optional[Any]) -> None:

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -20,10 +20,10 @@ class LspExecuteCommand(LspTextCommand):
             if window:
                 window.status_message("Running command {}".format(command_name))
             if command_args:
-                command_args = self._expand_variables(command_args)
+                self._expand_variables(command_args)
             self._send_command(client, command_name, command_args)
 
-    def _expand_variables(self, command_args: List[Any]) -> List[Any]:
+    def _expand_variables(self, command_args: List[Any]) -> None:
         region = self.view.sel()[0]
         for i, arg in enumerate(command_args):
             if arg in ["$file_uri", "${file_uri}"]:
@@ -40,7 +40,6 @@ class LspExecuteCommand(LspTextCommand):
                 command_args[i] = offset_to_point(self.view, region.b).to_lsp()
             elif arg in ["$range", "${range}"]:
                 command_args[i] = region_to_range(self.view, region).to_lsp()
-        return command_args
 
     def _handle_response(self, command: str, response: Optional[Any]) -> None:
         msg = "command {} completed".format(command)

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -21,7 +21,9 @@ class LspExecuteCommand(LspTextCommand):
                 window.status_message("Running command {}".format(command_name))
             self._send_command(client, command_name, self._expand_variables(command_args))
 
-    def _expand_variables(self, command_args: List[Any]) -> List[Any]:
+    def _expand_variables(self, command_args: Optional[List[Any]]) -> Optional[List[Any]]:
+        if not command_args:
+            return None
         for i, arg in enumerate(command_args):
             if arg == "${file}":
                 command_args[i] = filename_to_uri(self.view.file_name())

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -3,6 +3,7 @@ from .core.protocol import Request
 from .core.registry import LspTextCommand
 from .core.rpc import Client
 from .core.typing import List, Optional, Dict, Any
+from .core.url import filename_to_uri
 
 
 class LspExecuteCommand(LspTextCommand):
@@ -12,13 +13,27 @@ class LspExecuteCommand(LspTextCommand):
     def run(self,
             edit: sublime.Edit,
             command_name: Optional[str] = None,
-            command_args: Optional[Any] = None) -> None:
+            command_args: Optional[List[Any]] = None) -> None:
         client = self.client_with_capability('executeCommandProvider')
         if client and command_name:
             window = self.view.window()
             if window:
                 window.status_message("Running command {}".format(command_name))
-            self._send_command(client, command_name, command_args)
+            self._send_command(client, command_name, self._expand_variables(command_args))
+
+    def _expand_variables(self, command_args: List[Any]) -> List[Any]:
+        for i, arg in enumerate(command_args):
+            if arg == "${file}":
+                command_args[i] = filename_to_uri(self.view.file_name())
+            elif arg == "${offset}":
+                command_args[i] = self.view.sel()[-1].b
+            elif arg == "${selection_begin}":
+                command_args[i] = self.view.sel()[-1].begin()
+            elif arg == "${selection_end}":
+                command_args[i] = self.view.sel()[-1].end()
+            elif arg == "${selection}":
+                command_args[i] = self.view.substr(self.view.sel()[-1])
+        return command_args
 
     def _handle_response(self, command: str, response: Optional[Any]) -> None:
         msg = "command {} completed".format(command)

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -26,20 +26,20 @@ class LspExecuteCommand(LspTextCommand):
     def _expand_variables(self, command_args: List[Any]) -> List[Any]:
         region = self.view.sel()[-1]
         for i, arg in enumerate(command_args):
-            if arg == "${file_uri}":
+            if arg in ["$file_uri", "${file_uri}"]:
                 command_args[i] = uri_from_view(self.view)
-            elif arg == "${selection}":
+            elif arg in ["$selection", "${selection}"]:
                 command_args[i] = self.view.substr(region)
-            elif arg == "${offset}":
+            elif arg in ["$offset", "${offset}"]:
                 command_args[i] = region.b
-            elif arg == "${selection_begin}":
+            elif arg in ["$selection_begin", "${selection_begin}"]:
                 command_args[i] = region.begin()
-            elif arg == "${selection_end}":
+            elif arg in ["$selection_end", "${selection_end}"]:
                 command_args[i] = region.end()
-            elif arg == "${position}":
+            elif arg in ["$position", "${position}"]:
                 position = self.view.rowcol(region.b)
                 command_args[i] = {"line": position[0], "character": position[1]}
-            elif arg == "${range}":
+            elif arg in ["$range", "${range}"]:
                 start = self.view.rowcol(region.begin())
                 end = self.view.rowcol(region.end())
                 command_args[i] = {

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -24,7 +24,7 @@ class LspExecuteCommand(LspTextCommand):
             self._send_command(client, command_name, command_args)
 
     def _expand_variables(self, command_args: List[Any]) -> List[Any]:
-        region = self.view.sel()[-1]
+        region = self.view.sel()[0]
         for i, arg in enumerate(command_args):
             if arg in ["$file_uri", "${file_uri}"]:
                 command_args[i] = uri_from_view(self.view)


### PR DESCRIPTION
As it is now, the `lsp_execute` command is not really usefull if the request arguments require a file URI or other things dependent on current state. This PR expands (actually replaces) the following string arguments:

* `"${file_uri}"` for the file URI of the active view
* `"${offset}"` for the character offset of the (topmost) cursor position
* `"${selection_begin}"` for the character offset of the begin of the (topmost) selection
* `"${selection_end}"` for the character offset of the end of the (topmost) selection
* `"${selection}"` for the the content of the (topmost) selection
* `"${position}"` for Position object (from LSP specs) of the (topmost) cursor position
* `"${range}"` for Range object (from LSP specs) of the (topmost) selection 

In general the `arguments` parameter for the request is an array with items of any kind, but it should probably be sufficient to only check the top-level items.