### PR TITLE
Use LSPViewEventListener.has_supported_syntax consistently

### DIFF
--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -3,12 +3,10 @@ import mdpopups
 import sublime
 import sublime_plugin
 import webbrowser
-
-from .core.configurations import is_supported_syntax
 from .core.edit import parse_text_edit
 from .core.protocol import Request, InsertTextFormat, Range
 from .core.registry import session_for_view, client_from_session, LSPViewEventListener
-from .core.settings import settings, client_configs
+from .core.settings import settings
 from .core.typing import Any, List, Dict, Optional, Union, Generator
 from .core.views import text_document_position_params, range_to_region
 from .core.views import FORMAT_STRING, FORMAT_MARKUP_CONTENT, minihtml
@@ -150,9 +148,7 @@ class CompletionHandler(LSPViewEventListener):
     def is_applicable(cls, view_settings: dict) -> bool:
         if 'completion' in settings.disabled_capabilities:
             return False
-
-        syntax = view_settings.get('syntax')
-        return is_supported_syntax(syntax, client_configs.all) if syntax else False
+        return cls.has_supported_syntax(view_settings)
 
     def initialize(self) -> None:
         self.initialized = True

--- a/plugin/core/documents.py
+++ b/plugin/core/documents.py
@@ -1,8 +1,6 @@
 import sublime
 
-from .configurations import is_supported_syntax
 from .registry import LSPViewEventListener
-from .settings import client_configs
 from .typing import Optional, Iterable
 
 
@@ -40,18 +38,9 @@ def is_transient_view(view: sublime.View) -> bool:
 
 
 class DocumentSyncListener(LSPViewEventListener):
-    def __init__(self, view: sublime.View) -> None:
-        super().__init__(view)
-
     @classmethod
-    def is_applicable(cls, settings: dict) -> bool:
-        syntax = settings.get('syntax')  # type: 'Optional[str]'
-        # This enables all of document sync for any supportable syntax
-        # Global performance cost, consider a detect_lsp_support setting
-        if not syntax:
-            return False
-        else:
-            return is_supported_syntax(syntax, client_configs.all)
+    def is_applicable(cls, view_settings: dict) -> bool:
+        return cls.has_supported_syntax(view_settings)
 
     @classmethod
     def applies_to_primary_view_only(cls) -> bool:

--- a/plugin/formatting.py
+++ b/plugin/formatting.py
@@ -1,10 +1,8 @@
 import sublime
-from .core.configurations import is_supported_syntax
 from .core.edit import parse_text_edit
 from .core.registry import LspTextCommand, LSPViewEventListener, session_for_view, client_from_session
 from .core.registry import sessions_for_view
 from .core.sessions import Session
-from .core.settings import client_configs
 from .core.typing import Any, List, Optional
 from .core.views import will_save_wait_until, text_document_formatting, text_document_range_formatting
 
@@ -15,15 +13,9 @@ def apply_response_to_view(response: Optional[List[dict]], view: sublime.View) -
 
 
 class FormatOnSaveListener(LSPViewEventListener):
-    def __init__(self, view: sublime.View) -> None:
-        super().__init__(view)
-
     @classmethod
     def is_applicable(cls, view_settings: dict) -> bool:
-        syntax = view_settings.get('syntax')
-        if syntax:
-            return is_supported_syntax(syntax, client_configs.all)
-        return False
+        return cls.has_supported_syntax(view_settings)
 
     def on_pre_save(self) -> None:
         file_path = self.view.file_name()

--- a/plugin/signature_help.py
+++ b/plugin/signature_help.py
@@ -3,11 +3,10 @@ import sublime
 import html
 import webbrowser
 
-from .core.configurations import is_supported_syntax
 from .core.popups import popups
 from .core.protocol import Request
 from .core.registry import session_for_view, client_from_session, LSPViewEventListener
-from .core.settings import client_configs, settings
+from .core.settings import settings
 from .core.signature_help import create_signature_help, SignatureHelp
 from .core.typing import List, Dict, Optional, Union
 from .core.views import text_document_position_params
@@ -55,11 +54,7 @@ class SignatureHelpListener(LSPViewEventListener):
     def is_applicable(cls, view_settings: dict) -> bool:
         if 'signatureHelp' in settings.disabled_capabilities:
             return False
-        syntax = view_settings.get('syntax')
-        if syntax:
-            return is_supported_syntax(syntax, client_configs.all)
-        else:
-            return False
+        return cls.has_supported_syntax(view_settings)
 
     def initialize(self) -> None:
         session = session_for_view(self.view, 'signatureHelpProvider')


### PR DESCRIPTION
Instead of using the free-standing "is_supported_syntax" function.

(This doesn't fix the performance issue - just cleans up the code to make the fix easier.)