### PR TITLE
Fix performance issue related to calling is_supported_syntax a lot

### DIFF
--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -1,17 +1,10 @@
 from .collections import DottedDict
 from .logging import debug
-from .types import ClientConfig, WindowLike, syntax2scope, view2scope
-from .typing import Any, Generator, List, Dict, Iterable
+from .types import ClientConfig, WindowLike, view2scope
+from .typing import Any, Generator, List, Dict
 from .workspace import enable_in_project, disable_in_project
 from copy import deepcopy
 import sublime
-
-
-def is_supported_syntax(syntax: str, configs: Iterable[ClientConfig]) -> bool:
-    scope = syntax2scope(syntax)
-    if scope is not None:
-        return any(config.match_document(scope) for config in configs)
-    return False
 
 
 class ConfigManager(object):

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -1,7 +1,7 @@
 import sublime
 import sublime_plugin
 from .clients import start_window_config
-from .configurations import ConfigManager, is_supported_syntax
+from .configurations import ConfigManager
 from .handlers import LanguageHandler
 from .logging import debug
 from .rpc import Client
@@ -24,10 +24,7 @@ class LSPViewEventListener(sublime_plugin.ViewEventListener):
     @classmethod
     def has_supported_syntax(cls, view_settings: dict) -> bool:
         syntax = view_settings.get('syntax')
-        if syntax:
-            return is_supported_syntax(syntax, client_configs.all)
-        else:
-            return False
+        return bool(syntax and client_configs.is_syntax_supported(syntax))
 
     @property
     def manager(self) -> WindowManager:

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -92,6 +92,7 @@ class ClientConfigs(object):
         self._external_configs = dict()  # type: Dict[str, ClientConfig]
         self.all = []  # type: List[ClientConfig]
         self._listener = None  # type: Optional[Callable]
+        self._supported_syntaxes_cache = dict()  # type: Dict[str, bool]
 
     def update(self, settings_obj: sublime.Settings) -> None:
         self._default_settings = read_dict_setting(settings_obj, "default_clients", {})
@@ -103,6 +104,7 @@ class ClientConfigs(object):
 
     def update_configs(self) -> None:
         del self.all[:]
+        self._supported_syntaxes_cache = dict()
 
         for config_name, config in self._external_configs.items():
             user_settings = self._global_settings.get(config_name, dict())
@@ -135,6 +137,14 @@ class ClientConfigs(object):
 
     def set_listener(self, recipient: Callable) -> None:
         self._listener = recipient
+
+    def is_syntax_supported(self, syntax: str) -> bool:
+        if syntax in self._supported_syntaxes_cache:
+            return self._supported_syntaxes_cache[syntax]
+        scope = syntax2scope(syntax)
+        supported = bool(scope and any(config.match_document(scope) for config in self.all))
+        self._supported_syntaxes_cache[syntax] = supported
+        return supported
 
 
 _settings_obj = None  # type: Optional[sublime.Settings]

--- a/tests/test_configurations.py
+++ b/tests/test_configurations.py
@@ -1,6 +1,6 @@
 from LSP.plugin.core.configurations import ConfigManager
-from LSP.plugin.core.configurations import is_supported_syntax
 from LSP.plugin.core.configurations import WindowConfigManager
+from LSP.plugin.core.settings import client_configs
 from test_mocks import DISABLED_CONFIG
 from test_mocks import TEST_CONFIG
 from test_mocks import TEST_LANGUAGE
@@ -92,9 +92,22 @@ class WindowConfigManagerTests(unittest.TestCase):
 
 class IsSupportedSyntaxTests(unittest.TestCase):
 
-    def test_no_configs(self):
-        self.assertFalse(is_supported_syntax('asdf', []))
+    def tearDown(self) -> None:
+        # Resets state of configs to match settings
+        client_configs.update_configs()
 
-    def test_single_config(self):
+    def test_has_no_matching_config(self) -> None:
+        self.assertFalse(client_configs.is_syntax_supported('asdf'))
+
+    def test_has_matching_config(self) -> None:
+        client_configs.all.append(TEST_CONFIG)
         self.assertEqual(TEST_LANGUAGE.feature_selector, TEST_CONFIG.languages[0].feature_selector)
-        self.assertTrue(is_supported_syntax("Packages/Text/Plain text.tmLanguage", [TEST_CONFIG]))
+        self.assertTrue(client_configs.is_syntax_supported("Packages/Text/Plain text.tmLanguage"))
+        client_configs.all.remove(TEST_CONFIG)
+
+    def test_does_not_match_after_removing_config(self) -> None:
+        client_configs.all.append(TEST_CONFIG)
+        self.assertTrue(client_configs.is_syntax_supported("Packages/Text/Plain text.tmLanguage"))
+        # Removes manually added config
+        client_configs.update_configs()
+        self.assertFalse(client_configs.is_syntax_supported("Packages/Text/Plain text.tmLanguage"))


### PR DESCRIPTION
is_supported_syntax was called from all view listeners when checking
if listener is applicable. Added caching so that lookup for config
supporting given syntax is only done once per syntax.

Resolves #1057