### PR TITLE
Use sublime.COMPLETION_FORMAT_TEXT instead of escaping dollar-signs

### DIFF
--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -257,14 +257,16 @@ class CompletionHandler(LSPViewEventListener):
                 kind=kind,
                 details=st_details)
         else:
-            # A snippet completion suffices for insertText with no additionalTextEdits and no command.
-            snippet = item.get("insertText") or item["label"]
+            # A plain old completion suffices for insertText with no additionalTextEdits and no command.
             if item.get("insertTextFormat", InsertTextFormat.PlainText) == InsertTextFormat.PlainText:
-                snippet = snippet.replace('$', '\\$')
-            completion = sublime.CompletionItem.snippet_completion(
+                st_format = sublime.COMPLETION_FORMAT_TEXT
+            else:
+                st_format = sublime.COMPLETION_FORMAT_SNIPPET
+            completion = sublime.CompletionItem(
                 trigger=st_trigger,
-                snippet=snippet,
                 annotation=st_annotation,
+                completion=item.get("insertText") or item["label"],
+                completion_format=st_format,
                 kind=kind,
                 details=st_details)
 

--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -88,6 +88,8 @@ KIND_NAVIGATION = ...  # type: Tuple[int, str, str]
 KIND_MARKUP = ...  # type: Tuple[int, str, str]
 KIND_VARIABLE = ...  # type: Tuple[int, str, str]
 KIND_SNIPPET = ...  # type: Tuple[int, str, str]
+COMPLETION_FORMAT_TEXT = ...  # type: int
+COMPLETION_FORMAT_SNIPPET = ...  # type: int
 
 
 class Settings:
@@ -258,11 +260,23 @@ def windows() -> 'Sequence[Window]':
 def get_macro() -> Sequence[dict]:
     ...
 
+
 def list_syntaxes() -> Sequence[Dict[str, Any]]:
     ...
 
+
 class CompletionItem:
     flags = ...  # type: int
+
+    def __init__(
+            self,
+            trigger: str,
+            annotation: str = "",
+            completion: str = "",
+            completion_format: int = COMPLETION_FORMAT_TEXT,
+            kind: Tuple[int, str, str] = KIND_AMBIGUOUS,
+            details: str = "") -> None:
+        ...
 
     @classmethod
     def snippet_completion(


### PR DESCRIPTION
There are already tests that check that a dollar-sign is inserted, so no extra test is needed.