### PR TITLE
Support completion item tags

### DIFF
--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -4,7 +4,7 @@ import sublime
 import sublime_plugin
 import webbrowser
 from .core.edit import parse_text_edit
-from .core.protocol import Request, InsertTextFormat, Range
+from .core.protocol import Request, InsertTextFormat, Range, CompletionItemTag
 from .core.registry import session_for_view, client_from_session, LSPViewEventListener
 from .core.settings import settings
 from .core.typing import Any, List, Dict, Optional, Union, Generator
@@ -133,6 +133,10 @@ def resolve(completion_list: sublime.CompletionList, items: List[sublime.Complet
     sublime.set_timeout(lambda: completion_list.set_completions(items, flags))
 
 
+def is_deprecated(item: dict) -> bool:
+    return item.get("deprecated", False) or CompletionItemTag.Deprecated in item.get("tags", [])
+
+
 class CompletionHandler(LSPViewEventListener):
     completions = []  # type: List[dict]
 
@@ -215,7 +219,7 @@ class CompletionHandler(LSPViewEventListener):
         else:
             kind = sublime.KIND_AMBIGUOUS
 
-        if item.get("deprecated", False):
+        if is_deprecated(item):
             kind = (kind[0], '⚠', "⚠ {} - Deprecated".format(kind[2]))
 
         lsp_label = item["label"]

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -16,6 +16,10 @@ class DiagnosticSeverity(object):
     Hint = 4
 
 
+class CompletionItemTag:
+    Deprecated = 1
+
+
 class InsertTextFormat:
     PlainText = 1
     Snippet = 2

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -18,6 +18,7 @@ import os
 def get_initialize_params(workspace_folders: List[WorkspaceFolder], config: ClientConfig) -> dict:
     completion_kinds = list(range(1, len(COMPLETION_KINDS) + 1))
     symbol_kinds = list(range(1, len(SYMBOL_KINDS) + 1))
+    completion_tag_value_set = [v for k, v in CompletionItemTag.__dict__.items() if not k.startswith('_')]
     first_folder = workspace_folders[0] if workspace_folders else None
     capabilities = {
         "textDocument": {
@@ -37,7 +38,7 @@ def get_initialize_params(workspace_folders: List[WorkspaceFolder], config: Clie
                     "snippetSupport": True,
                     "deprecatedSupport": True,
                     "tagSupport": {
-                        "valueSet": [CompletionItemTag.Deprecated]
+                        "valueSet": completion_tag_value_set
                     }
                 },
                 "completionItemKind": {

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -2,7 +2,7 @@ from .. import __version__
 from .collections import DottedDict
 from .logging import debug
 from .process import start_server
-from .protocol import TextDocumentSyncKindNone, TextDocumentSyncKindIncremental
+from .protocol import TextDocumentSyncKindNone, TextDocumentSyncKindIncremental, CompletionItemTag
 from .protocol import WorkspaceFolder, Request, Notification
 from .rpc import Client, attach_stdio_client, Response
 from .transports import start_tcp_transport, start_tcp_listener, TCPTransport, Transport
@@ -35,7 +35,10 @@ def get_initialize_params(workspace_folders: List[WorkspaceFolder], config: Clie
                 "dynamicRegistration": True,
                 "completionItem": {
                     "snippetSupport": True,
-                    "deprecatedSupport": True
+                    "deprecatedSupport": True,
+                    "tagSupport": {
+                        "valueSet": [CompletionItemTag.Deprecated]
+                    }
                 },
                 "completionItemKind": {
                     "valueSet": completion_kinds

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,6 +1,7 @@
 from LSP.plugin.completion import CompletionHandler
 from LSP.plugin.core.registry import is_supported_view
 from LSP.plugin.core.registry import windows
+from LSP.plugin.core.protocol import CompletionItemTag
 from LSP.plugin.core.typing import Any, Generator, List, Dict, Callable
 from setup import TextDocumentTestCase, add_config, remove_config, text_config
 from unittesting import DeferrableTestCase
@@ -619,3 +620,25 @@ class QueryCompletionsTests(TextDocumentTestCase):
         # remove '"k"' is invalid. The code in completion.py must be able to handle this.
         yield self.create_commit_completion_closure()
         self.assertEqual(self.read_file(), '{"keys": []}')
+
+    def test_show_deprecated_flag(self) -> 'Generator':
+        item_with_deprecated_flag = {
+            "label": 'hello',
+            "kind": 2,  # Method
+            "deprecated": True
+        }
+        handler = CompletionHandler(self.view)
+        formatted_completion_item = handler.format_completion(item_with_deprecated_flag, 0, False)
+        self.assertEqual('⚠', formatted_completion_item.kind[1])
+        self.assertEqual('⚠ Method - Deprecated', formatted_completion_item.kind[2])
+
+    def test_show_deprecated_tag(self) -> 'Generator':
+        item_with_deprecated_tags = {
+            "label": 'hello',
+            "kind": 2,  # Method
+            "tags": [CompletionItemTag.Deprecated]
+        }
+        handler = CompletionHandler(self.view)
+        formatted_completion_item = handler.format_completion(item_with_deprecated_tags, 0, False)
+        self.assertEqual('⚠', formatted_completion_item.kind[1])
+        self.assertEqual('⚠ Method - Deprecated', formatted_completion_item.kind[2])


### PR DESCRIPTION
```
/**
 * Client supports the tag property on a completion item. Clients supporting
 * tags have to handle unknown tags gracefully. Clients especially need to
 * preserve unknown tags when sending a completion item back to the server in
 * a resolve call.
 *
 * @since 3.15.0
 */
```
The `deprecated` flag on a `CompletionItem` was deprecated in favor of `CompletionItem.tags`. This PR add support for tags.  