### PR TITLE
Trigger warning for ST4 users that are still using ST3-version of LSP

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -1,12 +1,3 @@
-import sublime
-
-if int(sublime.version()) > 4000:
-    sublime.error_message(
-        """The currently installed version of LSP package is not compatible with Sublime Text 4. """
-        """Please remove and reinstall this package to receive a version compatible with ST4. """
-        """Remember to restart Sublime Text after."""
-    )
-
 # Please keep this list sorted (Edit -> Sort Lines)
 from .plugin.code_actions import LspCodeActionBulbListener
 from .plugin.code_actions import LspCodeActionsCommand
@@ -20,7 +11,7 @@ from .plugin.configuration import LspEnableLanguageServerGloballyCommand
 from .plugin.configuration import LspEnableLanguageServerInProjectCommand
 from .plugin.core.documents import DocumentSyncListener
 from .plugin.core.main import shutdown as plugin_unloaded
-from .plugin.core.main import startup as plugin_loaded
+from .plugin.core.main import startup
 from .plugin.core.panels import LspClearPanelCommand
 from .plugin.core.panels import LspUpdatePanelCommand
 from .plugin.core.panels import LspUpdateServerPanelCommand
@@ -52,3 +43,15 @@ from .plugin.symbols import LspDocumentSymbolsCommand
 from .plugin.symbols import LspSelectionAddCommand
 from .plugin.symbols import LspSelectionClearCommand
 from .plugin.symbols import LspWorkspaceSymbolsCommand
+import sublime
+
+
+def plugin_loaded():
+    startup()
+
+    if int(sublime.version()) > 4000:
+        sublime.error_message(
+            """The currently installed version of LSP package is not compatible with Sublime Text 4. """
+            """Please remove and reinstall this package to receive a version compatible with ST4. """
+            """Remember to restart Sublime Text after."""
+        )

--- a/boot.py
+++ b/boot.py
@@ -2,9 +2,9 @@ import sublime
 
 if int(sublime.version()) > 4000:
     sublime.error_message(
-        """The installed version of LSP package is not compatible with Sublime Text 4.\n"""
-        """Please remove and reinstall this package to receive version compatible with ST4.\n"""
-        """Remember to restart Sublime Text after.\n"""
+        """The currently installed version of LSP package is not compatible with Sublime Text 4. """
+        """Please remove and reinstall this package to receive a version compatible with ST4. """
+        """Remember to restart Sublime Text after."""
     )
 
 # Please keep this list sorted (Edit -> Sort Lines)

--- a/boot.py
+++ b/boot.py
@@ -10,8 +10,8 @@ from .plugin.configuration import LspDisableLanguageServerInProjectCommand
 from .plugin.configuration import LspEnableLanguageServerGloballyCommand
 from .plugin.configuration import LspEnableLanguageServerInProjectCommand
 from .plugin.core.documents import DocumentSyncListener
-from .plugin.core.main import shutdown as plugin_unloaded
-from .plugin.core.main import startup
+from .plugin.core.main import plugin_loaded
+from .plugin.core.main import plugin_unloaded
 from .plugin.core.panels import LspClearPanelCommand
 from .plugin.core.panels import LspUpdatePanelCommand
 from .plugin.core.panels import LspUpdateServerPanelCommand
@@ -44,14 +44,3 @@ from .plugin.symbols import LspSelectionAddCommand
 from .plugin.symbols import LspSelectionClearCommand
 from .plugin.symbols import LspWorkspaceSymbolsCommand
 import sublime
-
-
-def plugin_loaded():
-    startup()
-
-    if int(sublime.version()) > 4000:
-        sublime.error_message(
-            """The currently installed version of LSP package is not compatible with Sublime Text 4. """
-            """Please remove and reinstall this package to receive a version compatible with ST4. """
-            """Remember to restart Sublime Text after."""
-        )

--- a/boot.py
+++ b/boot.py
@@ -1,12 +1,11 @@
 import sublime
-from .plugin import __version__
 
-if __version__ <= (0, 11, 0) and int(sublime.version()) > 4000:
+if int(sublime.version()) > 4000:
     sublime.error_message(
-        """Installed version of LSP package is not compatible with Sublime Text 4.\n"""
-        """Please remove and re-install this package to receive ST4-compatible version."""
+        """The installed version of LSP package is not compatible with Sublime Text 4.\n"""
+        """Please remove and reinstall this package to receive version compatible with ST4.\n"""
+        """Remember to restart Sublime Text after.\n"""
     )
-
 
 # Please keep this list sorted (Edit -> Sort Lines)
 from .plugin.code_actions import LspCodeActionBulbListener

--- a/boot.py
+++ b/boot.py
@@ -1,3 +1,13 @@
+import sublime
+from .plugin import __version__
+
+if __version__ <= (0, 11, 0) and int(sublime.version()) > 4000:
+    sublime.error_message(
+        """Installed version of LSP package is not compatible with Sublime Text 4.\n"""
+        """Please remove and re-install this package to receive ST4-compatible version."""
+    )
+
+
 # Please keep this list sorted (Edit -> Sort Lines)
 from .plugin.code_actions import LspCodeActionBulbListener
 from .plugin.code_actions import LspCodeActionsCommand

--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -32,8 +32,7 @@ def plugin_loaded() -> None:
         sublime.error_message(
             """The currently installed version of LSP package is not compatible with Sublime Text 4. """
             """Please remove and reinstall this package to receive a version compatible with ST4. """
-            """Remember to restart Sublime Text after."""
-        )
+            """Remember to restart Sublime Text after.""")
 
 
 def plugin_unloaded() -> None:

--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -15,7 +15,7 @@ def ensure_server_panel(window: sublime.Window) -> Optional[sublime.View]:
     return ensure_panel(window, PanelName.LanguageServers, "", "", "Packages/LSP/Syntaxes/ServerLog.sublime-syntax")
 
 
-def startup() -> None:
+def plugin_loaded() -> None:
     load_settings()
     popups.load_css()
     set_debug_logging(settings.log_debug)
@@ -28,9 +28,15 @@ def startup() -> None:
     window = sublime.active_window()
     if window:
         windows.lookup(window).start_active_views()
+    if int(sublime.version()) > 4000:
+        sublime.error_message(
+            """The currently installed version of LSP package is not compatible with Sublime Text 4. """
+            """Please remove and reinstall this package to receive a version compatible with ST4. """
+            """Remember to restart Sublime Text after."""
+        )
 
 
-def shutdown() -> None:
+def plugin_unloaded() -> None:
     # Also needs to handle package being disabled or removed
     # https://github.com/sublimelsp/LSP/issues/375
     unload_settings()


### PR DESCRIPTION
Since users upgrading to ST4 won't get automatically updated (apparently) to ST4-compatible LSP, we should do something about it or it can become a major hassle.

This is a proof of concept how we could handle it.

It doesn't work as-is, because both ST3 and ST4 versions of LSP use the same `__version__`. We should IMO actually bump `__version__` of ST4 branch a bunch of notches so that we can differentiate them. Then we can implement this solution properly.