### PR TITLE
Fix white space within links not being clickable

### DIFF
--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -169,3 +169,7 @@ def text_document_range_formatting(view: sublime.View, region: sublime.Region) -
         "options": formatting_options(view.settings()),
         "range": region_to_range(view, region).to_lsp()
     })
+
+
+def make_link(href: str, text: str) -> str:
+    return "<a href='{}'>{}</a>".format(href, text.replace(' ', '&nbsp;'))

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -12,6 +12,7 @@ from .core.protocol import Request, DiagnosticSeverity, Diagnostic, DiagnosticRe
 from .core.registry import session_for_view, LspTextCommand, windows
 from .core.settings import client_configs, settings
 from .core.typing import List, Optional, Any, Dict
+from .core.views import make_link
 from .core.views import text_document_position_params
 from .diagnostics import filter_by_point, view_diagnostics
 
@@ -120,11 +121,11 @@ class LspHoverCommand(LspTextCommand):
         actions = []
         for goto_kind in goto_kinds:
             if self.has_client_with_capability(goto_kind.lsp_name + "Provider"):
-                actions.append("<a href='{}'>{}</a>".format(goto_kind.lsp_name, goto_kind.label))
+                actions.append(make_link(goto_kind.lsp_name, goto_kind.label))
         if self.has_client_with_capability('referencesProvider'):
-            actions.append("<a href='{}'>{}</a>".format('references', 'References'))
+            actions.append(make_link('references', 'References'))
         if self.has_client_with_capability('renameProvider'):
-            actions.append("<a href='{}'>{}</a>".format('rename', 'Rename'))
+            actions.append(make_link('rename', 'Rename'))
         return "<p class='actions'>" + " | ".join(actions) + "</p>"
 
     def format_diagnostic_related_info(self, info: DiagnosticRelatedInformation) -> str:
@@ -132,7 +133,8 @@ class LspHoverCommand(LspTextCommand):
         if self._base_dir and file_path.startswith(self._base_dir):
             file_path = os.path.relpath(file_path, self._base_dir)
         location = "{}:{}:{}".format(file_path, info.location.range.start.row+1, info.location.range.start.col+1)
-        return "<a href='location:{}'>{}</a>: {}".format(location, location, escape(info.message))
+        link = make_link("location:{}".format(location), location)
+        return "{}: {}".format(link, escape(info.message))
 
     def format_diagnostic(self, diagnostic: 'Diagnostic') -> str:
         diagnostic_message = escape(diagnostic.message, False).replace('\n', '<br>')
@@ -162,8 +164,9 @@ class LspHoverCommand(LspTextCommand):
             if config_name in self._actions_by_config:
                 action_count = len(self._actions_by_config[config_name])
                 if action_count > 0:
-                    formatted.append("<div class=\"actions\"><a href='{}:{}'>{} ({})</a></div>".format(
-                        'code-actions', config_name, 'Code Actions', action_count))
+                    href = "{}:{}".format('code-actions', config_name)
+                    text = "{} ({})".format('Code Actions', action_count)
+                    formatted.append("<div class=\"actions\">{}</div>".format(make_link(href, text)))
 
             formatted.append("</div>")
 


### PR DESCRIPTION
ST is behaving weird and non-HTML-like when there are spaces within
an anchor. Those should still be part of the link and clickable but
in ST they are not. Work around by replacing spaces with non-breakable
ones.