### PR TITLE
Load "settings" from base file for plugin authors

### DIFF
--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -19,7 +19,7 @@ from .settings import client_configs
 from .settings import settings, load_settings, unload_settings
 from .transports import kill_all_subprocesses
 from .types import ClientConfig
-from .typing import Optional, List, Type, Callable, Dict
+from .typing import Optional, List, Type, Callable, Dict, Tuple
 import weakref
 
 
@@ -61,7 +61,7 @@ def _forcefully_register_plugins() -> None:
                 return cls.handler.name  # type: ignore
 
             @classmethod
-            def configuration(cls) -> sublime.Settings:
+            def configuration(cls) -> Tuple[sublime.Settings, str]:
                 file_base_name = cls.name()
                 if file_base_name.startswith("lsp-"):
                     file_base_name = "LSP-" + file_base_name[len("lsp-"):]
@@ -78,7 +78,7 @@ def _forcefully_register_plugins() -> None:
                         "feature_selector": language.feature_selector
                     })
                 settings.set("languages", langs)
-                return settings
+                return settings, "Packages/{0}/{0}.sublime-settings".format(file_base_name)
 
             @classmethod
             def can_start(cls, window: sublime.Window, initiating_view: sublime.View,

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -292,10 +292,14 @@ class AbstractPlugin(metaclass=ABCMeta):
     @classmethod
     def configuration(cls) -> sublime.Settings:
         """
-        The Settings object that defines the `command`, `languages`, and optionally the `initializationOptions`,
-        `settings`, `env` and `tcp_port`.
+        The Settings object that defines the "command", "languages", and optionally the "initializationOptions",
+        "default_settings", "env" and "tcp_port".
 
-        The `command`, `initializationOptions` and `env` are subject to template string substitution. The following
+        The "settings" dict is also supported, but not recommended for use. Because when a user defines its own
+        settings, the entire dict is overwritten. Because sublime.Settings objects don't recurse overrides in JSON
+        objects. Define your default settings in the "default_settings" object.
+
+        The "command", "initializationOptions" and "env" are subject to template string substitution. The following
         template strings are recognized:
 
         $file
@@ -315,14 +319,14 @@ class AbstractPlugin(metaclass=ABCMeta):
         $cache_path   sublime.cache_path()
         $temp_dir     tempfile.gettempdir()
         $home         os.path.expanduser('~')
-        $port         A random free TCP-port on localhost in case `tcp_port` is set to 0. This string template can only
-                      be used in the `command`
+        $port         A random free TCP-port on localhost in case "tcp_port" is set to 0. This string template can only
+                      be used in the "command"
 
-        The `command` and `env` are expanded upon starting the subprocess of the Session. The `initializationOptions`
-        are expanded upon doing the initialize request. `initializationOptions` does not expand $port.
+        The "command" and "env" are expanded upon starting the subprocess of the Session. The "initializationOptions"
+        are expanded upon doing the initialize request. "initializationOptions" does not expand $port.
 
         When you're managing your own server binary, you would typically place it in sublime.cache_path(). So your
-        `command` should look like this: "command": ["$cache_path/LSP-foobar/server_binary", "--stdio"]
+        "command" should look like this: "command": ["$cache_path/LSP-foobar/server_binary", "--stdio"]
         """
         return sublime.load_settings('LSP-{}.sublime-settings'.format(cls.name()))
 

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -113,6 +113,8 @@ class ClientConfigs(object):
             self._listener()
 
     def add_external_config(self, name: str, s: sublime.Settings) -> None:
+        settings = DottedDict(read_dict_setting(s, "default_settings", {}))  # defined by the plugin author
+        settings.update(read_dict_setting(s, "settings", {}))  # overrides from the user
         config = ClientConfig(
             name=name,
             binary_args=read_array_setting(s, "command", []),
@@ -121,7 +123,7 @@ class ClientConfigs(object):
             # Default to True, because an LSP plugin is enabled iff it is enabled as a Sublime package.
             enabled=bool(s.get("enabled", True)),
             init_options=s.get("initializationOptions"),  # type: ignore
-            settings=DottedDict(read_dict_setting(s, "settings", {})),
+            settings=settings,
             env=read_dict_setting(s, "env", {}),
             tcp_host=s.get("tcp_host", None),
             tcp_mode=s.get("tcp_mode", None),

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -112,8 +112,9 @@ class ClientConfigs(object):
         if self._listener:
             self._listener()
 
-    def add_external_config(self, name: str, s: sublime.Settings) -> None:
-        settings = DottedDict(read_dict_setting(s, "default_settings", {}))  # defined by the plugin author
+    def add_external_config(self, name: str, s: sublime.Settings, file: str) -> None:
+        base = sublime.decode_value(sublime.load_resource(file))
+        settings = DottedDict(base.get("settings", {}))  # defined by the plugin author
         settings.update(read_dict_setting(s, "settings", {}))  # overrides from the user
         config = ClientConfig(
             name=name,


### PR DESCRIPTION
Then, users have to override settings with "settings".

I tested this with LSP-eslint. I modified Packages/LSP-eslint/LSP-eslint.sublime-settings as follows:

```js
{
	"languages": [
		{"languageId": "javascriptreact", "document_selector": "source.js.react | source.jsx"},		
		{"languageId": "javascript",      "document_selector": "source.js"},
		{"languageId": "vue",             "document_selector": "text.html.vue"}
	],
	"initializationOptions": {},
	"default_settings": {
		"validate": true,
		"packageManager": "npm",
		"autoFix": true,
		"autoFixOnSave": true,
		"options": {},
		"run": "onType",
		"nodePath": null,
		"quiet": false,
		"workspaceFolder": null,
		"codeAction.disableRuleComment.enable": true,
		"codeAction.disableRuleComment.location": "separateLine",
		"codeAction.showDocumentation.enable": true
	},
}
```

I then ran "Preferences: LSP-eslint settings" from the command palette and put the following in my Packages/User/LSP-eslint.sublime-settings:

```js
// Settings in here override those in "LSP-eslint/LSP-eslint.sublime-settings"
{
	// Overrides for "default_settings"
	"settings":
	{
		"codeAction.disableRuleComment.enable": false
	}
}
```

The workspace/didChangeConfiguration notification correctly sent the override:

```
::  -> lsp-eslint workspace/didChangeConfiguration: {'settings': {'codeAction': {'showDocumentation': {'enable': True}, 'disableRuleComment': {'location': 'separateLine', 'enable': False}}, 'quiet': False, 'workspaceFolder': None, 'run': 'onType', 'nodePath': None, 'validate': True, 'packageManager': 'npm', 'autoFixOnSave': True, 'autoFix': True}}
``` 