### PR TITLE
The context commands are broken due to want_event

### DIFF
--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -181,7 +181,7 @@ class LspCodeActionsCommand(LspTextCommand):
 
     capability = 'codeActionProvider'
 
-    def run(self, edit: sublime.Edit) -> None:
+    def run(self, edit: sublime.Edit, event: Optional[dict] = None) -> None:
         self.commands = []  # type: List[Tuple[str, str, CodeActionOrCommand]]
         self.commands_by_config = {}  # type: CodeActionsByConfigName
         actions_manager.request(self.view, self.view.sel()[0].begin(), self.handle_responses)

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -104,16 +104,13 @@ class LspTextCommand(sublime_plugin.TextCommand):
 
     capability = ''
 
-    def is_visible(self, event: Optional[dict] = None) -> bool:
+    def is_enabled(self, event: Optional[dict] = None) -> bool:
         if self.capability:
             # At least one active session with the given capability must exist.
             return bool(self.session(self.capability, get_position(self.view, event)))
         else:
             # Any session will do.
             return any(self.sessions())
-
-    def is_enabled(self, event: Optional[dict] = None) -> bool:
-        return self.is_visible(event)
 
     def want_event(self) -> bool:
         return True

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -13,7 +13,8 @@ class LspExecuteCommand(LspTextCommand):
     def run(self,
             edit: sublime.Edit,
             command_name: Optional[str] = None,
-            command_args: Optional[List[Any]] = None) -> None:
+            command_args: Optional[List[Any]] = None,
+            event: Optional[dict] = None) -> None:
         session = self.session(self.capability)
         if session and command_name:
             window = self.view.window()

--- a/plugin/formatting.py
+++ b/plugin/formatting.py
@@ -56,7 +56,7 @@ class LspFormatDocumentCommand(LspTextCommand):
 
     capability = 'documentFormattingProvider'
 
-    def run(self, edit: sublime.Edit) -> None:
+    def run(self, edit: sublime.Edit, event: Optional[dict] = None) -> None:
         session = self.session(self.capability)
         file_path = self.view.file_name()
         if session and file_path:
@@ -77,7 +77,7 @@ class LspFormatDocumentRangeCommand(LspTextCommand):
                     return True
         return False
 
-    def run(self, edit: sublime.Edit) -> None:
+    def run(self, edit: sublime.Edit, event: Optional[dict] = None) -> None:
         session = self.session(self.capability)
         file_path = self.view.file_name()
         if session and file_path:

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -72,7 +72,7 @@ class LspHoverCommand(LspTextCommand):
         word_at_sel = self.view.classify(point)
         return bool(word_at_sel & SUBLIME_WORD_MASK)
 
-    def run(self, edit: sublime.Edit, point: Optional[int] = None) -> None:
+    def run(self, edit: sublime.Edit, point: Optional[int] = None, event: Optional[dict] = None) -> None:
         hover_point = point or self.view.sel()[0].begin()
         self._base_dir = windows.lookup(self.view.window()).get_project_path(self.view.file_name() or "")
 


### PR DESCRIPTION
Every LSP text command must have an optional `event` parameter in its `run` method.