### PR TITLE
Implement Code Actions On Save

### DIFF
--- a/Keymaps/Default (Linux).sublime-keymap
+++ b/Keymaps/Default (Linux).sublime-keymap
@@ -62,4 +62,7 @@
 
     // Symbol Hover
     // {"keys": ["UNBOUND"], "command": "lsp_hover", "context": [{"key": "setting.lsp_active"}]},
+
+    // Override native save to handle Code-Actions-On-Save
+    { "keys": ["ctrl+s"], "command": "lsp_save", "context": [{ "key": "setting.lsp_active"}] },
 ]

--- a/Keymaps/Default (OSX).sublime-keymap
+++ b/Keymaps/Default (OSX).sublime-keymap
@@ -62,4 +62,7 @@
 
     // Symbol Hover
     // {"keys": ["UNBOUND"], "command": "lsp_hover", "context": [{"key": "setting.lsp_active"}]},
+
+    // Override native save to handle Code-Actions-On-Save
+    { "keys": ["super+s"], "command": "lsp_save", "context": [{ "key": "setting.lsp_active"}] },
 ]

--- a/Keymaps/Default (Windows).sublime-keymap
+++ b/Keymaps/Default (Windows).sublime-keymap
@@ -62,4 +62,7 @@
 
     // Symbol Hover
     // {"keys": ["UNBOUND"], "command": "lsp_hover", "context": [{"key": "setting.lsp_active"}]},
+
+    // Override native save to handle Code-Actions-On-Save
+    { "keys": ["ctrl+s"], "command": "lsp_save", "context": [{ "key": "setting.lsp_active"}] },
 ]

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -8,6 +8,22 @@
   // Valid values are "never", "always" and "saved"
   "auto_show_diagnostics_panel": "saved",
 
+  // A dictionary of code action identifiers that should be triggered on save.
+  //
+  // Code action identifiers are not officially standardized so refer to specific
+  // server's documentation on what is supported but `source.fixAll` is commonly
+  // used to apply fix-on-save code action.
+  //
+  // It's also supported to set this in project-specific settings in which case
+  // it will only apply in that specific project. Setting it here will apply globally,
+  // unless overridden by project-specific settings.
+  //
+  // Only "source.*" actions are supported.
+  "lsp_code_actions_on_save": {},
+
+  // The amount of time the code actions on save are allowed to run for.
+  "code_action_on_save_timeout_ms": 2000,
+
   // Open the diagnostics panel automatically
   // when diagnostics level is equal to or less than:
   // error: 1

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -8,19 +8,23 @@
   // Valid values are "never", "always" and "saved"
   "auto_show_diagnostics_panel": "saved",
 
+  // Run the server's formatProvider (if supported) on a document before saving.
+  // This option is also supported in syntax-specific settings and/or in project files.
+  "lsp_format_on_save": false,
+
   // A dictionary of code action identifiers that should be triggered on save.
   //
   // Code action identifiers are not officially standardized so refer to specific
   // server's documentation on what is supported but `source.fixAll` is commonly
-  // used to apply fix-on-save code action.
+  // used to apply fix-on-save code actions.
   //
-  // It's also supported to set this in project-specific settings in which case
-  // it will only apply in that specific project. Setting it here will apply globally,
-  // unless overridden by project-specific settings.
+  // This option is also supported in syntax-specific settings and/or in project files.
+  // Settings from all places will be merged and more specific (syntax and project) settings will
+  // override less specific (from LSP or Sublime settings).
   //
   // Only "source.*" actions are supported.
   "lsp_code_actions_on_save": {
-    // "source.fixAll": True
+    // "source.fixAll": true
   },
 
   // The amount of time the code actions on save are allowed to run for.

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -19,7 +19,9 @@
   // unless overridden by project-specific settings.
   //
   // Only "source.*" actions are supported.
-  "lsp_code_actions_on_save": {},
+  "lsp_code_actions_on_save": {
+    // "source.fixAll": True
+  },
 
   // The amount of time the code actions on save are allowed to run for.
   "code_action_on_save_timeout_ms": 2000,

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -9,7 +9,8 @@
   "auto_show_diagnostics_panel": "saved",
 
   // Run the server's formatProvider (if supported) on a document before saving.
-  // This option is also supported in syntax-specific settings and/or in project files.
+  // This option is also supported in syntax-specific settings and/or in the "settings" section
+  // of project files
   "lsp_format_on_save": false,
 
   // A dictionary of code action identifiers that should be triggered on save.
@@ -18,9 +19,9 @@
   // server's documentation on what is supported but `source.fixAll` is commonly
   // used to apply fix-on-save code actions.
   //
-  // This option is also supported in syntax-specific settings and/or in project files.
-  // Settings from all places will be merged and more specific (syntax and project) settings will
-  // override less specific (from LSP or Sublime settings).
+  // This option is also supported in syntax-specific settings and/or in the "settings" section of
+  // project files. Settings from all those places will be merged and more specific (syntax and
+  // project) settings will override less specific (from LSP or Sublime settings).
   //
   // Only "source.*" actions are supported.
   "lsp_code_actions_on_save": {

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -9,8 +9,8 @@
   "auto_show_diagnostics_panel": "saved",
 
   // Run the server's formatProvider (if supported) on a document before saving.
-  // This option is also supported in syntax-specific settings and/or in the "settings" section
-  // of project files
+  // This option is also supported in syntax-specific settings and/or in the
+  // "settings" section of project files.
   "lsp_format_on_save": false,
 
   // A dictionary of code action identifiers that should be triggered on save.
@@ -19,9 +19,10 @@
   // server's documentation on what is supported but `source.fixAll` is commonly
   // used to apply fix-on-save code actions.
   //
-  // This option is also supported in syntax-specific settings and/or in the "settings" section of
-  // project files. Settings from all those places will be merged and more specific (syntax and
-  // project) settings will override less specific (from LSP or Sublime settings).
+  // This option is also supported in syntax-specific settings and/or in the
+  // "settings" section of project files. Settings from all those places will be
+  // merged and more specific (syntax and project) settings will override less
+  // specific (from LSP or Sublime settings).
   //
   // Only "source.*" actions are supported.
   "lsp_code_actions_on_save": {

--- a/boot.py
+++ b/boot.py
@@ -1,6 +1,7 @@
 # Please keep this list sorted (Edit -> Sort Lines)
 from .plugin.code_actions import LspCodeActionBulbListener
 from .plugin.code_actions import LspCodeActionsCommand
+from .plugin.code_actions import LspSaveCommand
 from .plugin.color import LspColorListener
 from .plugin.completion import CompletionHandler
 from .plugin.completion import LspCompleteInsertTextCommand

--- a/docs/features.md
+++ b/docs/features.md
@@ -115,7 +115,7 @@ https://stackoverflow.com/questions/16235706/sublime-3-set-key-map-for-function-
 
 ### Sublime settings
 
-Add these settings to your Sublime settings, Syntax-specific settings and/or in Project files.
+Add these settings to LSP settings, your Sublime settings, Syntax-specific settings and/or in Project files.
 
 * `lsp_format_on_save` `false` *run the server's formatProvider (if supported) on a document before saving.*
 * `lsp_code_actions_on_save` `{}` *request code actions with specified identifiers to trigger before saving.*

--- a/docs/features.md
+++ b/docs/features.md
@@ -118,10 +118,12 @@ https://stackoverflow.com/questions/16235706/sublime-3-set-key-map-for-function-
 Add these settings to your Sublime settings, Syntax-specific settings and/or in Project files.
 
 * `lsp_format_on_save` `false` *run the server's formatProvider (if supported) on a document before saving.*
+* `lsp_code_actions_on_save` `{}` *request code actions with specified identifiers to trigger before saving.*
 
 ### Package settings (LSP)
 
 * `only_show_lsp_completions` `false` *disable sublime word completion and snippets from autocomplete lists*
+* `code_action_on_save_timeout_ms` `2000` *the amount of time the code actions on save are allowed to run for*
 * `show_references_in_quick_panel` `false` *show symbol references in Sublime's quick panel instead of the bottom panel*
 * `show_view_status` `true` *show permanent language server status in the status bar*
 * `auto_show_diagnostics_panel` `always` (`never`, `saved`) *open the diagnostics panel automatically if there are diagnostics*

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -235,7 +235,7 @@ class LspSaveCommand(sublime_plugin.TextCommand):
 
     def _trigger_native_save(self) -> None:
         self._task = None
-        # Triggered from set timeout to preserve original semantics of on_pre_save handling
+        # Triggered from set_timeout to preserve original semantics of on_pre_save handling
         sublime.set_timeout(lambda: self.view.run_command('save', {"async": True}))
 
 

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -255,19 +255,12 @@ class CodeActionOnSaveTask:
         self._on_done = on_done
         self._completed = False
         self._canceled = False
-        # TODO: For limiting number of iterations the task can run. Maybe not needed since there is a timeout?
-        self._iteration = 0
 
     def run(self) -> None:
         sublime.set_timeout(self._on_timeout, settings.code_action_on_save_timeout_ms)
         self._request_code_actions()
 
     def _request_code_actions(self) -> None:
-        self._iteration += 1
-        if self._iteration > 3:
-            debug('Stopped applying Code-Actions-On-Save due to reaching iteration limit')
-            self._on_complete()
-            return
         self._manager.documents.purge_changes(self._view)
         request_code_actions_on_save(self._view, self._handle_response, self._on_save_actions)
 

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -1,5 +1,4 @@
 from .core.edit import parse_workspace_edit
-from .core.logging import debug
 from .core.protocol import Diagnostic
 from .core.protocol import Request, Point
 from .core.registry import LspTextCommand

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -236,7 +236,8 @@ class LspSaveCommand(sublime_plugin.TextCommand):
 
     def _trigger_native_save(self) -> None:
         self._task = None
-        self.view.run_command('save', {"async": True})
+        # Triggered from set timeout to preserve original semantics of on_pre_save handling
+        sublime.set_timeout(lambda: self.view.run_command('save', {"async": True}))
 
 
 class CodeActionOnSaveTask:

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -1,4 +1,5 @@
 from .core.edit import parse_workspace_edit
+from .core.logging import debug
 from .core.protocol import Diagnostic
 from .core.protocol import Request, Point
 from .core.registry import LspTextCommand
@@ -263,6 +264,7 @@ class CodeActionOnSaveTask:
     def _request_code_actions(self) -> None:
         self._iteration += 1
         if self._iteration > 3:
+            debug('Stopped applying Code Actions On Save due to reaching iteration limit')
             self._on_complete()
             return
         self._manager.documents.purge_changes(self._view)
@@ -283,6 +285,8 @@ class CodeActionOnSaveTask:
 
     def _on_timeout(self) -> None:
         if not self._completed and not self._canceled:
+            debug('Aborted process Code Actions On Save due to taking longer than {}ms'.format(
+                settings.code_action_on_save_timeout_ms))
             self._canceled = True
             self._on_complete()
 

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -264,7 +264,7 @@ class CodeActionOnSaveTask:
     def _request_code_actions(self) -> None:
         self._iteration += 1
         if self._iteration > 3:
-            debug('Stopped applying Code Actions On Save due to reaching iteration limit')
+            debug('Stopped applying Code-Actions-On-Save due to reaching iteration limit')
             self._on_complete()
             return
         self._manager.documents.purge_changes(self._view)
@@ -285,7 +285,7 @@ class CodeActionOnSaveTask:
 
     def _on_timeout(self) -> None:
         if not self._completed and not self._canceled:
-            debug('Aborted process Code Actions On Save due to taking longer than {}ms'.format(
+            debug('Aborted processing of Code-Actions-On-Save due to taking longer than {}ms'.format(
                 settings.code_action_on_save_timeout_ms))
             self._canceled = True
             self._on_complete()

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -153,7 +153,14 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
                 "dynamicRegistration": True,
                 "codeActionLiteralSupport": {
                     "codeActionKind": {
-                        "valueSet": ["quickfix", "refactor"]
+                        "valueSet": [
+                            "quickfix",
+                            "refactor",
+                            "refactor.extract",
+                            "refactor.inline",
+                            "refactor.rewrite",
+                            "source.organizeImports"
+                        ]
                     }
                 }
             },

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -153,7 +153,7 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
                 "dynamicRegistration": True,
                 "codeActionLiteralSupport": {
                     "codeActionKind": {
-                        "valueSet": []
+                        "valueSet": ["quickfix", "refactor"]
                     }
                 }
             },
@@ -537,6 +537,9 @@ class Session(Client):
         execute_commands = self.get_capability('executeCommandProvider.commands')
         if execute_commands:
             debug("{}: Supported execute commands: {}".format(self.config.name, execute_commands))
+        code_action_kinds = self.get_capability('codeActionProvider.codeActionKinds')
+        if code_action_kinds:
+            debug('{}: supported code action kinds: {}'.format(self.config.name, code_action_kinds))
         mgr = self.manager()
         if mgr:
             mgr.on_post_initialize(self)

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -82,6 +82,8 @@ def update_settings(settings: Settings, settings_obj: sublime.Settings) -> None:
     settings.log_server = read_bool_setting(settings_obj, "log_server", True)
     settings.log_stderr = read_bool_setting(settings_obj, "log_stderr", False)
     settings.log_payloads = read_bool_setting(settings_obj, "log_payloads", False)
+    settings.lsp_code_actions_on_save = read_dict_setting(settings_obj, "lsp_code_actions_on_save", {})
+    settings.code_action_on_save_timeout_ms = read_int_setting(settings_obj, "code_action_on_save_timeout_ms", 2000)
 
 
 class ClientConfigs(object):

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -82,6 +82,7 @@ def update_settings(settings: Settings, settings_obj: sublime.Settings) -> None:
     settings.log_server = read_bool_setting(settings_obj, "log_server", True)
     settings.log_stderr = read_bool_setting(settings_obj, "log_stderr", False)
     settings.log_payloads = read_bool_setting(settings_obj, "log_payloads", False)
+    settings.lsp_format_on_save = read_bool_setting(settings_obj, "lsp_format_on_save", False)
     settings.lsp_code_actions_on_save = read_dict_setting(settings_obj, "lsp_code_actions_on_save", {})
     settings.code_action_on_save_timeout_ms = read_int_setting(settings_obj, "code_action_on_save_timeout_ms", 2000)
 

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -30,6 +30,8 @@ class Settings(object):
         self.log_server = True
         self.log_stderr = False
         self.log_payloads = False
+        self.lsp_code_actions_on_save = {}  # type: Dict[str, bool]
+        self.code_action_on_save_timeout_ms = 2000
 
 
 class ClientStates(object):

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -30,6 +30,7 @@ class Settings(object):
         self.log_server = True
         self.log_stderr = False
         self.log_payloads = False
+        self.lsp_format_on_save = False
         self.lsp_code_actions_on_save = {}  # type: Dict[str, bool]
         self.code_action_on_save_timeout_ms = 2000
 

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -151,6 +151,10 @@ def entire_content(view: sublime.View) -> str:
     return view.substr(sublime.Region(0, view.size()))
 
 
+def entire_content_range(view: sublime.View) -> Range:
+    return region_to_range(view, sublime.Region(0, view.size()))
+
+
 def text_document_item(view: sublime.View, language_id: str) -> Dict[str, Any]:
     return {
         "uri": uri_from_view(view),

--- a/plugin/formatting.py
+++ b/plugin/formatting.py
@@ -28,8 +28,9 @@ class FormatOnSaveListener(LSPViewEventListener):
             self._purge_changes_if_needed()
             self._will_save_wait_until(session)
 
-        format_on_save = self.view.settings().get("lsp_format_on_save", None)
-        if (format_on_save is not None and format_on_save) or settings.lsp_format_on_save:
+        view_format_on_save = self.view.settings().get("lsp_format_on_save", None)
+        enabled = view_format_on_save if isinstance(view_format_on_save, bool) else settings.lsp_format_on_save
+        if enabled:
             self._purge_changes_if_needed()
             self._format_on_save()
 

--- a/plugin/formatting.py
+++ b/plugin/formatting.py
@@ -3,6 +3,7 @@ from .core.edit import parse_text_edit
 from .core.registry import LspTextCommand, LSPViewEventListener, session_for_view
 from .core.registry import sessions_for_view
 from .core.sessions import Session
+from .core.settings import settings
 from .core.typing import Any, List, Optional
 from .core.views import will_save_wait_until, text_document_formatting, text_document_range_formatting
 
@@ -27,7 +28,8 @@ class FormatOnSaveListener(LSPViewEventListener):
             self._purge_changes_if_needed()
             self._will_save_wait_until(session)
 
-        if self.view.settings().get("lsp_format_on_save"):
+        format_on_save = self.view.settings().get("lsp_format_on_save", None)
+        if (format_on_save is not None and format_on_save) or settings.lsp_format_on_save:
             self._purge_changes_if_needed()
             self._format_on_save()
 

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -100,7 +100,7 @@ class LspHoverCommand(LspTextCommand):
                 lambda response: self.handle_response(response, point))
 
     def request_code_actions(self, point: int) -> None:
-        actions_manager.request(self.view, point, lambda response: self.handle_code_actions(response, point))
+        actions_manager.request(self.view, lambda response: self.handle_code_actions(response, point), point)
 
     def handle_code_actions(self, responses: Dict[str, List[CodeActionOrCommand]], point: int) -> None:
         self._actions_by_config = responses

--- a/tests/server.py
+++ b/tests/server.py
@@ -261,7 +261,7 @@ class Session:
                 self._reply(request_id, self._responses.pop(method))
             elif request_id is not None:
                 self._error(request_id, Error(
-                    ErrorCode.MethodNotFound, "method not found"))
+                    ErrorCode.MethodNotFound, "method '{}' not found".format(method)))
             else:
                 if unhandled:
                     self._log(f"unhandled {typestr} {method}")

--- a/tests/server.py
+++ b/tests/server.py
@@ -173,7 +173,7 @@ class Session:
         self._received_shutdown = False
 
         # properties used for testing purposes
-        self._responses: Dict[str, PayloadLike] = {}
+        self._responses: List[Tuple[str, PayloadLike]] = []
         self._received: Dict[str, PayloadLike] = {}
         self._received_cv = asyncio.Condition()
 
@@ -256,9 +256,10 @@ class Session:
                 unhandled = False
         handler = handlers.get(method)
         if handler is None:
-            if method in self._responses:
+            mocked_response = self._get_mocked_response(method)
+            if not isinstance(mocked_response, bool):
                 assert request_id is not None
-                self._reply(request_id, self._responses.pop(method))
+                self._reply(request_id, mocked_response)
             elif request_id is not None:
                 self._error(request_id, Error(
                     ErrorCode.MethodNotFound, "method '{}' not found".format(method)))
@@ -282,6 +283,14 @@ class Session:
             except Exception as ex:
                 if not self._received_shutdown:
                     self._notify("window/logMessage", {"type": MessageType.error, "message": str(ex)})
+
+    def _get_mocked_response(self, method: str) -> Union[PayloadLike, bool]:
+        for response in self._responses:
+            resp_method, resp_payload = response
+            if resp_method == method:
+                self._responses.remove(response)
+                return resp_payload
+        return False
 
     async def _handle_body(self, body: bytes) -> None:
         try:
@@ -323,11 +332,23 @@ class Session:
         self._on_request("$test/getReceived", self._get_received)
         self._on_request("$test/fakeRequest", self._fake_request)
         self._on_request("$test/sendNotification", self._send_notification)
+        self._on_request("$test/setResponses", self._set_responses)
         self._on_notification("$test/setResponse", self._on_set_response)
 
     async def _on_set_response(self, params: PayloadLike) -> None:
         if isinstance(params, dict):
-            self._responses[params["method"]] = params["response"]
+            self._responses.append((params["method"], params["response"]))
+
+    async def _set_responses(self, params: PayloadLike) -> PayloadLike:
+        if not isinstance(params, list):
+            raise Error(ErrorCode.InvalidParams, 'expected responses to be a list')
+
+        for param in params:
+            if not isinstance(param, dict) or 'method' not in param or 'response' not in param:
+                raise Error(ErrorCode.InvalidParams, 'expected a response object to have a method and params keys')
+
+        self._responses.extend([(param['method'], param['response']) for param in params])
+        return None
 
     async def _send_notification(self, params: PayloadLike) -> PayloadLike:
         method, payload = self._validate_request_params(params)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -1,13 +1,12 @@
 from LSP.plugin.core.documents import DocumentSyncListener
 from LSP.plugin.core.logging import debug
-from LSP.plugin.core.protocol import Notification, Request, WorkspaceFolder
+from LSP.plugin.core.protocol import Notification, Request
 from LSP.plugin.core.registry import windows
 from LSP.plugin.core.sessions import Session
 from LSP.plugin.core.settings import client_configs
 from LSP.plugin.core.types import ClientConfig, LanguageConfig, ClientStates
 from LSP.plugin.core.typing import Any, Optional, Generator
 from os import environ
-from os.path import dirname
 from os.path import join
 from sublime_plugin import view_event_listeners
 from test_mocks import basic_responses
@@ -17,9 +16,6 @@ import sublime
 
 CI = any(key in environ for key in ("TRAVIS", "CI", "GITHUB_ACTIONS"))
 
-project_path = dirname(__file__)
-test_file_path = join(project_path, "testfile.txt")
-workspace_folders = [WorkspaceFolder.from_path(project_path)]
 TIMEOUT_TIME = 10000 if CI else 2000
 text_language = LanguageConfig(language_id="text", document_selector="text.plain")
 text_config = ClientConfig(

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -5,7 +5,7 @@ from LSP.plugin.core.registry import windows
 from LSP.plugin.core.sessions import Session
 from LSP.plugin.core.settings import client_configs
 from LSP.plugin.core.types import ClientConfig, LanguageConfig, ClientStates
-from LSP.plugin.core.typing import Any, Optional, Generator
+from LSP.plugin.core.typing import Any, Generator, List, Optional, Tuple
 from os import environ
 from os.path import join
 from sublime_plugin import view_event_listeners
@@ -186,6 +186,21 @@ class TextDocumentTestCase(DeferrableTestCase):
         assert self.session  # mypy
         self.session.send_notification(
             Notification("$test/setResponse", {"method": method, "response": response}))
+
+    def set_responses(self, responses: List[Tuple[str, Any]]) -> Generator:
+        self.assertIsNotNone(self.session)
+        assert self.session  # mypy
+        promise = YieldPromise()
+
+        def handler(params: Any) -> None:
+            promise.fulfill(params)
+
+        def error_handler(params: Any) -> None:
+            debug("Got error:", params, "awaiting timeout :(")
+
+        payload = [{"method": method, "response": responses} for method, responses in responses]
+        self.session.send_request(Request("$test/setResponses", payload), handler, error_handler)
+        yield from self.await_promise(promise)
 
     def await_client_notification(self, method: str, params: Any = None) -> 'Generator':
         self.assertIsNotNone(self.session)

--- a/tests/test_code_actions.py
+++ b/tests/test_code_actions.py
@@ -1,22 +1,25 @@
+from copy import deepcopy
 from LSP.plugin.core.protocol import Point, Range
 from LSP.plugin.core.typing import Dict, Generator, List, Tuple
 from LSP.plugin.core.url import filename_to_uri
 from LSP.plugin.core.views import entire_content
+from LSP.plugin.code_actions import get_matching_kinds
 from LSP.plugin.code_actions import run_code_action_or_command
 from setup import TextDocumentTestCase
 from test_single_document import TEST_FILE_PATH
+import unittest
 
 TEST_FILE_URI = filename_to_uri(TEST_FILE_PATH)
 
 
-def create_test_code_actions(document_version: int, edits: List[Tuple[str, Range]]) -> Dict:
+def create_test_code_action(document_version: int, edits: List[Tuple[str, Range]], kind: str = None) -> Dict:
     def edit_to_lsp(edit: Tuple[str, Range]) -> Dict:
         new_text, range = edit
         return {
             "newText": new_text,
             "range": range.to_lsp()
         }
-    return {
+    action = {
         "title": "Fix errors",
         "edit": {
             "documentChanges": [
@@ -30,35 +33,147 @@ def create_test_code_actions(document_version: int, edits: List[Tuple[str, Range
             ]
         }
     }
+    if kind:
+        action['kind'] = kind
+    return action
+
+
+def create_test_diagnostics(diagnostics: List[Tuple[str, Range]]) -> Dict:
+    def diagnostic_to_lsp(diagnostic: Tuple[str, Range]) -> Dict:
+        message, range = diagnostic
+        return {
+            "message": message,
+            "range": range.to_lsp()
+        }
+    return {
+        "uri": TEST_FILE_URI,
+        "diagnostics": list(map(diagnostic_to_lsp, diagnostics))
+    }
+
+
+class CodeActionsOnSaveTestCase(TextDocumentTestCase):
+    def setUp(self) -> Generator:
+        yield from super().setUp()
+        # "quickfix" is not supported but its here for testing purposes
+        self.view.settings().set('lsp_code_actions_on_save', {'source.fixAll': True, 'quickfix': True})
+
+    def tearDown(self) -> Generator:
+        yield from self.await_clear_view_and_save()
+        self.view.settings().set('lsp_code_actions_on_save', {})
+        yield from super().tearDown()
+
+    def get_test_server_capabilities(self) -> dict:
+        capabilities = deepcopy(super().get_test_server_capabilities())
+        capabilities['capabilities']['codeActionProvider'] = {'codeActionKinds': ['quickfix', 'source.fixAll']}
+        return capabilities
+
+    def test_applies_matching_kind(self) -> Generator:
+        yield from self._setup_document_with_missing_semicolon()
+        code_action_kind = 'source.fixAll'
+        code_action = create_test_code_action(
+            self.view.change_count(),
+            [(';', Range(Point(0, 11), Point(0, 11)))],
+            code_action_kind
+        )
+        self.set_response('textDocument/codeAction', [code_action])
+        self.view.run_command('lsp_save')
+        yield from self.await_message('textDocument/codeAction')
+        self.assertEquals(entire_content(self.view), 'const x = 1;')
+        self.assertEquals(self.view.is_dirty(), False)
+
+    def test_applies_immediately_after_text_change(self) -> Generator:
+        self.insert_characters('const x = 1')
+        code_action_kind = 'source.fixAll'
+        code_action = create_test_code_action(
+            self.view.change_count(),
+            [(';', Range(Point(0, 11), Point(0, 11)))],
+            code_action_kind
+        )
+        self.set_response('textDocument/codeAction', [code_action])
+        self.view.run_command('lsp_save')
+        yield from self.await_message('textDocument/codeAction')
+        self.assertEquals(entire_content(self.view), 'const x = 1;')
+        self.assertEquals(self.view.is_dirty(), False)
+
+    def test_no_fix_on_non_matching_kind(self) -> Generator:
+        yield from self._setup_document_with_missing_semicolon()
+        initial_content = 'const x = 1'
+        self.view.run_command('lsp_save')
+        self.assertEquals(entire_content(self.view), initial_content)
+        self.assertEquals(self.view.is_dirty(), True)
+
+    def test_does_not_apply_unsupported_kind(self) -> Generator:
+        yield from self._setup_document_with_missing_semicolon()
+        code_action_kind = 'quickfix'
+        code_action = create_test_code_action(
+            self.view.change_count(),
+            [(';', Range(Point(0, 11), Point(0, 11)))],
+            code_action_kind
+        )
+        self.set_response('textDocument/codeAction', [code_action])
+        self.view.run_command('lsp_save')
+        self.assertEquals(entire_content(self.view), 'const x = 1')
+
+    def _setup_document_with_missing_semicolon(self) -> Generator:
+        self.insert_characters('const x = 1')
+        yield from self.await_message("textDocument/didChange")
+        yield from self.await_client_notification(
+            "textDocument/publishDiagnostics",
+            create_test_diagnostics([
+                ('Missing semicolon', Range(Point(0, 11), Point(0, 11))),
+            ])
+        )
+
+
+class CodeActionMatchingTestCase(unittest.TestCase):
+    def test_does_not_match(self) -> None:
+        actual = get_matching_kinds({'a.x': True}, ['a.b'])
+        expected = []  # type: List[str]
+        self.assertEquals(actual, expected)
+
+    def test_matches_exact_action(self) -> None:
+        actual = get_matching_kinds({'a.b': True}, ['a.b'])
+        expected = ['a.b']
+        self.assertEquals(actual, expected)
+
+    def test_matches_more_specific_action(self) -> None:
+        actual = get_matching_kinds({'a.b': True}, ['a.b.c'])
+        expected = ['a.b.c']
+        self.assertEquals(actual, expected)
+
+    def test_does_not_match_disabled_action(self) -> None:
+        actual = get_matching_kinds({'a.b': True, 'a.b.c': False}, ['a.b.c'])
+        expected = []  # type: List[str]
+        self.assertEquals(actual, expected)
 
 
 class CodeActionsTestCase(TextDocumentTestCase):
     def test_applies_code_actions(self) -> Generator:
         self.insert_characters('a\nb')
         yield from self.await_message("textDocument/didChange")
-        code_actions = create_test_code_actions(self.view.change_count(), [
+        code_action = create_test_code_action(self.view.change_count(), [
             ("c", Range(Point(0, 0), Point(0, 1))),
             ("d", Range(Point(1, 0), Point(1, 1))),
         ])
-        run_code_action_or_command(self.view, self.config.name, code_actions)
+        run_code_action_or_command(self.view, self.config.name, code_action)
         self.assertEquals(entire_content(self.view), 'c\nd')
 
     def test_does_not_apply_with_nonmatching_document_version(self) -> Generator:
         initial_content = 'a\nb'
         self.insert_characters(initial_content)
         yield from self.await_message("textDocument/didChange")
-        code_actions = create_test_code_actions(0, [
+        code_action = create_test_code_action(0, [
             ("c", Range(Point(0, 0), Point(0, 1))),
             ("d", Range(Point(1, 0), Point(1, 1))),
         ])
-        run_code_action_or_command(self.view, self.config.name, code_actions)
+        run_code_action_or_command(self.view, self.config.name, code_action)
         self.assertEquals(entire_content(self.view), initial_content)
 
     # Keep this test last as it breaks pyls!
     def test_applies_correctly_after_emoji(self) -> Generator:
         self.insert_characters('🕵️hi')
         yield from self.await_message("textDocument/didChange")
-        code_action = create_test_code_actions(self.view.change_count(), [
+        code_action = create_test_code_action(self.view.change_count(), [
             ("bye", Range(Point(0, 3), Point(0, 5))),
         ])
         run_code_action_or_command(self.view, self.config.name, code_action)

--- a/tests/test_code_actions.py
+++ b/tests/test_code_actions.py
@@ -100,7 +100,8 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
         initial_content = 'const x = 1'
         self.view.run_command('lsp_save')
         self.assertEquals(entire_content(self.view), initial_content)
-        self.assertEquals(self.view.is_dirty(), True)
+        yield 100
+        self.assertEquals(self.view.is_dirty(), False)
 
     def test_does_not_apply_unsupported_kind(self) -> Generator:
         yield from self._setup_document_with_missing_semicolon()

--- a/tests/test_code_actions.py
+++ b/tests/test_code_actions.py
@@ -100,8 +100,7 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
         initial_content = 'const x = 1'
         self.view.run_command('lsp_save')
         self.assertEquals(entire_content(self.view), initial_content)
-        yield 100
-        self.assertEquals(self.view.is_dirty(), False)
+        yield lambda: not self.view.is_dirty()
 
     def test_does_not_apply_unsupported_kind(self) -> Generator:
         yield from self._setup_document_with_missing_semicolon()


### PR DESCRIPTION
## TODO
 - [x] 1. On triggering CAOS (Code Actions On Save), only request code actions from servers that report `codeActionProvider.codeActionKinds` and only request those specific kinds. ESlint reacts very weirdly if we send `source.fixAll.stylelint` to it, for example.
 - [x] 2. Implement more sophisticated `lsp_code_actions_on_save` setting handling. There are various combinations of that setting that can be applied by the user. There is a couple of examples in [vscode-stylelint readme](https://github.com/stylelint/vscode-stylelint#editorcodeactionsonsave). For an example having `source.fixAll` set, that matches ESlint's more specific kind  `source.fixAll.eslint`, we send a request with  `source.fixAll.eslint` kind. When having both `source.fixAll: true` and `source.fixAll.eslint: false` in settings, we must not send the request.
 - [x] 3. Making a change and saving quickly fails to correct fixes. That's because, on a change, we clear diagnostics and send `didChange` notification, then find no diagnostics so we don't fire code action request. Only after that, we get diagnostics but it's too late.
 - [x] 4. Abandon sync handling in favor of overriding `save` (and `save_all`) command. Sync request blocks the main thread which is not an ideal experience. Especially if the fix takes a second or more.
 - [x] 5. Request and apply fixes from all servers on saving. That means we have to re-request code actions (which also means we have to wait for diagnostics) between each batch of fixes. And we need to request them until we exhaust all fixes or we time out...

## Questions/doubts
 - [x] Q: Should we only apply fixes with TextEdit. `Command`s need extra round-trip.
   A: We are applying all right now. I think it's just fine but haven't seen any servers using `commands` for this functionality.
 - [x] Q: When we get fixes from multiple servers then what do we do? It's possible that fixes from one server will invalidate fixes from another server. It's fine if the fixes were versioned with `VersionedTextDocumentIdentifier` but otherwise, they might apply to a document that has already changed.
  A: At current state, we're re-applying code actions as long as they make changes in the document, limited by time (2s).

## Related links
[Code Action Request Spec](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction)