### PR TITLE
Dependency inject the logger

### DIFF
--- a/plugin/core/rpc.py
+++ b/plugin/core/rpc.py
@@ -1,7 +1,6 @@
 from .logging import debug, exception_log
 from .protocol import Request, Notification, Response, Error, ErrorCode
 from .transports import Transport, TransportCallbacks
-from .types import Settings
 from .typing import Any, Dict, Tuple, Callable, Optional, List
 from abc import ABCMeta, abstractmethod
 from threading import Condition, Lock
@@ -123,10 +122,10 @@ def method2attr(method: str) -> str:
 
 
 class Client(TransportCallbacks):
-    def __init__(self, config_name: str, settings: Settings) -> None:
+    def __init__(self, logger: Logger) -> None:
         self.transport = None  # type: Optional[Transport]
         self.request_id = 0  # Our request IDs are always integers.
-        self.logger = SublimeLogger(settings, config_name, debug)
+        self.logger = logger
         self._response_handlers = {}  # type: Dict[int, Tuple[Callable, Optional[Callable[[Any], None]]]]
         self._sync_request_result = SyncRequestStatus()
         self._sync_request_lock = Lock()
@@ -331,83 +330,3 @@ class Client(TransportCallbacks):
 
     def _get_handler(self, method: str) -> Optional[Callable]:
         return getattr(self, method2attr(method), None)
-
-
-class SublimeLogger(Logger):
-
-    def __init__(self, settings: Settings, server_name: str, sink: Callable[[str], None]) -> None:
-        self.settings = settings
-        self.server_name = server_name
-        self.sink = sink
-
-    def log(self, message: str, params: Any, log_payload: bool) -> None:
-        if log_payload:
-            message = "{}: {}".format(message, params)
-        self.sink(message)
-
-    def format_response(self, direction: str, request_id: Any) -> str:
-        return "{} {} {}".format(direction, self.server_name, request_id)
-
-    def format_request(self, direction: str, method: str, request_id: Any) -> str:
-        return "{} {} {}({})".format(direction, self.server_name, method, request_id)
-
-    def format_notification(self, direction: str, method: str) -> str:
-        return "{} {} {}".format(direction, self.server_name, method)
-
-    def outgoing_response(self, request_id: Any, params: Any) -> None:
-        if not self.settings.log_debug:
-            return
-        self.log(self.format_response(">>>", request_id), params, self.settings.log_payloads)
-
-    def outgoing_error_response(self, request_id: Any, error: Error) -> None:
-        if not self.settings.log_debug:
-            return
-        self.log(self.format_response("~~>", request_id), error.to_lsp(), self.settings.log_payloads)
-
-    def outgoing_request(self, request_id: int, method: str, params: Any, blocking: bool) -> None:
-        if not self.settings.log_debug:
-            return
-        direction = "==>" if blocking else "-->"
-        self.log(self.format_request(direction, method, request_id), params, self.settings.log_payloads)
-
-    def outgoing_notification(self, method: str, params: Any) -> None:
-        if not self.settings.log_debug:
-            return
-        # Do not log the payloads if any of these conditions occur because the payloads might contain the entire
-        # content of the view.
-        log_payload = self.settings.log_payloads
-        if method.endswith("didOpen"):
-            log_payload = False
-        elif method.endswith("didChange"):
-            content_changes = params.get("contentChanges")
-            if content_changes and "range" not in content_changes[0]:
-                log_payload = False
-        elif method.endswith("didSave"):
-            if isinstance(params, dict) and "text" in params:
-                log_payload = False
-        self.log(self.format_notification(" ->", method), params, log_payload)
-
-    def incoming_response(self, request_id: int, params: Any, is_error: bool, blocking: bool) -> None:
-        if not self.settings.log_debug:
-            return
-        if is_error:
-            direction = "<~~"
-        else:
-            direction = "<==" if blocking else "<<<"
-        self.log(self.format_response(direction, request_id), params, self.settings.log_payloads)
-
-    def incoming_error_response(self, request_id: Any, error: Any) -> None:
-        if not self.settings.log_debug:
-            return
-        self.log(self.format_response('<~~', request_id), error, self.settings.log_payloads)
-
-    def incoming_request(self, request_id: Any, method: str, params: Any) -> None:
-        if not self.settings.log_debug:
-            return
-        self.log(self.format_request("<--", method, request_id), params, self.settings.log_payloads)
-
-    def incoming_notification(self, method: str, params: Any, unhandled: bool) -> None:
-        if not self.settings.log_debug or method == "window/logMessage":
-            return
-        direction = "<? " if unhandled else "<- "
-        self.log(self.format_notification(direction, method), params, self.settings.log_payloads)

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -5,9 +5,10 @@ from .logging import exception_log
 from .protocol import TextDocumentSyncKindNone, TextDocumentSyncKindIncremental, CompletionItemTag
 from .protocol import WorkspaceFolder, Request, Notification, Response
 from .rpc import Client
+from .rpc import Logger
 from .settings import client_configs
 from .transports import Transport
-from .types import ClientConfig, ClientStates, Settings
+from .types import ClientConfig, ClientStates
 from .typing import Dict, Any, Optional, List, Tuple, Generator, Type
 from .views import COMPLETION_KINDS
 from .views import did_change_configuration
@@ -409,7 +410,7 @@ def get_plugin(name: str) -> Optional[Type[AbstractPlugin]]:
 
 class Session(Client):
 
-    def __init__(self, manager: Manager, settings: Settings, workspace_folders: List[WorkspaceFolder],
+    def __init__(self, manager: Manager, logger: Logger, workspace_folders: List[WorkspaceFolder],
                  config: ClientConfig, plugin_class: Optional[Type[AbstractPlugin]]) -> None:
         self.config = config
         self.manager = weakref.ref(manager)
@@ -420,7 +421,7 @@ class Session(Client):
         self._progress = {}  # type: Dict[Any, Dict[str, str]]
         self._plugin_class = plugin_class
         self._plugin = None  # type: Optional[AbstractPlugin]
-        super().__init__(config.name, settings)
+        super().__init__(logger)
 
     def __getattr__(self, name: str) -> Any:
         """

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,11 +1,12 @@
+from LSP.plugin.core.protocol import Error
 from LSP.plugin.core.protocol import TextDocumentSyncKindFull, TextDocumentSyncKindNone, TextDocumentSyncKindIncremental
 from LSP.plugin.core.protocol import WorkspaceFolder
+from LSP.plugin.core.rpc import Logger
 from LSP.plugin.core.sessions import get_initialize_params
 from LSP.plugin.core.sessions import Manager
 from LSP.plugin.core.sessions import Session
 from LSP.plugin.core.types import ClientConfig
-from LSP.plugin.core.types import Settings
-from LSP.plugin.core.typing import Optional, Generator
+from LSP.plugin.core.typing import Any, Optional, Generator
 from test_mocks import TEST_CONFIG
 import sublime
 import unittest
@@ -30,6 +31,33 @@ class MockManager(Manager):
         pass
 
     def on_post_initialize(self, session: Session) -> None:
+        pass
+
+
+class MockLogger(Logger):
+
+    def outgoing_response(self, request_id: Any, params: Any) -> None:
+        pass
+
+    def outgoing_error_response(self, request_id: Any, error: Error) -> None:
+        pass
+
+    def outgoing_request(self, request_id: int, method: str, params: Any, blocking: bool) -> None:
+        pass
+
+    def outgoing_notification(self, method: str, params: Any) -> None:
+        pass
+
+    def incoming_response(self, request_id: int, params: Any, is_error: bool, blocking: bool) -> None:
+        pass
+
+    def incoming_error_response(self, request_id: Any, error: Any) -> None:
+        pass
+
+    def incoming_request(self, request_id: Any, method: str, params: Any) -> None:
+        pass
+
+    def incoming_notification(self, method: str, params: Any, unhandled: bool) -> None:
         pass
 
 
@@ -83,7 +111,7 @@ class SessionTest(unittest.TestCase):
 
     def test_document_sync_capabilities(self) -> None:
         manager = MockManager(sublime.active_window())
-        session = Session(manager=manager, settings=Settings(), workspace_folders=[], config=TEST_CONFIG,
+        session = Session(manager=manager, logger=MockLogger(), workspace_folders=[], config=TEST_CONFIG,
                           plugin_class=None)
         session.capabilities.assign({
             'textDocumentSync': {


### PR DESCRIPTION
It's more neat to have it like this. The Logger is created in the WindowManager and then passed to the Client, which then doesn't know with what type of Logger it's dealing with.