### PR TITLE
Fix document synchronization issue when restoring from session

### DIFF
--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -214,6 +214,8 @@ class WindowDocumentHandler(object):
 
     def _notify_did_open(self, view: ViewLike, session: Session) -> None:
         language_id = self._view_language(view, session.config.name)
+        # There might be pending, no longer valid changes when restoring session.
+        self._pending_buffer_changes.pop(view.buffer_id(), None)
         # mypy: expected sublime.View, got ViewLike
         session.send_notification(did_open(view, language_id))  # type: ignore
 


### PR DESCRIPTION
When restoring from session, and making some changes in the document
quickly after plugin initialized but before LSP initialized the server,
we would end up with some accumulated pending buffer changes from
"on_text_changed" listener that we would send after sending "didOpen"
notification. That broke view synchronization as it applied old changes
to the current state of the document send in "didOpen".

Resolves #1096