### PR TITLE
Replace a global map of view IDs to phantomset

### DIFF
--- a/plugin/color.py
+++ b/plugin/color.py
@@ -1,16 +1,11 @@
 import sublime
-from .core.documents import is_transient_view
-from .core.protocol import Range
 from .core.protocol import Request
-from .core.registry import session_for_view, sessions_for_view, configurations_for_view
 from .core.registry import LSPViewEventListener
+from .core.registry import session_for_view, sessions_for_view, configurations_for_view
 from .core.settings import settings
-from .core.typing import List, Dict, Optional
-from .core.url import filename_to_uri
-from .core.views import range_to_region
-
-
-color_phantoms_by_view = dict()  # type: Dict[int, sublime.PhantomSet]
+from .core.typing import List, Optional
+from .core.views import document_color_params
+from .core.views import lsp_color_to_phantom
 
 
 class LspColorListener(LSPViewEventListener):
@@ -19,16 +14,17 @@ class LspColorListener(LSPViewEventListener):
         self._stored_point = -1
         self.initialized = False
         self.enabled = False
+        self._phantoms = sublime.PhantomSet(self.view, "lsp_color")
+
+    def __del__(self) -> None:
+        self._stored_point = -1  # Prevent a debounced request to alter the phantoms again
+        self._phantoms.update([])
 
     @classmethod
     def is_applicable(cls, view_settings: dict) -> bool:
         if 'colorProvider' in settings.disabled_capabilities:
             return False
         return cls.has_supported_syntax(view_settings)
-
-    @property
-    def phantom_set(self) -> sublime.PhantomSet:
-        return color_phantoms_by_view.setdefault(self.view.id(), sublime.PhantomSet(self.view, "lsp_color"))
 
     def on_activated_async(self) -> None:
         if not self.initialized:
@@ -41,7 +37,7 @@ class LspColorListener(LSPViewEventListener):
         if sessions:
             self.initialized = True
             self.enabled = True
-            self.send_color_request()
+            self.fire_request(self._stored_point)
         elif not is_retry:
             # session may be starting, try again once in a second.
             sublime.set_timeout_async(lambda: self.initialize(is_retry=True), 1000)
@@ -50,67 +46,20 @@ class LspColorListener(LSPViewEventListener):
 
     def on_modified_async(self) -> None:
         if self.enabled:
-            self.schedule_request()
-
-    def schedule_request(self) -> None:
-        sel = self.view.sel()
-        if len(sel) < 1:
-            return
-
-        current_point = sel[0].begin()
-        if self._stored_point != current_point:
-            self._stored_point = current_point
-            sublime.set_timeout_async(lambda: self.fire_request(current_point), 800)
+            sel = self.view.sel()
+            if len(sel) < 1:
+                return
+            current_point = sel[0].begin()
+            if self._stored_point != current_point:
+                self._stored_point = current_point
+                sublime.set_timeout_async(lambda: self.fire_request(current_point), 800)
 
     def fire_request(self, current_point: int) -> None:
         if current_point == self._stored_point:
-            self.send_color_request()
-
-    def send_color_request(self) -> None:
-        if is_transient_view(self.view):
-            return
-
-        session = session_for_view(self.view, 'colorProvider')
-        if session:
-            file_path = self.view.file_name()
-            if file_path:
-                params = {
-                    "textDocument": {
-                        "uri": filename_to_uri(file_path)
-                    }
-                }
-                session.send_request(
-                    Request.documentColor(params),
-                    self.handle_response
-                )
+            session = session_for_view(self.view, 'colorProvider')
+            if session:
+                session.send_request(Request.documentColor(document_color_params(self.view)), self.handle_response)
 
     def handle_response(self, response: Optional[List[dict]]) -> None:
         color_infos = response if response else []
-        phantoms = []
-        for color_info in color_infos:
-            color = color_info['color']
-            red = color['red'] * 255
-            green = color['green'] * 255
-            blue = color['blue'] * 255
-            alpha = color['alpha']
-
-            content = """
-            <style>html {{padding: 0}}</style>
-            <div style='padding: 0.4em;
-                        margin-top: 0.2em;
-                        border: 1px solid color(var(--foreground) alpha(0.25));
-                        background-color: rgba({}, {}, {}, {})'>
-            </div>""".format(red, green, blue, alpha)
-
-            range = Range.from_lsp(color_info['range'])
-            region = range_to_region(range, self.view)
-
-            phantoms.append(sublime.Phantom(region, content, sublime.LAYOUT_INLINE))
-
-        self.phantom_set.update(phantoms)
-
-
-def remove_color_boxes(view: sublime.View) -> None:
-    phantom_set = color_phantoms_by_view.get(view.id())
-    if phantom_set:
-        phantom_set.update([])
+        self._phantoms.update([lsp_color_to_phantom(self.view, color_info) for color_info in color_infos])

--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -1,7 +1,6 @@
 import sublime
 import sublime_plugin
 
-from ..color import remove_color_boxes
 from ..diagnostics import DiagnosticsPresenter
 from ..highlights import remove_highlights
 from .handlers import LanguageHandler
@@ -134,7 +133,6 @@ def plugin_unloaded() -> None:
         for view in window.views():
             if view.file_name():
                 remove_highlights(view)
-                remove_color_boxes(view)
                 for key in ['error', 'warning', 'info', 'hint', 'diagnostics']:
                     view.erase_regions('lsp_{}'.format(key))
                 for key in ['diagnostics', 'clients']:

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -388,3 +388,30 @@ def text2html(content: str) -> str:
 
 def make_link(href: str, text: str) -> str:
     return "<a href='{}'>{}</a>".format(href, text.replace(' ', '&nbsp;'))
+
+
+COLOR_BOX_HTML = """
+<style>html {{padding: 0}}</style>
+<div style='padding: 0.4em;
+            margin-top: 0.2em;
+            border: 1px solid color(var(--foreground) alpha(0.25));
+            background-color: rgba({}, {}, {}, {})'>
+</div>"""
+
+
+def lsp_color_to_html(color_info: Dict[str, Any]) -> str:
+    color = color_info['color']
+    red = color['red'] * 255
+    green = color['green'] * 255
+    blue = color['blue'] * 255
+    alpha = color['alpha']
+    return COLOR_BOX_HTML.format(red, green, blue, alpha)
+
+
+def lsp_color_to_phantom(view: sublime.View, color_info: Dict[str, Any]) -> sublime.Phantom:
+    region = range_to_region(Range.from_lsp(color_info['range']), view)
+    return sublime.Phantom(region, lsp_color_to_html(color_info), sublime.LAYOUT_INLINE)
+
+
+def document_color_params(view: sublime.View) -> Dict[str, Any]:
+    return {"textDocument": text_document_identifier(view)}


### PR DESCRIPTION
By storing the phantomset in the listener instead.
Also separate the parsing and construction of params and the actual
logic in the listener.
The place for parsing payloads is in views.py