### PR TITLE
Fix IndexError when diagnostic message string is empty

### DIFF
--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -344,7 +344,7 @@ class DiagnosticOutputPanel(DiagnosticsUpdateWalk):
     def format_diagnostic(self, diagnostic: Diagnostic) -> str:
         location = "{:>8}:{:<4}".format(
             diagnostic.range.start.row + 1, diagnostic.range.start.col + 1)
-        lines = diagnostic.message.splitlines()
+        lines = diagnostic.message.splitlines() or [""]
         formatted = " {}\t{:<12}\t{:<10}\t{}".format(
             location, diagnostic.source, format_severity(diagnostic.severity), lines[0])
         for line in lines[1:]:


### PR DESCRIPTION
Encountered this issue when using haskell-ide-engine. When there is any error in a file, it sends two diagnostics, one with the actual error and one at the top of the file with a blank message. This caused `splitlines()` to return an empty list so that the `lines[0]` on the next line threw an `IndexError`, preventing any diagnostics from being displayed. I'm not sure why HIE does this, but this commit at least allows SublimeLSP to show the actual errors.