### PR TITLE
Fix textDocument/documentHighlight getting called twice when using the mouse

### DIFF
--- a/plugin/highlights.py
+++ b/plugin/highlights.py
@@ -43,9 +43,11 @@ class DocumentHighlightListener(LSPViewEventListener):
                 current_point = self.view.sel()[0].begin()
             except IndexError:
                 return
-            self._stored_point = current_point
             self._clear_regions()
-            debounced(self._on_document_highlight, 500, lambda: self._stored_point == current_point, async_thread=True)
+            if self._stored_point != current_point:
+                self._stored_point = current_point
+                debounced(self._on_document_highlight, 500, lambda: self._stored_point == current_point,
+                          async_thread=True)
 
     def _initialize(self) -> None:
         self._initialized = True


### PR DESCRIPTION
close #1108 

A mouse-button-release event also triggers on_query_completions(_async).
Whether that should actually happen even if the selection doesn't change is
debatable.