### PR TITLE
Fix debouncing equality check on making selection

### DIFF
--- a/plugin/color.py
+++ b/plugin/color.py
@@ -46,7 +46,7 @@ class LspColorListener(LSPViewEventListener):
             sel = self.view.sel()
             if len(sel) < 1:
                 return
-            current_point = sel[0].begin()
+            current_point = sel[0].b
             if self._stored_point != current_point:
                 self._stored_point = current_point
                 debounced(self.fire_request, 800, lambda: self._stored_point == current_point, async_thread=True)

--- a/plugin/highlights.py
+++ b/plugin/highlights.py
@@ -40,7 +40,7 @@ class DocumentHighlightListener(LSPViewEventListener):
             self._initialize()
         if self._enabled and settings.document_highlight_style:
             try:
-                current_point = self.view.sel()[0].begin()
+                current_point = self.view.sel()[0].b
             except IndexError:
                 return
             self._clear_regions()


### PR DESCRIPTION
On extending selection "sel().begin()" point does change as it denotes
beginning of selection, not end. So the check that compares current point
with stored point would always be True.

That resulted in trigger many many requests on making a selection as
all debounced request would go through.