### PR TITLE
Make log_server setting work again and remove log_payloads

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -95,7 +95,7 @@
   // Show messages from language servers in the Language Servers output panel.
   // This output panel can be toggled from the command palette with the
   // command "LSP: Toggle Panel: Language Servers".
-  "log_server": true,
+  "log_server": false,
 
   // Show language server stderr output in the Language Servers output panel.
   // This output panel can be toggled from the command palette with the

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -102,13 +102,6 @@
   // command "LSP: Toggle Panel: Language Servers".
   "log_stderr": false,
 
-  // Show full JSON-RPC requests/responses/notifications in the Language Servers
-  // output panel. Note that if the payload is very large, SublimeText will not
-  // highlight the log line.
-  // This output panel can be toggled from the command palette with the
-  // command "LSP: Toggle Panel: Language Servers".
-  "log_payloads": false,
-
   // User clients configuration can be used to
   // - override single settings of "default_clients"
   // - create add new user specified clients

--- a/docs/features.md
+++ b/docs/features.md
@@ -137,7 +137,7 @@ Add these settings to LSP settings, your Sublime settings, Syntax-specific setti
 * `show_symbol_action_links` `false` *show links to symbol actions like go to, references and rename in the hover popup*
 * `disabled_capabilities`, `[]` *Turn off client capabilities (features): "hover", "completion", "documentHighlight", "colorProvider", "signatureHelp"
 * `log_debug` `false` *show debug logging in the sublime console*
-* `log_server` `true` *show server/logMessage notifications from language servers in the console*
+* `log_server` `false` *log language server communication in a dedicated panel*
 * `log_stderr` `false` *show language server stderr output in the console*
 * `log_payloads` `false` *show full JSON-RPC responses in the console*
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -139,7 +139,6 @@ Add these settings to LSP settings, your Sublime settings, Syntax-specific setti
 * `log_debug` `false` *show debug logging in the sublime console*
 * `log_server` `false` *log language server communication in a dedicated panel*
 * `log_stderr` `false` *show language server stderr output in the console*
-* `log_payloads` `false` *show full JSON-RPC responses in the console*
 
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,6 @@ Here is an example of the `LSP.sublime-settings` file with configurations for th
 {
   // General settings
   "log_stderr": true,
-  "log_payloads": true,
 
   // Language server configurations
   "clients": {
@@ -64,7 +63,6 @@ Some language servers support multiple languages, which can be specified in the 
 {
   // General settings
   "log_stderr": true,
-  "log_payloads": true,
 
   // Language server configurations
   "clients": {

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 ## Self-help instructions
 
-Enable LSP logging: In LSP Settings enable the `log_debug` setting and `log_payloads` if needed.
+Enable LSP logging: In LSP Settings enable the `log_debug` setting.
 Enable server logging: set `log_server` and `log_stderr` to `true`
 Restart Sublime and open the console (``ctrl+` ``) to see the additional logging.
 If you believe the issue is with this package, please include the output from the Sublime console in your issue report!

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,7 +2,7 @@
 
 Enable LSP logging: In LSP Settings enable the `log_debug` setting.
 Enable server logging: set `log_server` and `log_stderr` to `true`
-Restart Sublime and open the console (``ctrl+` ``) to see the additional logging.
+Run "LSP: Toggle Log Panel" from the command palette. No restart is needed.
 If you believe the issue is with this package, please include the output from the Sublime console in your issue report!
 
 ## Common problems

--- a/plugin/core/rpc.py
+++ b/plugin/core/rpc.py
@@ -32,10 +32,6 @@ class Logger(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def incoming_error_response(self, request_id: Any, error: Any) -> None:
-        pass
-
-    @abstractmethod
     def incoming_request(self, request_id: Any, method: str, params: Any) -> None:
         pass
 

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -78,7 +78,7 @@ def update_settings(settings: Settings, settings_obj: sublime.Settings) -> None:
     settings.show_references_in_quick_panel = read_bool_setting(settings_obj, "show_references_in_quick_panel", False)
     settings.disabled_capabilities = read_array_setting(settings_obj, "disabled_capabilities", [])
     settings.log_debug = read_bool_setting(settings_obj, "log_debug", False)
-    settings.log_server = read_bool_setting(settings_obj, "log_server", True)
+    settings.log_server = read_bool_setting(settings_obj, "log_server", False)
     settings.log_stderr = read_bool_setting(settings_obj, "log_stderr", False)
     settings.log_payloads = read_bool_setting(settings_obj, "log_payloads", False)
     settings.lsp_format_on_save = read_bool_setting(settings_obj, "lsp_format_on_save", False)

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -80,7 +80,6 @@ def update_settings(settings: Settings, settings_obj: sublime.Settings) -> None:
     settings.log_debug = read_bool_setting(settings_obj, "log_debug", False)
     settings.log_server = read_bool_setting(settings_obj, "log_server", False)
     settings.log_stderr = read_bool_setting(settings_obj, "log_stderr", False)
-    settings.log_payloads = read_bool_setting(settings_obj, "log_payloads", False)
     settings.lsp_format_on_save = read_bool_setting(settings_obj, "lsp_format_on_save", False)
     settings.lsp_code_actions_on_save = read_dict_setting(settings_obj, "lsp_code_actions_on_save", {})
     settings.code_action_on_save_timeout_ms = read_int_setting(settings_obj, "code_action_on_save_timeout_ms", 2000)

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -28,7 +28,6 @@ class Settings(object):
         self.log_debug = False
         self.log_server = False
         self.log_stderr = False
-        self.log_payloads = False
         self.lsp_format_on_save = False
         self.lsp_code_actions_on_save = {}  # type: Dict[str, bool]
         self.code_action_on_save_timeout_ms = 2000

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -25,8 +25,8 @@ class Settings(object):
         self.show_symbol_action_links = False
         self.show_references_in_quick_panel = False
         self.disabled_capabilities = []  # type: List[str]
-        self.log_debug = True
-        self.log_server = True
+        self.log_debug = False
+        self.log_server = False
         self.log_stderr = False
         self.log_payloads = False
         self.lsp_format_on_save = False

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -679,23 +679,23 @@ class PanelLogger(Logger):
         sublime.set_timeout_async(run_on_async_worker_thread)
 
     def outgoing_response(self, request_id: Any, params: Any) -> None:
-        if not settings.log_debug:
+        if not settings.log_server:
             return
         self.log(self._format_response(">>>", request_id), params, settings.log_payloads)
 
     def outgoing_error_response(self, request_id: Any, error: Error) -> None:
-        if not settings.log_debug:
+        if not settings.log_server:
             return
         self.log(self._format_response("~~>", request_id), error.to_lsp(), settings.log_payloads)
 
     def outgoing_request(self, request_id: int, method: str, params: Any, blocking: bool) -> None:
-        if not settings.log_debug:
+        if not settings.log_server:
             return
         direction = "==>" if blocking else "-->"
         self.log(self._format_request(direction, method, request_id), params, settings.log_payloads)
 
     def outgoing_notification(self, method: str, params: Any) -> None:
-        if not settings.log_debug:
+        if not settings.log_server:
             return
         # Do not log the payloads if any of these conditions occur because the payloads might contain the entire
         # content of the view.
@@ -712,7 +712,7 @@ class PanelLogger(Logger):
         self.log(self._format_notification(" ->", method), params, log_payload)
 
     def incoming_response(self, request_id: int, params: Any, is_error: bool, blocking: bool) -> None:
-        if not settings.log_debug:
+        if not settings.log_server:
             return
         if is_error:
             direction = "<~~"
@@ -721,17 +721,17 @@ class PanelLogger(Logger):
         self.log(self._format_response(direction, request_id), params, settings.log_payloads)
 
     def incoming_error_response(self, request_id: Any, error: Any) -> None:
-        if not settings.log_debug:
+        if not settings.log_server:
             return
         self.log(self._format_response('<~~', request_id), error, settings.log_payloads)
 
     def incoming_request(self, request_id: Any, method: str, params: Any) -> None:
-        if not settings.log_debug:
+        if not settings.log_server:
             return
         self.log(self._format_request("<--", method, request_id), params, settings.log_payloads)
 
     def incoming_notification(self, method: str, params: Any, unhandled: bool) -> None:
-        if not settings.log_debug or method == "window/logMessage":
+        if not settings.log_server or method == "window/logMessage":
             return
         direction = "<? " if unhandled else "<- "
         self.log(self._format_notification(direction, method), params, settings.log_payloads)

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -666,7 +666,7 @@ class PanelLogger(Logger):
         self._manager = ref(manager)
         self._server_name = server_name
 
-    def log(self, message: str, params: Any, log_payload: Optional[bool] = True) -> None:
+    def log(self, message: str, params: Any, log_payload: bool = True) -> None:
 
         def run_on_async_worker_thread() -> None:
             nonlocal message

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -720,11 +720,6 @@ class PanelLogger(Logger):
             direction = "<==" if blocking else "<<<"
         self.log(self._format_response(direction, request_id), params, settings.log_payloads)
 
-    def incoming_error_response(self, request_id: Any, error: Any) -> None:
-        if not settings.log_server:
-            return
-        self.log(self._format_response('<~~', request_id), error, settings.log_payloads)
-
     def incoming_request(self, request_id: Any, method: str, params: Any) -> None:
         if not settings.log_server:
             return

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -666,7 +666,7 @@ class PanelLogger(Logger):
         self._manager = ref(manager)
         self._server_name = server_name
 
-    def log(self, message: str, params: Any, log_payload: bool) -> None:
+    def log(self, message: str, params: Any, log_payload: Optional[bool] = True) -> None:
 
         def run_on_async_worker_thread() -> None:
             nonlocal message
@@ -681,25 +681,25 @@ class PanelLogger(Logger):
     def outgoing_response(self, request_id: Any, params: Any) -> None:
         if not settings.log_server:
             return
-        self.log(self._format_response(">>>", request_id), params, settings.log_payloads)
+        self.log(self._format_response(">>>", request_id), params)
 
     def outgoing_error_response(self, request_id: Any, error: Error) -> None:
         if not settings.log_server:
             return
-        self.log(self._format_response("~~>", request_id), error.to_lsp(), settings.log_payloads)
+        self.log(self._format_response("~~>", request_id), error.to_lsp())
 
     def outgoing_request(self, request_id: int, method: str, params: Any, blocking: bool) -> None:
         if not settings.log_server:
             return
         direction = "==>" if blocking else "-->"
-        self.log(self._format_request(direction, method, request_id), params, settings.log_payloads)
+        self.log(self._format_request(direction, method, request_id), params)
 
     def outgoing_notification(self, method: str, params: Any) -> None:
         if not settings.log_server:
             return
         # Do not log the payloads if any of these conditions occur because the payloads might contain the entire
         # content of the view.
-        log_payload = settings.log_payloads
+        log_payload = True
         if method.endswith("didOpen"):
             log_payload = False
         elif method.endswith("didChange"):
@@ -718,18 +718,18 @@ class PanelLogger(Logger):
             direction = "<~~"
         else:
             direction = "<==" if blocking else "<<<"
-        self.log(self._format_response(direction, request_id), params, settings.log_payloads)
+        self.log(self._format_response(direction, request_id), params)
 
     def incoming_request(self, request_id: Any, method: str, params: Any) -> None:
         if not settings.log_server:
             return
-        self.log(self._format_request("<--", method, request_id), params, settings.log_payloads)
+        self.log(self._format_request("<--", method, request_id), params)
 
     def incoming_notification(self, method: str, params: Any, unhandled: bool) -> None:
         if not settings.log_server or method == "window/logMessage":
             return
         direction = "<? " if unhandled else "<- "
-        self.log(self._format_notification(direction, method), params, settings.log_payloads)
+        self.log(self._format_notification(direction, method), params)
 
     def _format_response(self, direction: str, request_id: Any) -> str:
         return "{} {} {}".format(direction, self._server_name, request_id)

--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -51,7 +51,6 @@ class MockSettings(Settings):
 
     def __init__(self):
         Settings.__init__(self)
-        self.log_payloads = False
         self.show_view_status = True
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -51,9 +51,6 @@ class MockLogger(Logger):
     def incoming_response(self, request_id: int, params: Any, is_error: bool, blocking: bool) -> None:
         pass
 
-    def incoming_error_response(self, request_id: Any, error: Any) -> None:
-        pass
-
     def incoming_request(self, request_id: Any, method: str, params: Any) -> None:
         pass
 


### PR DESCRIPTION
This setting was not used anywhere, instead log_debug controlled logging
in the panel.

Change default to False and make it control the log panel logging.