### PR TITLE
Fix: send initialized notification first

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -358,12 +358,8 @@ class Session(object):
         self.on_request("workspace/configuration", self._handle_request_workspace_configuration)
         self.on_request("client/registerCapability", self._handle_register_capability)
         self.on_request("client/unregisterCapability", self._handle_unregister_capability)
-        if self.config.settings:
-            self.client.send_notification(Notification.didChangeConfiguration({'settings': self.config.settings}))
-
         if self._on_post_initialize:
             self._on_post_initialize(self)
-
         execute_commands = self.get_capability('executeCommandProvider.commands')
         if execute_commands:
             debug("{}: Supported execute commands: {}".format(self.config.name, execute_commands))

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -560,7 +560,8 @@ class WindowManager(object):
         self._handlers.on_initialized(session.config.name, self._window, session.client)
 
         session.client.send_notification(Notification.initialized())
-
+        if session.config.settings:
+            session.client.send_notification(Notification.didChangeConfiguration({'settings': session.config.settings}))
         if session.has_capability("textDocumentSync"):
             self.documents.add_session(session)
         self._window.status_message("{} initialized".format(session.config.name))


### PR DESCRIPTION
closes #1122 

I remember there being an issue with this. Perhaps @predragnikolic or @rchl can comment. If not, we can merge this.