### PR TITLE
Request code actions using range extended to include diagnostics

### DIFF
--- a/messages/4070-unreleased.txt
+++ b/messages/4070-unreleased.txt
@@ -1,0 +1,5 @@
+=> unreleased
+
+Fixes:
+ - Expand variables in configuration notifications and requests (#1125) (Raoul Wols)
+ - Inconsistencies in number of reported code actions in hover popup and annotations (#1128) (Rafał Chłodnicki)

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -88,7 +88,7 @@ class CodeActionsManager:
         actions_handler: Callable[[CodeActionsByConfigName], None],
         request_point: int
     ) -> None:
-        current_location_key = "{}#{}:{}".format(view.file_name(), view.change_count(), request_point)
+        current_location_key = "{}#{}:{}".format(view.buffer_id(), view.change_count(), request_point)
         if current_location_key in self._point_cache:
             actions_handler(self._point_cache[current_location_key].get_actions())
         else:

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -305,6 +305,22 @@ class Range(object):
         return self.contains(rge.start) or self.contains(rge.end) or \
             rge.contains(self.start) or rge.contains(self.end)
 
+    def extend(self, rge: 'Range') -> 'Range':
+        """
+        Extends current range to fully include another range. If another range is already fully
+        enclosed withing current range then nothing changes.
+
+        :param    rge: The region to extend current with
+
+        :returns: The extended region (itself)
+        """
+        if self.intersects(rge):
+            if rge.contains(self.start):
+                self.start = rge.start
+            if rge.contains(self.end):
+                self.end = rge.end
+        return self
+
 
 class Location(object):
     def __init__(self, file_path: str, range: Range) -> None:

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -308,7 +308,7 @@ class Range(object):
     def extend(self, rge: 'Range') -> 'Range':
         """
         Extends current range to fully include another range. If another range is already fully
-        enclosed withing current range then nothing changes.
+        enclosed within the current range then nothing changes.
 
         :param    rge: The region to extend current with
 

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -314,11 +314,10 @@ class Range(object):
 
         :returns: The extended region (itself)
         """
-        if self.intersects(rge):
-            if rge.contains(self.start):
-                self.start = rge.start
-            if rge.contains(self.end):
-                self.end = rge.end
+        if rge.contains(self.start):
+            self.start = rge.start
+        if rge.contains(self.end):
+            self.end = rge.end
         return self
 
 

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -6,7 +6,7 @@ from html import escape
 from .code_actions import actions_manager, run_code_action_or_command
 from .code_actions import CodeActionOrCommand
 from .core.popups import popups
-from .core.protocol import Request, DiagnosticSeverity, Diagnostic, DiagnosticRelatedInformation, Point
+from .core.protocol import Request, DiagnosticSeverity, Diagnostic, DiagnosticRelatedInformation
 from .core.registry import LspTextCommand
 from .core.registry import LSPViewEventListener
 from .core.registry import windows

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -13,6 +13,7 @@ from .core.registry import windows
 from .core.settings import settings
 from .core.typing import List, Optional, Any, Dict
 from .core.views import FORMAT_MARKED_STRING, FORMAT_MARKUP_CONTENT, minihtml
+from .core.views import offset_to_point
 from .core.views import make_link
 from .core.views import text_document_position_params
 from .diagnostics import filter_by_point, view_diagnostics
@@ -84,8 +85,8 @@ class LspHoverCommand(LspTextCommand):
         if self.is_likely_at_symbol(hover_point):
             self.request_symbol_hover(hover_point)
 
-        self._diagnostics_by_config = filter_by_point(view_diagnostics(self.view),
-                                                      Point(*self.view.rowcol(hover_point)))
+        request_point = offset_to_point(self.view, hover_point)
+        self._diagnostics_by_config, _ = filter_by_point(view_diagnostics(self.view), request_point)
         if self._diagnostics_by_config:
             self.request_code_actions(hover_point)
             self.request_show_hover(hover_point)
@@ -99,6 +100,7 @@ class LspHoverCommand(LspTextCommand):
                 lambda response: self.handle_response(response, point))
 
     def request_code_actions(self, point: int) -> None:
+        # TODO: Remove "request_for_point" and cache code action requests for all actions_manager endpoints
         actions_manager.request_for_point(self.view, lambda response: self.handle_code_actions(response, point), point)
 
     def handle_code_actions(self, responses: Dict[str, List[CodeActionOrCommand]], point: int) -> None:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -109,6 +109,23 @@ class RangeTests(unittest.TestCase):
         })
         self.assertTrue(range1.intersects(range2))
 
+    def test_extend(self) -> None:
+        # includes range 1
+        base_range = Range(Point(0, 0), Point(0, 0))
+        other_range = Range(Point(0, 0), Point(0, 3))
+        base_range.extend(other_range)
+        self.assertEqual(base_range, other_range)
+        # includes range 2
+        base_range = Range(Point(1, 0), Point(1, 1))
+        other_range = Range(Point(0, 0), Point(2, 0))
+        base_range.extend(other_range)
+        self.assertEqual(base_range, other_range)
+        # is not extended
+        base_range = Range(Point(1, 0), Point(1, 5))
+        other_range = Range(Point(1, 1), Point(1, 2))
+        base_range.extend(other_range)
+        self.assertEqual(base_range, Range(Point(1, 0), Point(1, 5)))
+
 
 class DiagnosticTests(unittest.TestCase):
 


### PR DESCRIPTION
Change filter_by_point and filter_by_range to also return an extended
range that includes filtered diagnostics.

This range is then used to request code actions with all filtered
diagnostics included within the range.

Previously the code only included range of the first diagnostics which
wasn't entirely correct and for "range" requests the range was not
extended at all, making those two types of calls inconsistent in number
of code actions returned.

Resolves #1128