### PR TITLE
Fix diagnostics for lowercase drive letter in DocumentUri

### DIFF
--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -243,7 +243,8 @@ class DiagnosticViewRegions(DiagnosticsUpdateWalk):
 
     def begin_file(self, file_name: str) -> None:
         # TODO: would be nice if walk could skip this updater
-        if os.path.samefile(file_name, self._view.file_name()):
+        file = self._view.file_name()
+        if file and os.path.samefile(file_name, file):
             self._relevant_file = True
 
     def diagnostic(self, diagnostic: Diagnostic) -> None:

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -43,7 +43,9 @@ def view_diagnostics(view: sublime.View) -> Dict[str, List[Diagnostic]]:
         file_name = view.file_name()
         if file_name:
             window_diagnostics = windows.lookup(view.window()).diagnostics.get()
-            return window_diagnostics.get(file_name, {})
+            for file in window_diagnostics:
+                if os.path.samefile(file, file_name):
+                    return window_diagnostics[file]
     return {}
 
 
@@ -241,7 +243,7 @@ class DiagnosticViewRegions(DiagnosticsUpdateWalk):
 
     def begin_file(self, file_name: str) -> None:
         # TODO: would be nice if walk could skip this updater
-        if file_name == self._view.file_name():
+        if os.path.samefile(file_name, self._view.file_name()):
             self._relevant_file = True
 
     def diagnostic(self, diagnostic: Diagnostic) -> None:


### PR DESCRIPTION
It might happen that the server sends diagnostics with a lowercase drive letter (on Windows OS) for the filename in the `uri` field (e.g. the Julia server does that). Sublimes `view.file_name()` function on the other side returns a uppercase drive letter. Therefore the filenames don't match and diagnostics will only be shown in the panel, but not as regions in the editor or on hover.