### PR TITLE
Don't show dialog for successful workspace/executeCommand

### DIFF
--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -46,7 +46,9 @@ class LspExecuteCommand(LspTextCommand):
         if response:
             msg += "with response: {}".format(response)
 
-        sublime.message_dialog(msg)
+        window = self.view.window()
+        if window:
+            window.status_message(msg)
 
     def _handle_error(self, command: str, error: Dict[str, Any]) -> None:
         msg = "command {} failed. Reason: {}".format(command, error.get("message", "none provided by server :("))


### PR DESCRIPTION
It's annoying to have a dialog pop up each time `lsp_execute` is run.