### PR TITLE
Update keybindings with more precise capability checks

### DIFF
--- a/Keymaps/Default (Linux).sublime-keymap
+++ b/Keymaps/Default (Linux).sublime-keymap
@@ -8,64 +8,319 @@
     //         "text": "LSP: ",
     //     }
     // },
-
-    // Show Code Actions
-    { "keys": ["ctrl+."], "command": "lsp_code_actions", "context": [{"key": "setting.lsp_active"}]},
-
-    // Show/Hide Diagnostics Panel
-    { "keys": ["ctrl+alt+m"], "command": "lsp_show_diagnostics_panel", "context": [{"key": "setting.lsp_active"}]},
-
-    // Show/Hide Language Server Logs Panel
-    // { "keys": ["UNBOUND"], "command": "lsp_toggle_server_panel", "context": [{"key": "setting.lsp_active"}]},
-
-    // Trigger Signature Help
-    { "keys": ["ctrl+alt+space"], "command": "noop", "context": [{ "key": "lsp.signature_help", "operator": "equal", "operand": 0}] },
-
-    // Move Up/Down in Signature Help
-    { "keys": ["up"], "command": "noop", "context": [{ "key": "lsp.signature_help", "operator": "equal", "operand": -1 }] },
-    { "keys": ["down"], "command": "noop", "context": [{ "key": "lsp.signature_help", "operator": "equal", "operand": 1 }] },
-
-     // Find Symbol References
-    { "keys": ["shift+f12"], "command": "lsp_symbol_references", "context": [{"key": "setting.lsp_active"}]},
-
-    // Next/Prevous diagnostics
-    { "keys": ["f8"], "command": "lsp_next_diagnostic", "context": [{"key": "setting.lsp_active"}] },
-    { "keys": ["shift+f8"], "command": "lsp_previous_diagnostic", "context": [{"key": "setting.lsp_active"}] },
-    { "keys": ["escape"], "command": "lsp_hide_diagnostic", "context": [{ "key": "setting.lsp_diagnostic_phantom"}] },
-
-    // Go To Definition
-    // {"keys": ["UNBOUND"], "command": "lsp_symbol_definition", "context": [{"key": "setting.lsp_active"}]},
-
-    // Go To Type Definition
-    // {"keys": ["UNBOUND"], "command": "lsp_symbol_type_definition", "context": [{"key": "setting.lsp_active"}]},
-
-    // Go To Declaration
-    // {"keys": ["UNBOUND"], "command": "lsp_symbol_declaration", "context": [{"key": "setting.lsp_active"}]},
-
-    // Go To Implementation
-    // {"keys": ["UNBOUND"], "command": "lsp_symbol_implementation", "context": [{"key": "setting.lsp_active"}]},
-
-    // Rename Symbol
-    // { "keys": ["UNBOUND"], "command": "lsp_symbol_rename", "context": [{"key": "setting.lsp_active"}]},
-
-    // Format Document
-    // {"keys": ["UNBOUND"], "command": "lsp_format_document", "context": [{"key": "setting.lsp_active"}]},
-
-    // Format Selection
-    // {"keys": ["UNBOUND"], "command": "lsp_format_document_range", "context": [{"key": "setting.lsp_active"}]},
-
-    // Document Symbols (a replacement for ST's "Goto Symbol")
-    // {"keys": ["ctrl+r"], "command": "lsp_document_symbols", "context": [{"key": "setting.lsp_active"}]},
-
-    // Workspace Symbols
-    // {"keys": ["UNBOUND"], "command": "lsp_workspace_symbols", "context": [{"key": "setting.lsp_active"}]},
-
-    // Symbol Hover
-    // {"keys": ["UNBOUND"], "command": "lsp_hover", "context": [{"key": "setting.lsp_active"}]},
-
-    // Expand Selection (a replacement for ST's "Expand Selection")
-    // {"keys": ["ctrl+shift+a"], "command": "lsp_expand_selection", "context": [{"key": "setting.lsp_active"}]},
-
     // Override native save to handle Code-Actions-On-Save
-    { "keys": ["ctrl+s"], "command": "lsp_save", "context": [{ "key": "setting.lsp_active"}] },
+    {
+        "command": "lsp_save",
+        "keys": [
+            "ctrl+s"
+        ],
+        "context": [
+            {
+                "key": "lsp_session_with_capability",
+                "operator": "equal",
+                "operand": "codeActionProvider"
+            }
+        ]
+    },
+    // Show Code Actions
+    {
+        "command": "lsp_code_actions",
+        "keys": [
+            "ctrl+."
+        ],
+        "context": [
+            {
+                "key": "lsp_session_with_capability",
+                "operator": "equal",
+                "operand": "codeActionProvider"
+            }
+        ]
+    },
+    // Show/Hide Diagnostics Panel
+    {
+        "command": "lsp_show_diagnostics_panel",
+        "keys": [
+            "ctrl+alt+m"
+        ],
+        "context": [
+            {
+                "key": "setting.lsp_active"
+            }
+        ]
+    },
+    // Show/Hide Language Server Logs Panel
+    // {
+    //     "command": "lsp_toggle_server_panel",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "setting.lsp_active"
+    //         }
+    //     ]
+    // },
+    // Trigger Signature Help
+    {
+        "command": "noop",
+        "keys": [
+            "ctrl+alt+space"
+        ],
+        "context": [
+            {
+                "key": "lsp.signature_help",
+                "operator": "equal",
+                "operand": 0
+            }
+        ]
+    },
+    // Move Up/Down in Signature Help
+    {
+        "command": "noop",
+        "keys": [
+            "up"
+        ],
+        "context": [
+            {
+                "key": "lsp.signature_help",
+                "operator": "equal",
+                "operand": -1
+            }
+        ]
+    },
+    {
+        "command": "noop",
+        "keys": [
+            "down"
+        ],
+        "context": [
+            {
+                "key": "lsp.signature_help",
+                "operator": "equal",
+                "operand": 1
+            }
+        ]
+    },
+    // Find Symbol References
+    {
+        "command": "lsp_symbol_references",
+        "keys": [
+            "shift+f12"
+        ],
+        "context": [
+            {
+                "key": "lsp_session_with_capability",
+                "operator": "equal",
+                "operand": "referencesProvider"
+            },
+        ]
+    },
+    // Next/Prevous diagnostics
+    {
+        "command": "lsp_next_diagnostic",
+        "keys": [
+            "f8"
+        ],
+        "context": [
+            {
+                "key": "setting.lsp_active"
+            }
+        ]
+    },
+    {
+        "command": "lsp_previous_diagnostic",
+        "keys": [
+            "shift+f8"
+        ],
+        "context": [
+            {
+                "key": "setting.lsp_active"
+            }
+        ]
+    },
+    {
+        "command": "lsp_hide_diagnostic",
+        "keys": [
+            "escape"
+        ],
+        "context": [
+            {
+                "key": "setting.lsp_diagnostic_phantom"
+            }
+        ]
+    },
+    // Go To Definition
+    // {
+    //     "command": "lsp_symbol_definition",
+    //     "keys": [
+    //         "f12"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "definitionProvider"
+    //         },
+    //         {
+    //             "key": "auto_complete_visible",
+    //             "operator": "equal",
+    //             "operand": false
+    //         }
+    //     ]
+    // },
+    // Go To Type Definition
+    // {
+    //     "command": "lsp_symbol_type_definition",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "typeDefinitionProvider"
+    //         },
+    //         {
+    //             "key": "auto_complete_visible",
+    //             "operator": "equal",
+    //             "operand": false
+    //         }
+    //     ]
+    // },
+    // Go To Declaration
+    // {
+    //     "command": "lsp_symbol_declaration",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "declarationProvider"
+    //         },
+    //         {
+    //             "key": "auto_complete_visible",
+    //             "operator": "equal",
+    //             "operand": false
+    //         }
+    //     ]
+    // },
+    // Go To Implementation
+    // {
+    //     "command": "lsp_symbol_implementation",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "implementationProvider"
+    //         },
+    //         {
+    //             "key": "auto_complete_visible",
+    //             "operator": "equal",
+    //             "operand": false
+    //         }
+    //     ]
+    // },
+    // Rename Symbol
+    // {
+    //     "command": "lsp_symbol_rename",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "renameProvider"
+    //         }
+    //     ]
+    // },
+    // Format Document
+    // {
+    //     "command": "lsp_format_document",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "documentFormattingProvider | documentRangeFormattingProvider"
+    //         }
+    //     ]
+    // },
+    // Format Selection
+    // {
+    //     "command": "lsp_format_document_range",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "documentRangeFormattingProvider"
+    //         }
+    //     ]
+    // },
+    // Document Symbols (a replacement for ST's "Goto Symbol")
+    // {
+    //     "command": "lsp_document_symbols",
+    //     "keys": [
+    //         "ctrl+r"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "documentSymbolProvider"
+    //         }
+    //     ]
+    // },
+    // Workspace Symbols (a replacement for ST's "Goto Symbol In Project")
+    // {
+    //     "command": "lsp_workspace_symbols",
+    //     "keys": [
+    //         "ctrl+shift+r"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "workspaceSymbolProvider"
+    //         }
+    //     ]
+    // },
+    // Symbol Hover
+    // {
+    //     "command": "lsp_hover",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "hoverProvider"
+    //         }
+    //     ]
+    // },
+    // Expand Selection (a replacement for ST's "Expand Selection")
+    // {
+    //     "command": "lsp_expand_selection",
+    //     "keys": [
+    //         "ctrl+shift+a"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "selectionRangeProvider"
+    //         }
+    //     ]
+    // },
 ]

--- a/Keymaps/Default (Linux).sublime-keymap
+++ b/Keymaps/Default (Linux).sublime-keymap
@@ -16,7 +16,7 @@
         ],
         "context": [
             {
-                "key": "lsp_session_with_capability",
+                "key": "lsp.session_with_capability",
                 "operator": "equal",
                 "operand": "codeActionProvider"
             }
@@ -30,7 +30,7 @@
         ],
         "context": [
             {
-                "key": "lsp_session_with_capability",
+                "key": "lsp.session_with_capability",
                 "operator": "equal",
                 "operand": "codeActionProvider"
             }
@@ -109,7 +109,7 @@
         ],
         "context": [
             {
-                "key": "lsp_session_with_capability",
+                "key": "lsp.session_with_capability",
                 "operator": "equal",
                 "operand": "referencesProvider"
             },
@@ -157,7 +157,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "definitionProvider"
     //         },
@@ -176,7 +176,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "typeDefinitionProvider"
     //         },
@@ -195,7 +195,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "declarationProvider"
     //         },
@@ -214,7 +214,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "implementationProvider"
     //         },
@@ -233,7 +233,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "renameProvider"
     //         }
@@ -247,7 +247,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "documentFormattingProvider | documentRangeFormattingProvider"
     //         }
@@ -261,7 +261,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "documentRangeFormattingProvider"
     //         }
@@ -275,7 +275,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "documentSymbolProvider"
     //         }
@@ -289,7 +289,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "workspaceSymbolProvider"
     //         }
@@ -303,7 +303,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "hoverProvider"
     //         }
@@ -317,7 +317,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "selectionRangeProvider"
     //         }

--- a/Keymaps/Default (OSX).sublime-keymap
+++ b/Keymaps/Default (OSX).sublime-keymap
@@ -8,64 +8,319 @@
     //         "text": "LSP: ",
     //     }
     // },
-
-    // Show Code Actions
-    { "keys": ["super+."], "command": "lsp_code_actions", "context": [{"key": "setting.lsp_active"}]},
-
-    // Show/Hide Diagnostics Panel
-    { "keys": ["super+alt+m"], "command": "lsp_show_diagnostics_panel", "context": [{"key": "setting.lsp_active"}]},
-
-    // Show/Hide Language Server Logs Panel
-    // { "keys": ["UNBOUND"], "command": "lsp_toggle_server_panel", "context": [{"key": "setting.lsp_active"}]},
-
-    // Trigger Signature Help
-    { "keys": ["super+alt+space"], "command": "noop", "context": [{ "key": "lsp.signature_help", "operator": "equal", "operand": 0}] },
-
-    // Move Up/Down in Signature Help
-    { "keys": ["up"], "command": "noop", "context": [{ "key": "lsp.signature_help", "operator": "equal", "operand": -1 }] },
-    { "keys": ["down"], "command": "noop", "context": [{ "key": "lsp.signature_help", "operator": "equal", "operand": 1 }] },
-
-     // Find Symbol References
-    { "keys": ["shift+f12"], "command": "lsp_symbol_references", "context": [{"key": "setting.lsp_active"}]},
-
-    // Next/Prevous diagnostics
-    { "keys": ["f8"], "command": "lsp_next_diagnostic", "context": [{"key": "setting.lsp_active"}] },
-    { "keys": ["shift+f8"], "command": "lsp_previous_diagnostic", "context": [{"key": "setting.lsp_active"}] },
-    { "keys": ["escape"], "command": "lsp_hide_diagnostic", "context": [{ "key": "setting.lsp_diagnostic_phantom"}] },
-
-    // Go To Definition
-    // {"keys": ["UNBOUND"], "command": "lsp_symbol_definition", "context": [{"key": "setting.lsp_active"}]},
-
-    // Go To Type Definition
-    // {"keys": ["UNBOUND"], "command": "lsp_symbol_type_definition", "context": [{"key": "setting.lsp_active"}]},
-
-    // Go To Declaration
-    // {"keys": ["UNBOUND"], "command": "lsp_symbol_declaration", "context": [{"key": "setting.lsp_active"}]},
-
-    // Go To Implementation
-    // {"keys": ["UNBOUND"], "command": "lsp_symbol_implementation", "context": [{"key": "setting.lsp_active"}]},
-
-    // Rename Symbol
-    // { "keys": ["UNBOUND"], "command": "lsp_symbol_rename", "context": [{"key": "setting.lsp_active"}]},
-
-    // Format Document
-    // {"keys": ["UNBOUND"], "command": "lsp_format_document", "context": [{"key": "setting.lsp_active"}]},
-
-    // Format Selection
-    // {"keys": ["UNBOUND"], "command": "lsp_format_document_range", "context": [{"key": "setting.lsp_active"}]},
-
-    // Document Symbols (a replacement for ST's "Goto Symbol")
-    // {"keys": ["super+r"], "command": "lsp_document_symbols", "context": [{"key": "setting.lsp_active"}]},
-
-    // Workspace Symbols
-    // {"keys": ["UNBOUND"], "command": "lsp_workspace_symbols", "context": [{"key": "setting.lsp_active"}]},
-
-    // Symbol Hover
-    // {"keys": ["UNBOUND"], "command": "lsp_hover", "context": [{"key": "setting.lsp_active"}]},
-
-    // Expand Selection (a replacement for ST's "Expand Selection")
-    // {"keys": ["super+shift+a"], "command": "lsp_expand_selection", "context": [{"key": "setting.lsp_active"}]},
-
     // Override native save to handle Code-Actions-On-Save
-    { "keys": ["super+s"], "command": "lsp_save", "context": [{ "key": "setting.lsp_active"}] },
+    {
+        "command": "lsp_save",
+        "keys": [
+            "super+s"
+        ],
+        "context": [
+            {
+                "key": "lsp_session_with_capability",
+                "operator": "equal",
+                "operand": "codeActionProvider"
+            }
+        ]
+    },
+    // Show Code Actions
+    {
+        "command": "lsp_code_actions",
+        "keys": [
+            "super+."
+        ],
+        "context": [
+            {
+                "key": "lsp_session_with_capability",
+                "operator": "equal",
+                "operand": "codeActionProvider"
+            }
+        ]
+    },
+    // Show/Hide Diagnostics Panel
+    {
+        "command": "lsp_show_diagnostics_panel",
+        "keys": [
+            "super+alt+m"
+        ],
+        "context": [
+            {
+                "key": "setting.lsp_active"
+            }
+        ]
+    },
+    // Show/Hide Language Server Logs Panel
+    // {
+    //     "command": "lsp_toggle_server_panel",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "setting.lsp_active"
+    //         }
+    //     ]
+    // },
+    // Trigger Signature Help
+    {
+        "command": "noop",
+        "keys": [
+            "super+alt+space"
+        ],
+        "context": [
+            {
+                "key": "lsp.signature_help",
+                "operator": "equal",
+                "operand": 0
+            }
+        ]
+    },
+    // Move Up/Down in Signature Help
+    {
+        "command": "noop",
+        "keys": [
+            "up"
+        ],
+        "context": [
+            {
+                "key": "lsp.signature_help",
+                "operator": "equal",
+                "operand": -1
+            }
+        ]
+    },
+    {
+        "command": "noop",
+        "keys": [
+            "down"
+        ],
+        "context": [
+            {
+                "key": "lsp.signature_help",
+                "operator": "equal",
+                "operand": 1
+            }
+        ]
+    },
+    // Find Symbol References
+    {
+        "command": "lsp_symbol_references",
+        "keys": [
+            "shift+f12"
+        ],
+        "context": [
+            {
+                "key": "lsp_session_with_capability",
+                "operator": "equal",
+                "operand": "referencesProvider"
+            },
+        ]
+    },
+    // Next/Prevous diagnostics
+    {
+        "command": "lsp_next_diagnostic",
+        "keys": [
+            "f8"
+        ],
+        "context": [
+            {
+                "key": "setting.lsp_active"
+            }
+        ]
+    },
+    {
+        "command": "lsp_previous_diagnostic",
+        "keys": [
+            "shift+f8"
+        ],
+        "context": [
+            {
+                "key": "setting.lsp_active"
+            }
+        ]
+    },
+    {
+        "command": "lsp_hide_diagnostic",
+        "keys": [
+            "escape"
+        ],
+        "context": [
+            {
+                "key": "setting.lsp_diagnostic_phantom"
+            }
+        ]
+    },
+    // Go To Definition
+    // {
+    //     "command": "lsp_symbol_definition",
+    //     "keys": [
+    //         "f12"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "definitionProvider"
+    //         },
+    //         {
+    //             "key": "auto_complete_visible",
+    //             "operator": "equal",
+    //             "operand": false
+    //         }
+    //     ]
+    // },
+    // Go To Type Definition
+    // {
+    //     "command": "lsp_symbol_type_definition",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "typeDefinitionProvider"
+    //         },
+    //         {
+    //             "key": "auto_complete_visible",
+    //             "operator": "equal",
+    //             "operand": false
+    //         }
+    //     ]
+    // },
+    // Go To Declaration
+    // {
+    //     "command": "lsp_symbol_declaration",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "declarationProvider"
+    //         },
+    //         {
+    //             "key": "auto_complete_visible",
+    //             "operator": "equal",
+    //             "operand": false
+    //         }
+    //     ]
+    // },
+    // Go To Implementation
+    // {
+    //     "command": "lsp_symbol_implementation",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "implementationProvider"
+    //         },
+    //         {
+    //             "key": "auto_complete_visible",
+    //             "operator": "equal",
+    //             "operand": false
+    //         }
+    //     ]
+    // },
+    // Rename Symbol
+    // {
+    //     "command": "lsp_symbol_rename",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "renameProvider"
+    //         }
+    //     ]
+    // },
+    // Format Document
+    // {
+    //     "command": "lsp_format_document",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "documentFormattingProvider | documentRangeFormattingProvider"
+    //         }
+    //     ]
+    // },
+    // Format Selection
+    // {
+    //     "command": "lsp_format_document_range",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "documentRangeFormattingProvider"
+    //         }
+    //     ]
+    // },
+    // Document Symbols (a replacement for ST's "Goto Symbol")
+    // {
+    //     "command": "lsp_document_symbols",
+    //     "keys": [
+    //         "super+r"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "documentSymbolProvider"
+    //         }
+    //     ]
+    // },
+    // Workspace Symbols (a replacement for ST's "Goto Symbol In Project")
+    // {
+    //     "command": "lsp_workspace_symbols",
+    //     "keys": [
+    //         "super+shift+r"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "workspaceSymbolProvider"
+    //         }
+    //     ]
+    // },
+    // Symbol Hover
+    // {
+    //     "command": "lsp_hover",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "hoverProvider"
+    //         }
+    //     ]
+    // },
+    // Expand Selection (a replacement for ST's "Expand Selection")
+    // {
+    //     "command": "lsp_expand_selection",
+    //     "keys": [
+    //         "super+shift+a"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "selectionRangeProvider"
+    //         }
+    //     ]
+    // },
 ]

--- a/Keymaps/Default (OSX).sublime-keymap
+++ b/Keymaps/Default (OSX).sublime-keymap
@@ -16,7 +16,7 @@
         ],
         "context": [
             {
-                "key": "lsp_session_with_capability",
+                "key": "lsp.session_with_capability",
                 "operator": "equal",
                 "operand": "codeActionProvider"
             }
@@ -30,7 +30,7 @@
         ],
         "context": [
             {
-                "key": "lsp_session_with_capability",
+                "key": "lsp.session_with_capability",
                 "operator": "equal",
                 "operand": "codeActionProvider"
             }
@@ -109,7 +109,7 @@
         ],
         "context": [
             {
-                "key": "lsp_session_with_capability",
+                "key": "lsp.session_with_capability",
                 "operator": "equal",
                 "operand": "referencesProvider"
             },
@@ -157,7 +157,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "definitionProvider"
     //         },
@@ -176,7 +176,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "typeDefinitionProvider"
     //         },
@@ -195,7 +195,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "declarationProvider"
     //         },
@@ -214,7 +214,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "implementationProvider"
     //         },
@@ -233,7 +233,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "renameProvider"
     //         }
@@ -247,7 +247,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "documentFormattingProvider | documentRangeFormattingProvider"
     //         }
@@ -261,7 +261,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "documentRangeFormattingProvider"
     //         }
@@ -275,7 +275,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "documentSymbolProvider"
     //         }
@@ -289,7 +289,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "workspaceSymbolProvider"
     //         }
@@ -303,7 +303,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "hoverProvider"
     //         }
@@ -317,7 +317,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "selectionRangeProvider"
     //         }

--- a/Keymaps/Default (Windows).sublime-keymap
+++ b/Keymaps/Default (Windows).sublime-keymap
@@ -8,64 +8,319 @@
     //         "text": "LSP: ",
     //     }
     // },
-
-    // Show Code Actions
-    { "keys": ["ctrl+."], "command": "lsp_code_actions", "context": [{"key": "setting.lsp_active"}]},
-
-    // Show/Hide Diagnostics Panel
-    { "keys": ["ctrl+alt+m"], "command": "lsp_show_diagnostics_panel", "context": [{"key": "setting.lsp_active"}]},
-
-    // Show/Hide Language Server Logs Panel
-    // { "keys": ["UNBOUND"], "command": "lsp_toggle_server_panel", "context": [{"key": "setting.lsp_active"}]},
-
-    // Trigger Signature Help
-    { "keys": ["ctrl+alt+space"], "command": "noop", "context": [{ "key": "lsp.signature_help", "operator": "equal", "operand": 0}] },
-
-    // Move Up/Down in Signature Help
-    { "keys": ["up"], "command": "noop", "context": [{ "key": "lsp.signature_help", "operator": "equal", "operand": -1 }] },
-    { "keys": ["down"], "command": "noop", "context": [{ "key": "lsp.signature_help", "operator": "equal", "operand": 1 }] },
-
-     // Find Symbol References
-    { "keys": ["shift+f12"], "command": "lsp_symbol_references", "context": [{"key": "setting.lsp_active"}]},
-
-    // Next/Prevous diagnostics
-    { "keys": ["f8"], "command": "lsp_next_diagnostic", "context": [{"key": "setting.lsp_active"}] },
-    { "keys": ["shift+f8"], "command": "lsp_previous_diagnostic", "context": [{"key": "setting.lsp_active"}] },
-    { "keys": ["escape"], "command": "lsp_hide_diagnostic", "context": [{ "key": "setting.lsp_diagnostic_phantom"}] },
-
-    // Go To Definition
-    // {"keys": ["UNBOUND"], "command": "lsp_symbol_definition", "context": [{"key": "setting.lsp_active"}]},
-
-    // Go To Type Definition
-    // {"keys": ["UNBOUND"], "command": "lsp_symbol_type_definition", "context": [{"key": "setting.lsp_active"}]},
-
-    // Go To Declaration
-    // {"keys": ["UNBOUND"], "command": "lsp_symbol_declaration", "context": [{"key": "setting.lsp_active"}]},
-
-    // Go To Implementation
-    // {"keys": ["UNBOUND"], "command": "lsp_symbol_implementation", "context": [{"key": "setting.lsp_active"}]},
-
-    // Rename Symbol
-    // { "keys": ["UNBOUND"], "command": "lsp_symbol_rename", "context": [{"key": "setting.lsp_active"}]},
-
-    // Format Document
-    // {"keys": ["UNBOUND"], "command": "lsp_format_document", "context": [{"key": "setting.lsp_active"}]},
-
-    // Format Selection
-    // {"keys": ["UNBOUND"], "command": "lsp_format_document_range", "context": [{"key": "setting.lsp_active"}]},
-
-    // Document Symbols (a replacement for ST's "Goto Symbol")
-    // {"keys": ["ctrl+r"], "command": "lsp_document_symbols", "context": [{"key": "setting.lsp_active"}]},
-
-    // Workspace Symbols
-    // {"keys": ["UNBOUND"], "command": "lsp_workspace_symbols", "context": [{"key": "setting.lsp_active"}]},
-
-    // Symbol Hover
-    // {"keys": ["UNBOUND"], "command": "lsp_hover", "context": [{"key": "setting.lsp_active"}]},
-
-    // Expand Selection (a replacement for ST's "Expand Selection")
-    // {"keys": ["ctrl+shift+a"], "command": "lsp_expand_selection", "context": [{"key": "setting.lsp_active"}]},
-
     // Override native save to handle Code-Actions-On-Save
-    { "keys": ["ctrl+s"], "command": "lsp_save", "context": [{ "key": "setting.lsp_active"}] },
+    {
+        "command": "lsp_save",
+        "keys": [
+            "ctrl+s"
+        ],
+        "context": [
+            {
+                "key": "lsp_session_with_capability",
+                "operator": "equal",
+                "operand": "codeActionProvider"
+            }
+        ]
+    },
+    // Show Code Actions
+    {
+        "command": "lsp_code_actions",
+        "keys": [
+            "ctrl+."
+        ],
+        "context": [
+            {
+                "key": "lsp_session_with_capability",
+                "operator": "equal",
+                "operand": "codeActionProvider"
+            }
+        ]
+    },
+    // Show/Hide Diagnostics Panel
+    {
+        "command": "lsp_show_diagnostics_panel",
+        "keys": [
+            "ctrl+alt+m"
+        ],
+        "context": [
+            {
+                "key": "setting.lsp_active"
+            }
+        ]
+    },
+    // Show/Hide Language Server Logs Panel
+    // {
+    //     "command": "lsp_toggle_server_panel",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "setting.lsp_active"
+    //         }
+    //     ]
+    // },
+    // Trigger Signature Help
+    {
+        "command": "noop",
+        "keys": [
+            "ctrl+alt+space"
+        ],
+        "context": [
+            {
+                "key": "lsp.signature_help",
+                "operator": "equal",
+                "operand": 0
+            }
+        ]
+    },
+    // Move Up/Down in Signature Help
+    {
+        "command": "noop",
+        "keys": [
+            "up"
+        ],
+        "context": [
+            {
+                "key": "lsp.signature_help",
+                "operator": "equal",
+                "operand": -1
+            }
+        ]
+    },
+    {
+        "command": "noop",
+        "keys": [
+            "down"
+        ],
+        "context": [
+            {
+                "key": "lsp.signature_help",
+                "operator": "equal",
+                "operand": 1
+            }
+        ]
+    },
+    // Find Symbol References
+    {
+        "command": "lsp_symbol_references",
+        "keys": [
+            "shift+f12"
+        ],
+        "context": [
+            {
+                "key": "lsp_session_with_capability",
+                "operator": "equal",
+                "operand": "referencesProvider"
+            },
+        ]
+    },
+    // Next/Prevous diagnostics
+    {
+        "command": "lsp_next_diagnostic",
+        "keys": [
+            "f8"
+        ],
+        "context": [
+            {
+                "key": "setting.lsp_active"
+            }
+        ]
+    },
+    {
+        "command": "lsp_previous_diagnostic",
+        "keys": [
+            "shift+f8"
+        ],
+        "context": [
+            {
+                "key": "setting.lsp_active"
+            }
+        ]
+    },
+    {
+        "command": "lsp_hide_diagnostic",
+        "keys": [
+            "escape"
+        ],
+        "context": [
+            {
+                "key": "setting.lsp_diagnostic_phantom"
+            }
+        ]
+    },
+    // Go To Definition
+    // {
+    //     "command": "lsp_symbol_definition",
+    //     "keys": [
+    //         "f12"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "definitionProvider"
+    //         },
+    //         {
+    //             "key": "auto_complete_visible",
+    //             "operator": "equal",
+    //             "operand": false
+    //         }
+    //     ]
+    // },
+    // Go To Type Definition
+    // {
+    //     "command": "lsp_symbol_type_definition",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "typeDefinitionProvider"
+    //         },
+    //         {
+    //             "key": "auto_complete_visible",
+    //             "operator": "equal",
+    //             "operand": false
+    //         }
+    //     ]
+    // },
+    // Go To Declaration
+    // {
+    //     "command": "lsp_symbol_declaration",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "declarationProvider"
+    //         },
+    //         {
+    //             "key": "auto_complete_visible",
+    //             "operator": "equal",
+    //             "operand": false
+    //         }
+    //     ]
+    // },
+    // Go To Implementation
+    // {
+    //     "command": "lsp_symbol_implementation",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "implementationProvider"
+    //         },
+    //         {
+    //             "key": "auto_complete_visible",
+    //             "operator": "equal",
+    //             "operand": false
+    //         }
+    //     ]
+    // },
+    // Rename Symbol
+    // {
+    //     "command": "lsp_symbol_rename",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "renameProvider"
+    //         }
+    //     ]
+    // },
+    // Format Document
+    // {
+    //     "command": "lsp_format_document",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "documentFormattingProvider | documentRangeFormattingProvider"
+    //         }
+    //     ]
+    // },
+    // Format Selection
+    // {
+    //     "command": "lsp_format_document_range",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "documentRangeFormattingProvider"
+    //         }
+    //     ]
+    // },
+    // Document Symbols (a replacement for ST's "Goto Symbol")
+    // {
+    //     "command": "lsp_document_symbols",
+    //     "keys": [
+    //         "ctrl+r"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "documentSymbolProvider"
+    //         }
+    //     ]
+    // },
+    // Workspace Symbols (a replacement for ST's "Goto Symbol In Project")
+    // {
+    //     "command": "lsp_workspace_symbols",
+    //     "keys": [
+    //         "ctrl+shift+r"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "workspaceSymbolProvider"
+    //         }
+    //     ]
+    // },
+    // Symbol Hover
+    // {
+    //     "command": "lsp_hover",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "hoverProvider"
+    //         }
+    //     ]
+    // },
+    // Expand Selection (a replacement for ST's "Expand Selection")
+    // {
+    //     "command": "lsp_expand_selection",
+    //     "keys": [
+    //         "ctrl+shift+a"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp_session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "selectionRangeProvider"
+    //         }
+    //     ]
+    // },
 ]

--- a/Keymaps/Default (Windows).sublime-keymap
+++ b/Keymaps/Default (Windows).sublime-keymap
@@ -16,7 +16,7 @@
         ],
         "context": [
             {
-                "key": "lsp_session_with_capability",
+                "key": "lsp.session_with_capability",
                 "operator": "equal",
                 "operand": "codeActionProvider"
             }
@@ -30,7 +30,7 @@
         ],
         "context": [
             {
-                "key": "lsp_session_with_capability",
+                "key": "lsp.session_with_capability",
                 "operator": "equal",
                 "operand": "codeActionProvider"
             }
@@ -109,7 +109,7 @@
         ],
         "context": [
             {
-                "key": "lsp_session_with_capability",
+                "key": "lsp.session_with_capability",
                 "operator": "equal",
                 "operand": "referencesProvider"
             },
@@ -157,7 +157,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "definitionProvider"
     //         },
@@ -176,7 +176,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "typeDefinitionProvider"
     //         },
@@ -195,7 +195,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "declarationProvider"
     //         },
@@ -214,7 +214,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "implementationProvider"
     //         },
@@ -233,7 +233,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "renameProvider"
     //         }
@@ -247,7 +247,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "documentFormattingProvider | documentRangeFormattingProvider"
     //         }
@@ -261,7 +261,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "documentRangeFormattingProvider"
     //         }
@@ -275,7 +275,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "documentSymbolProvider"
     //         }
@@ -289,7 +289,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "workspaceSymbolProvider"
     //         }
@@ -303,7 +303,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "hoverProvider"
     //         }
@@ -317,7 +317,7 @@
     //     ],
     //     "context": [
     //         {
-    //             "key": "lsp_session_with_capability",
+    //             "key": "lsp.session_with_capability",
     //             "operator": "equal",
     //             "operand": "selectionRangeProvider"
     //         }

--- a/plugin/core/documents.py
+++ b/plugin/core/documents.py
@@ -127,7 +127,7 @@ class DocumentSyncListener(LSPViewEventListener, AbstractViewListener):
         self._clear_async()
 
     def on_query_context(self, key: str, operator: int, operand: Any, match_all: bool) -> bool:
-        if key == "lsp_session_with_capability" and operator == sublime.OP_EQUAL and isinstance(operand, str):
+        if key == "lsp.session_with_capability" and operator == sublime.OP_EQUAL and isinstance(operand, str):
             capabilities = [s.strip() for s in operand.split("|")]
             get = self.view.settings().get
             for capability in capabilities:

--- a/plugin/core/documents.py
+++ b/plugin/core/documents.py
@@ -126,10 +126,14 @@ class DocumentSyncListener(LSPViewEventListener, AbstractViewListener):
     def on_close(self) -> None:
         self._clear_async()
 
-    def on_query_context(self, key: str, operator: str, operand: Any, match_all: bool) -> bool:
-        capability_prefix = "lsp.capabilities."
-        if key.startswith(capability_prefix):
-            return isinstance(self.view.settings().get(key[len(capability_prefix):]), dict)
+    def on_query_context(self, key: str, operator: int, operand: Any, match_all: bool) -> bool:
+        if key == "lsp_session_with_capability" and operator == sublime.OP_EQUAL and isinstance(operand, str):
+            capabilities = [s.strip() for s in operand.split("|")]
+            get = self.view.settings().get
+            for capability in capabilities:
+                if isinstance(get(capability), dict):
+                    return True
+            return False
         elif key in ("lsp.sessions", "setting.lsp_active"):
             return bool(self._session_views)
         else:


### PR DESCRIPTION
The capability check can be done with key "lsp_session_with_capability",
operator "equal", and operand one of the LSP provider names.

You'll have to consult the LSP spec to find the provider names.

I have also formatted our keybinding files with the formatter of vscode-json-language-server. This way I can actually read the text when I have two views side-by-side.

closes #765 