### PR TITLE
Add "source.organizeImports" example to lsp_code_actions_on_save setting

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -26,7 +26,8 @@
   //
   // Only "source.*" actions are supported.
   "lsp_code_actions_on_save": {
-    // "source.fixAll": true
+    // "source.fixAll": true,
+    // "source.organizeImports": true,
   },
 
   // The amount of time the code actions on save are allowed to run for.


### PR DESCRIPTION
This is a common fix type in use so worth having it there to simplify things.