### PR TITLE
Pass the window/logMessage notifications through the loggers

### DIFF
--- a/plugin/core/rpc.py
+++ b/plugin/core/rpc.py
@@ -191,9 +191,12 @@ class Client(TransportCallbacks):
     def flush_deferred_notifications(self) -> None:
         for payload in self._deferred_notifications:
             try:
-                handler = self._get_handler(payload["method"])
+                method = payload["method"]
+                handler = self._get_handler(method)
+                result = payload["params"]
+                self._logger.incoming_notification(method, result, handler is None)
                 if handler:
-                    handler(payload["params"])
+                    handler(result)
             except Exception as err:
                 exception_log("Error handling server payload", err)
         self._deferred_notifications.clear()


### PR DESCRIPTION
Deferred notifications were never logged through the loggers. Those were
logged in the log panel through a different code path:
m_window_logMessage -> WindowManager.handle_log_message
but since those didn't pass through the loggers, the remote logger didn't
see those.

I've noticed this while looking at #1145.