### PR TITLE
Fix sync requests failing after one has errored out

### DIFF
--- a/plugin/core/rpc.py
+++ b/plugin/core/rpc.py
@@ -106,6 +106,7 @@ class SyncRequestStatus:
 
     def reset(self) -> None:
         self.__payload = None
+        self.__error = None
         self.__request_id = -1
         self.__response_id = -1
 


### PR DESCRIPTION
Reset error property on SyncRequestStatus on resetting state. Otherwise
the asserts in prepare() would fail on next sync request.

Resolves #1145