### PR TITLE
Introduce the SessionBuffer class

### DIFF
--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -120,6 +120,12 @@ class WindowManager(Manager):
     def listeners(self) -> Generator[AbstractViewListener, None, None]:
         yield from self._listeners
 
+    def listener_for_view(self, view: sublime.View) -> Optional[AbstractViewListener]:
+        for listener in self.listeners():
+            if listener.view == view:
+                return listener
+        return None
+
     def _dequeue_listener_async(self) -> None:
         listener = None  # type: Optional[AbstractViewListener]
         if self._new_listener is not None:

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -1,0 +1,158 @@
+from .core.logging import debug
+from .core.protocol import TextDocumentSyncKindFull
+from .core.protocol import TextDocumentSyncKindNone
+from .core.sessions import SessionViewProtocol
+from .core.settings import settings
+from .core.types import debounced
+from .core.typing import Any, Iterable, Optional, List, Dict
+from .core.views import did_change
+from .core.views import did_close
+from .core.views import did_open
+from .core.views import did_save
+from .core.views import will_save
+from weakref import WeakSet
+import sublime
+
+
+class PendingChanges:
+
+    __slots__ = ('version', 'changes')
+
+    def __init__(self, version: int, changes: Iterable[sublime.TextChange]) -> None:
+        self.version = version
+        self.changes = list(changes)
+
+    def update(self, version: int, changes: Iterable[sublime.TextChange]) -> None:
+        self.version = version
+        self.changes.extend(changes)
+
+
+class SessionBuffer:
+    """
+    Holds state per session per buffer.
+
+    It stores the filename, handles document synchronization for the buffer.
+
+    TODO: Move diagnostics storage to this class.
+    """
+
+    def __init__(self, session_view: SessionViewProtocol, buffer_id: int, language_id: str) -> None:
+        self.view = session_view.view
+        self.session = session_view.session
+        self.session_views = WeakSet()  # type: WeakSet[SessionViewProtocol]
+        self.session_views.add(session_view)
+        file_name = self.view.file_name()
+        if not file_name:
+            raise ValueError("missing filename")
+        self.file_name = file_name
+        self.id = buffer_id
+        self.pending_changes = None  # type: Optional[PendingChanges]
+        if self.session.should_notify_did_open():
+            self.session.send_notification(did_open(self.view, language_id))
+        self.session.register_session_buffer_async(self)
+
+    def __del__(self) -> None:
+        # If the session is exiting then there's no point in sending textDocument/didClose and there's also no point
+        # in unregistering ourselves from the session.
+        if not self.session.exiting:
+            # Only send textDocument/didClose when we are the only view left (i.e. there are no other clones).
+            if self.session.should_notify_did_close():
+                self.session.send_notification(did_close(self.file_name))
+            self.session.unregister_session_buffer_async(self)
+
+    def add_session_view(self, sv: SessionViewProtocol) -> None:
+        self.session_views.add(sv)
+
+    def shutdown_async(self) -> None:
+        for sv in self.session_views:
+            listener = sv.listener()
+            if listener:
+                listener.on_session_shutdown_async(self.session)
+
+    def on_text_changed(self, changes: Iterable[sublime.TextChange]) -> None:
+        last_change = list(changes)[-1]
+        if last_change.a.pt == 0 and last_change.b.pt == 0 and last_change.str == '' and self.view.size() != 0:
+            # Issue https://github.com/sublimehq/sublime_text/issues/3323
+            # A special situation when changes externally. We receive two changes,
+            # one that removes all content and one that has 0,0,'' parameters. We resend whole
+            # file in that case to fix broken state.
+            debug('Working around the on_text_changed bug {}'.format(self.view.file_name()))
+            self.purge_changes()
+            notification = did_change(self.view, None)  # type: ignore
+            self.session.send_notification(notification)
+            self._massive_hack_changed()
+        else:
+            change_count = self.view.change_count()
+            if self.pending_changes is None:
+                self.pending_changes = PendingChanges(change_count, changes)
+            else:
+                self.pending_changes.update(change_count, changes)
+            debounced(self.purge_changes, 500,
+                      lambda: self.view.is_valid() and change_count == self.view.change_count())
+
+    def purge_changes(self) -> None:
+        if self.pending_changes is not None:
+            sync_kind = self.session.text_sync_kind()
+            if sync_kind == TextDocumentSyncKindNone:
+                return
+            c = None if sync_kind == TextDocumentSyncKindFull else self.pending_changes.changes
+            notification = did_change(self.view, c)  # type: ignore
+            self.session.send_notification(notification)
+            self.pending_changes = None
+            self._massive_hack_changed()
+
+    def on_pre_save(self) -> None:
+        if self.session.should_notify_will_save():
+            self.purge_changes()
+            # mypy: expected sublime.View, got ViewLike
+            # TextDocumentSaveReason.Manual
+            self.session.send_notification(will_save(self.view, 1))  # type: ignore
+
+    def on_post_save(self) -> None:
+        file_name = self.view.file_name()
+        if file_name and file_name != self.file_name:
+            if self.session.should_notify_did_close():
+                self.session.send_notification(did_close(self.file_name))
+            self.file_name = file_name
+            if self.session.should_notify_did_open():
+                # TODO: Language ID should be UNIQUE!
+                language_ids = self.view.settings().get("lsp_language")
+                if isinstance(language_ids, dict):
+                    for config_name, language_id in language_ids.items():
+                        if config_name == self.session.config.name:
+                            self.session.send_notification(did_open(self.view, language_id))
+                            break
+        else:
+            send_did_save, include_text = self.session.should_notify_did_save()
+            if send_did_save:
+                self.purge_changes()
+                # mypy: expected sublime.View, got ViewLike
+                self.session.send_notification(did_save(self.view, include_text, self.file_name))  # type: ignore
+        self._massive_hack_saved()
+
+    def on_diagnostics_async(self, diagnostics: List[Dict[str, Any]], version: Optional[int]) -> None:
+        # TODO: Store diagnostics here.
+        pass
+
+    def _massive_hack_changed(self) -> None:
+        if settings.auto_show_diagnostics_panel == 'saved':
+            # TODO: This method should disappear
+            for sv in self.session_views:
+                listener = sv.listener()
+                if listener:
+                    mgr = listener.manager  # type: ignore
+                    mgr.diagnostics._updatable.on_document_changed()  # type: ignore
+                    return
+
+    def _massive_hack_saved(self) -> None:
+        if settings.auto_show_diagnostics_panel == 'saved':
+            # TODO: This method should disappear
+            for sv in self.session_views:
+                listener = sv.listener()
+                if listener:
+                    mgr = listener.manager  # type: ignore
+                    mgr.diagnostics._updatable.on_document_saved()  # type: ignore
+                    return
+
+    def __str__(self) -> str:
+        return '{}:{}:{}'.format(self.session.config.name, self.id, self.file_name)

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -1,51 +1,28 @@
-from .core.logging import debug
-from .core.protocol import TextDocumentSyncKindNone, TextDocumentSyncKindFull
+from .core.protocol import Diagnostic
 from .core.sessions import Session
-from .core.settings import settings
-from .core.types import debounced
 from .core.types import view2scope
-from .core.typing import Any, Iterable, Optional
-from .core.views import did_change
-from .core.views import did_close
-from .core.views import did_open
-from .core.views import did_save
-from .core.views import will_save
+from .core.typing import Iterable, List
 from .core.windows import AbstractViewListener
+from .session_buffer import SessionBuffer
 import sublime
 import weakref
 
 
-class PendingBuffer:
-
-    __slots__ = ('version', 'changes')
-
-    def __init__(self, version: int, changes: Iterable[sublime.TextChange]) -> None:
-        self.version = version
-        self.changes = list(changes)
-
-    def update(self, version: int, changes: Iterable[sublime.TextChange]) -> None:
-        self.version = version
-        self.changes.extend(changes)
-
-
 class SessionView:
+    """
+    Holds state per session per view.
+    """
+
+    LANGUAGE_ID_KEY = "lsp_language"
+
+    _session_buffers = weakref.WeakValueDictionary()  # type: weakref.WeakValueDictionary[int, SessionBuffer]
 
     def __init__(self, listener: AbstractViewListener, session: Session) -> None:
         self.view = listener.view
         self.session = session
-        self.listener = weakref.ref(listener)
-        self._file_name = self.view.file_name() or ""
-        if not self._file_name:
-            raise ValueError("missing filename")
-        self._buffer_id = self.view.buffer_id()
-        if self._buffer_id == 0:
-            raise ValueError("missing buffer ID")
-        self._pending_buffer = None  # type: Optional[PendingBuffer]
-        session.register_session_view_async(self)
-        session.config.set_view_status(self.view, "")
         settings = self.view.settings()
         # TODO: Language ID must be UNIQUE!
-        languages = settings.get("lsp_language")
+        languages = settings.get(self.LANGUAGE_ID_KEY)
         self._language_id = ''
         if not isinstance(languages, dict):
             languages = {}
@@ -54,9 +31,18 @@ class SessionView:
                 languages[session.config.name] = language.id
                 self._language_id = language.id
                 break
-        settings.set("lsp_language", languages)
-        if self.view.is_primary() and self.session.should_notify_did_open():
-            self.session.send_notification(did_open(self.view, self._language_id))
+        settings.set(self.LANGUAGE_ID_KEY, languages)
+        buffer_id = self.view.buffer_id()
+        session_buffer = self._session_buffers.get(buffer_id)
+        if session_buffer is None:
+            session_buffer = SessionBuffer(self, buffer_id, self._language_id)
+            self._session_buffers[buffer_id] = session_buffer
+        else:
+            session_buffer.add_session_view(self)
+        self.session_buffer = session_buffer
+        self.listener = weakref.ref(listener)
+        session.register_session_view_async(self)
+        session.config.set_view_status(self.view, "")
         for capability in self.session.capabilities.toplevel_keys():
             if capability.endswith('Provider'):
                 self.register_capability(capability)
@@ -68,20 +54,17 @@ class SessionView:
         # If the session is exiting then there's no point in sending textDocument/didClose and there's also no point
         # in unregistering ourselves from the session.
         if not self.session.exiting:
-            # Only send textDocument/didClose when we are the only view left (i.e. there are no other clones).
-            if self.session.should_notify_did_close() and not self._has_clones():
-                self.session.send_notification(did_close(self._file_name))
             self.session.unregister_session_view_async(self)
         self.session.config.erase_view_status(self.view)
         settings = self.view.settings()  # type: sublime.Settings
         # TODO: Language ID must be UNIQUE!
-        languages = settings.get("lsp_language")
+        languages = settings.get(self.LANGUAGE_ID_KEY)
         if isinstance(languages, dict):
             languages.pop(self.session.config.name, None)
             if languages:
-                settings.set("lsp_language", languages)
+                settings.set(self.LANGUAGE_ID_KEY, languages)
             else:
-                settings.erase("lsp_language")
+                settings.erase(self.LANGUAGE_ID_KEY)
 
     def register_capability(self, capability: str) -> None:
         self._add_self_to_setting(capability)
@@ -121,84 +104,21 @@ class SessionView:
         if listener:
             listener.on_session_shutdown_async(self.session)
 
+    def present_diagnostics_async(self, diagnostics: List[Diagnostic]) -> None:
+        # TODO: Present diagnostics here.
+        pass
+
     def on_text_changed(self, changes: Iterable[sublime.TextChange]) -> None:
-        last_change = list(changes)[-1]
-        if last_change.a.pt == 0 and last_change.b.pt == 0 and last_change.str == '' and self.view.size() != 0:
-            # Issue https://github.com/sublimehq/sublime_text/issues/3323
-            # A special situation when changes externally. We receive two changes,
-            # one that removes all content and one that has 0,0,'' parameters. We resend whole
-            # file in that case to fix broken state.
-            debug('Working around the on_text_changed bug {}'.format(self.view.file_name()))
-            self.purge_changes()
-            notification = did_change(self.view, None)  # type: ignore
-            self.session.send_notification(notification)
-            self._massive_hack_changed()
-        else:
-            change_count = self.view.change_count()
-            if self._pending_buffer is None:
-                self._pending_buffer = PendingBuffer(change_count, changes)
-            else:
-                self._pending_buffer.update(change_count, changes)
-            debounced(self.purge_changes, 500,
-                      lambda: self.view.is_valid() and change_count == self.view.change_count())
+        self.session_buffer.on_text_changed(changes)
 
     def purge_changes(self) -> None:
-        if self._pending_buffer is not None:
-            sync_kind = self.session.text_sync_kind()
-            if sync_kind == TextDocumentSyncKindNone:
-                return
-            c = None if sync_kind == TextDocumentSyncKindFull else self._pending_buffer.changes
-            notification = did_change(self.view, c)  # type: ignore
-            self.session.send_notification(notification)
-            self._pending_buffer = None
-            self._massive_hack_changed()
+        self.session_buffer.purge_changes()
 
     def on_pre_save(self) -> None:
-        if self.session.should_notify_will_save():
-            self.purge_changes()
-            # mypy: expected sublime.View, got ViewLike
-            # TextDocumentSaveReason.Manual
-            self.session.send_notification(will_save(self.view, 1))  # type: ignore
+        self.session_buffer.on_pre_save()
 
     def on_post_save(self) -> None:
-        send_did_save, include_text = self.session.should_notify_did_save()
-        if send_did_save:
-            self.purge_changes()
-            # mypy: expected sublime.View, got ViewLike
-            self.session.send_notification(did_save(self.view, include_text, self._file_name))  # type: ignore
-        self._massive_hack_saved()
-
-    def on_diagnostics(self, diagnostics: Any) -> None:
-        pass  # TODO
-
-    def _has_clones(self) -> bool:
-        # TODO: Maybe listen for the "clone_file" command and do some bookkeeping? This is currently an O(N) algorithm.
-        try:
-            views = self.session.window.views()
-            view_id = self.view.id()
-            for view in views:
-                if view.id() != view_id:
-                    if view.buffer_id() == self._buffer_id:
-                        return True
-        except AttributeError:
-            pass
-        return False
-
-    def _massive_hack_changed(self) -> None:
-        if settings.auto_show_diagnostics_panel == 'saved':
-            # TODO: This method should disappear
-            listener = self.listener()
-            if listener:
-                mgr = listener.manager  # type: ignore
-                mgr.diagnostics._updatable.on_document_changed()  # type: ignore
-
-    def _massive_hack_saved(self) -> None:
-        if settings.auto_show_diagnostics_panel == 'saved':
-            # TODO: This method should disappear
-            listener = self.listener()
-            if listener:
-                mgr = listener.manager  # type: ignore
-                mgr.diagnostics._updatable.on_document_saved()  # type: ignore
+        self.session_buffer.on_post_save()
 
     def __str__(self) -> str:
-        return '{}-{}'.format(self.view.id(), self.session.config.name)
+        return '{}:{}'.format(self.session.config.name, self.view.id())


### PR DESCRIPTION
SessionView Part II: Attack of the Clones

This solves the clones problem by storing state per session *per buffer* instead of per session *per view*. Multiple views may refer to the same underlying buffer.

After this we can store diagnostics in the SessionBuffer class.