### PR TITLE
Switch away from deprecated Github API

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -120,8 +120,9 @@ def publish_release(args: argparse.Namespace) -> None:
     git('push', repo_url, 'tag', version)
 
     # publish the release
-    post_url = '/repos/{}/releases?access_token={}'.format(GITHUB_REPO, args.token)
+    post_url = '/repos/{}/releases'.format(GITHUB_REPO)
     headers = {
+        'Authorization': 'token {}'.format(args.token),
         'User-Agent': 'Sublime Text',
         'Content-type': 'application/json',
     }


### PR DESCRIPTION
More info: https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/

Have not tested but hopefully didn't mess up such simple change.