### PR TITLE
Listen for on_revert and on_reload events

### DIFF
--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -113,6 +113,18 @@ class DocumentSyncListener(LSPViewEventListener, AbstractViewListener):
                 for sv in self.session_views():
                     sv.on_text_changed(changes)
 
+    def on_revert(self) -> None:
+        if self.view.is_primary():
+            with self._session_views_lock:
+                for sv in self.session_views():
+                    sv.on_revert()
+
+    def on_reload(self) -> None:
+        if self.view.is_primary():
+            with self._session_views_lock:
+                for sv in self.session_views():
+                    sv.on_reload()
+
     def on_pre_save(self) -> None:
         if self.view.is_primary():
             view_settings = self.view.settings()

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -113,6 +113,12 @@ class SessionView:
     def on_text_changed(self, changes: Iterable[sublime.TextChange]) -> None:
         self.session_buffer.on_text_changed(changes)
 
+    def on_revert(self) -> None:
+        self.session_buffer.on_revert()
+
+    def on_reload(self) -> None:
+        self.session_buffer.on_reload()
+
     def purge_changes(self) -> None:
         self.session_buffer.purge_changes()
 


### PR DESCRIPTION
There's still a small bug left where ST fires a text change event
with all zeroes.

See: https://github.com/sublimelsp/LSP/issues/1015
See: https://github.com/sublimehq/sublime_text/issues/3323