### PR TITLE
Create WindowManager instance from 'on_new_window_async'

### DIFF
--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -157,8 +157,8 @@ class Listener(sublime_plugin.EventListener):
     def on_load_project_async(self, w: sublime.Window) -> None:
         windows.lookup(w).on_load_project_async()
 
-    def on_new_window(self, w: sublime.Window) -> None:
-        windows.lookup(w)
+    def on_new_window_async(self, w: sublime.Window) -> None:
+        sublime.set_timeout(lambda: windows.lookup(w))
 
     def on_pre_close_window(self, w: sublime.Window) -> None:
         windows.discard(w)


### PR DESCRIPTION
Instead of using sync variant ('on_new_window') where window.folders()
are not yet available, use async one where they seem to be.

Additional use set_timeout to jump on the main thread.

Fixes regression from SessionView task.