### PR TITLE
Fix: respect tabs when applying TextEdits

### DIFF
--- a/plugin/edit.py
+++ b/plugin/edit.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 
 
 @contextmanager
-def temporary(settings: sublime.Settings, key: str, val: Any) -> Generator[None, None, None]:
+def temporary_setting(settings: sublime.Settings, key: str, val: Any) -> Generator[None, None, None]:
     prev_val = None
     has_prev_val = settings.has(key)
     if has_prev_val:
@@ -56,7 +56,7 @@ class LspApplyDocumentEditCommand(sublime_plugin.TextCommand):
         # of any change that we haven't applied yet.
         if not changes:
             return
-        with temporary(self.view.settings(), "translate_tabs_to_spaces", False):
+        with temporary_setting(self.view.settings(), "translate_tabs_to_spaces", False):
             view_version = self.view.change_count()
             last_row, last_col = self.view.rowcol(self.view.size())
             for start, end, replacement, version in reversed(sort_by_application_order(changes)):

--- a/plugin/edit.py
+++ b/plugin/edit.py
@@ -7,17 +7,16 @@ from contextlib import contextmanager
 
 
 @contextmanager
-def temporary_setting(settings: sublime.Settings, key: str, value: Any) -> Generator[None, None, None]:
-    previous_value = None
-    has_previous_value = settings.has(key)
-    if has_previous_value:
-        previous_value = settings.get(key)
-    settings.set(key, value)
+def temporary(settings: sublime.Settings, key: str, val: Any) -> Generator[None, None, None]:
+    prev_val = None
+    has_prev_val = settings.has(key)
+    if has_prev_val:
+        prev_val = settings.get(key)
+    settings.set(key, val)
     yield
-    if has_previous_value:
-        settings.set(key, previous_value)
-    else:
-        settings.erase(key)
+    settings.erase(key)
+    if has_prev_val and settings.get(key) != prev_val:
+        settings.set(key, prev_val)
 
 
 class LspApplyWorkspaceEditCommand(sublime_plugin.WindowCommand):
@@ -57,7 +56,7 @@ class LspApplyDocumentEditCommand(sublime_plugin.TextCommand):
         # of any change that we haven't applied yet.
         if not changes:
             return
-        with temporary_setting(self.view.settings(), "translate_tabs_to_spaces", False):
+        with temporary(self.view.settings(), "translate_tabs_to_spaces", False):
             view_version = self.view.change_count()
             last_row, last_col = self.view.rowcol(self.view.size())
             for start, end, replacement, version in reversed(sort_by_application_order(changes)):

--- a/plugin/edit.py
+++ b/plugin/edit.py
@@ -66,8 +66,16 @@ class LspApplyDocumentEditCommand(sublime_plugin.TextCommand):
                 if start[0] > last_row and replacement[0] != '\n':
                     # Handle when a language server (eg gopls) inserts at a row beyond the document
                     # some editors create the line automatically, sublime needs to have the newline prepended.
-                    debug('adding new line for edit at line {}, document ended at line {}'.format(start[0], last_row))
-                    self.view.replace(edit, region, '\n' + replacement)
+                    self.apply_change(region, '\n' + replacement, edit)
                     last_row, last_col = self.view.rowcol(self.view.size())
                 else:
-                    self.view.replace(edit, region, replacement)
+                    self.apply_change(region, replacement, edit)
+
+    def apply_change(self, region: sublime.Region, replacement: str, edit: Any) -> None:
+        if region.empty():
+            self.view.insert(edit, region.a, replacement)
+        else:
+            if len(replacement) > 0:
+                self.view.replace(edit, region, replacement)
+            else:
+                self.view.erase(edit, region)

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -1,8 +1,9 @@
-import unittest
 from LSP.plugin.core.edit import sort_by_application_order, parse_workspace_edit, parse_text_edit
 from LSP.plugin.core.url import filename_to_uri
+from LSP.plugin.edit import temporary_setting
 from test_protocol import LSP_RANGE
 import sublime
+import unittest
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -69,3 +70,23 @@ class SortByApplicationOrderTests(unittest.TestCase):
         self.assertEqual(sorted_edits[0][2], 'b')
         self.assertEqual(sorted_edits[1][2], 'a')
         self.assertEqual(sorted_edits[2][2], 'c')
+
+
+class TemporarySetting(unittest.TestCase):
+
+    def test_basics(self):
+        v = sublime.active_window().active_view()
+        s = v.settings()
+        key = "__some_setting_that_should_not_exist__"
+        with temporary_setting(s, key, "hello"):
+            # The value should be modified while in the with-context
+            self.assertEqual(s.get(key), "hello")
+        # The key should be erased once out of the with-context, because it was not present before.
+        self.assertFalse(s.has(key))
+        s.set(key, "hello there")
+        with temporary_setting(s, key, "general kenobi"):
+            # value key should be modified while in the with-context
+            self.assertEqual(s.get(key), "general kenobi")
+        # The key should remain present, and the value should be restored.
+        self.assertEqual(s.get(key), "hello there")
+        s.erase(key)

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -1,6 +1,6 @@
 from LSP.plugin.core.edit import sort_by_application_order, parse_workspace_edit, parse_text_edit
 from LSP.plugin.core.url import filename_to_uri
-from LSP.plugin.edit import temporary_setting
+from LSP.plugin.edit import temporary
 from test_protocol import LSP_RANGE
 import sublime
 import unittest
@@ -74,17 +74,17 @@ class SortByApplicationOrderTests(unittest.TestCase):
 
 class TemporarySetting(unittest.TestCase):
 
-    def test_basics(self):
+    def test_basics(self) -> None:
         v = sublime.active_window().active_view()
         s = v.settings()
         key = "__some_setting_that_should_not_exist__"
-        with temporary_setting(s, key, "hello"):
+        with temporary(s, key, "hello"):
             # The value should be modified while in the with-context
             self.assertEqual(s.get(key), "hello")
         # The key should be erased once out of the with-context, because it was not present before.
         self.assertFalse(s.has(key))
         s.set(key, "hello there")
-        with temporary_setting(s, key, "general kenobi"):
+        with temporary(s, key, "general kenobi"):
             # value key should be modified while in the with-context
             self.assertEqual(s.get(key), "general kenobi")
         # The key should remain present, and the value should be restored.

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -1,6 +1,6 @@
 from LSP.plugin.core.edit import sort_by_application_order, parse_workspace_edit, parse_text_edit
 from LSP.plugin.core.url import filename_to_uri
-from LSP.plugin.edit import temporary
+from LSP.plugin.edit import temporary_setting
 from test_protocol import LSP_RANGE
 import sublime
 import unittest
@@ -78,13 +78,13 @@ class TemporarySetting(unittest.TestCase):
         v = sublime.active_window().active_view()
         s = v.settings()
         key = "__some_setting_that_should_not_exist__"
-        with temporary(s, key, "hello"):
+        with temporary_setting(s, key, "hello"):
             # The value should be modified while in the with-context
             self.assertEqual(s.get(key), "hello")
         # The key should be erased once out of the with-context, because it was not present before.
         self.assertFalse(s.has(key))
         s.set(key, "hello there")
-        with temporary(s, key, "general kenobi"):
+        with temporary_setting(s, key, "general kenobi"):
             # value key should be modified while in the with-context
             self.assertEqual(s.get(key), "general kenobi")
         # The key should remain present, and the value should be restored.

--- a/tests/test_single_document.py
+++ b/tests/test_single_document.py
@@ -263,3 +263,26 @@ class WillSaveWaitUntilTestCase(TextDocumentTestCase):
         text = self.view.substr(sublime.Region(0, self.view.size()))
         self.assertEquals("BBB", text)
         yield from self.await_clear_view_and_save()
+
+
+class TabsSpacesTextEdits(TextDocumentTestCase):
+
+    def init_view_settings(self) -> None:
+        super().init_view_settings()
+        self.view.settings().set("translate_tabs_to_spaces", True)
+
+    def test_tabs_are_respected_even_when_translate_tabs_to_spaces_is_set_to_true(self) -> 'Generator':
+        assert self.view
+        original_change_count = self.insert_characters(" " * 4)
+        # self.assertEqual(original_change_count, 1)
+        self.set_response('textDocument/formatting', [{
+            'newText': '\t',
+            'range': {
+                'start': {'line': 0, 'character': 0},
+                'end': {'line': 0, 'character': 4}}}]
+        )
+        self.view.run_command('lsp_format_document')
+        yield from self.await_message('textDocument/formatting')
+        yield from self.await_view_change(original_change_count + 1)
+        self.assertEquals(self.view.substr(sublime.Region(0, self.view.size())), "\t")
+        self.assertTrue(self.view.settings().get("translate_tabs_to_spaces"))

--- a/tests/test_single_document.py
+++ b/tests/test_single_document.py
@@ -169,6 +169,16 @@ class SingleDocumentTestCase(TextDocumentTestCase):
         )
         yield from self.__run_formatting_test(original, expected, file_changes)
 
+    def test_tabs_are_respected_even_when_translate_tabs_to_spaces_is_set_to_true(self) -> 'Generator':
+        original = ' ' * 4
+        file_changes = [((0, 0), (0, 4), '\t')]
+        expected = '\t'
+        assert self.view
+        self.view.settings().set("translate_tabs_to_spaces", True)
+        yield from self.__run_formatting_test(original, expected, file_changes)
+        # Make sure the user's settings haven't changed
+        self.assertTrue(self.view.settings().get("translate_tabs_to_spaces"))
+
     def __run_formatting_test(
         self,
         original: 'Iterable[str]',
@@ -263,26 +273,3 @@ class WillSaveWaitUntilTestCase(TextDocumentTestCase):
         text = self.view.substr(sublime.Region(0, self.view.size()))
         self.assertEquals("BBB", text)
         yield from self.await_clear_view_and_save()
-
-
-class TabsSpacesTextEdits(TextDocumentTestCase):
-
-    def init_view_settings(self) -> None:
-        super().init_view_settings()
-        self.view.settings().set("translate_tabs_to_spaces", True)
-
-    def test_tabs_are_respected_even_when_translate_tabs_to_spaces_is_set_to_true(self) -> 'Generator':
-        assert self.view
-        original_change_count = self.insert_characters(" " * 4)
-        # self.assertEqual(original_change_count, 1)
-        self.set_response('textDocument/formatting', [{
-            'newText': '\t',
-            'range': {
-                'start': {'line': 0, 'character': 0},
-                'end': {'line': 0, 'character': 4}}}]
-        )
-        self.view.run_command('lsp_format_document')
-        yield from self.await_message('textDocument/formatting')
-        yield from self.await_view_change(original_change_count + 1)
-        self.assertEquals(self.view.substr(sublime.Region(0, self.view.size())), "\t")
-        self.assertTrue(self.view.settings().get("translate_tabs_to_spaces"))


### PR DESCRIPTION
I couldn't find a way to make view.insert or view.replace to respect tabs. We have to temporarily change view setting.