### PR TITLE
Fix completions not being requested from server in some cases

### DIFF
--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -42,17 +42,6 @@ class InitializationTests(DeferrableTestCase):
         except Exception:
             pass
 
-    def test_not_enabled(self) -> 'Generator':
-        wm = windows.lookup(self.view.window())
-        wm._configs.all.append(text_config)
-        handler = CompletionHandler(self.view)
-        self.assertFalse(handler.initialized)
-        self.assertFalse(handler.enabled)
-        result = handler.on_query_completions("", [0])
-        yield lambda: handler.initialized
-        yield lambda: not handler.enabled
-        self.assertIsNone(result)
-
     def doCleanups(self) -> 'Generator':
         yield from super().doCleanups()
         wm = windows.lookup(self.view.window())


### PR DESCRIPTION
When "on_query_completions" has been triggered before session has
been initialized (for example on start of ST), then the initialize()
has not seen the session yet and has disabled the completions
for the rest of the session for that file.

Fix by not storing "initialized" or "ready" state and instead handle
"initialize" (renamed to "apply_view_settings") on every request to
"on_query_completions".

To make that work nicely, also fixed issue with "auto_complete_triggers"
values being duplicated. Those values are stored in STs session so after
restarting ST, we would add duplicate entries to that list.
With "apply_view_settings" running on each completion request now that
would become even worse.