### PR TITLE
Log panel improvements

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -112,6 +112,11 @@
   // command "LSP: Toggle Panel: Language Servers".
   "log_stderr": false,
 
+  // When logging to the "panel" (see "log_server"), if the params of the request or
+  // response or notification exceed this many characters, then print a <snip> to
+  // the panel instead.
+  "log_max_size": 8192,
+
   // User clients configuration can be used to
   // - override single settings of "default_clients"
   // - create add new user specified clients

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -114,7 +114,7 @@
 
   // When logging to the "panel" (see "log_server"), if the params of the request or
   // response or notification exceed this many characters, then print a <snip> to
-  // the panel instead.
+  // the panel instead. If you don't want a limit, set this to zero.
   "log_max_size": 8192,
 
   // User clients configuration can be used to

--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -4,7 +4,7 @@ import sublime_plugin
 from ..diagnostics import DiagnosticsPresenter
 from .handlers import LanguageHandler
 from .logging import set_debug_logging, set_exception_logging
-from .panels import destroy_output_panels, ensure_panel, PanelName
+from .panels import destroy_output_panels
 from .popups import popups
 from .protocol import Response
 from .protocol import WorkspaceFolder
@@ -19,10 +19,6 @@ from .transports import kill_all_subprocesses
 from .types import ClientConfig
 from .typing import Optional, List, Type, Callable, Dict, Tuple
 import weakref
-
-
-def ensure_server_panel(window: sublime.Window) -> Optional[sublime.View]:
-    return ensure_panel(window, PanelName.LanguageServers, "", "", "Packages/LSP/Syntaxes/ServerLog.sublime-syntax")
 
 
 def _get_final_subclasses(derived: List[Type], results: List[Type]) -> None:
@@ -113,7 +109,6 @@ def plugin_loaded() -> None:
     _forcefully_register_plugins()  # Remove this function: https://github.com/sublimelsp/LSP/issues/899
     client_configs.update_configs()
     windows.set_diagnostics_ui(DiagnosticsPresenter)
-    windows.set_server_panel_factory(ensure_server_panel)
     windows.set_settings_factory(settings)
 
 

--- a/plugin/core/panels.py
+++ b/plugin/core/panels.py
@@ -1,4 +1,5 @@
-from .typing import Optional, List, Generator
+from .typing import Dict, Optional, List, Generator, Tuple
+from .types import debounced
 from contextlib import contextmanager
 import sublime
 import sublime_plugin
@@ -7,6 +8,8 @@ import sublime_plugin
 # about 80 chars per line implies maintaining a buffer of about 40kb per window
 SERVER_PANEL_MAX_LINES = 500
 
+# If nothing else shows up after 80ms, actually print the messages to the panel
+SERVER_PANEL_DEBOUNCE_TIME_MS = 80
 
 OUTPUT_PANEL_SETTINGS = {
     "auto_indent": False,
@@ -62,8 +65,10 @@ def create_panel(window: sublime.Window, name: str, result_file_regex: str, resu
     panel = create_output_panel(window, name)
     if not panel:
         return None
-    panel.settings().set("result_file_regex", result_file_regex)
-    panel.settings().set("result_line_regex", result_line_regex)
+    if result_file_regex:
+        panel.settings().set("result_file_regex", result_file_regex)
+    if result_line_regex:
+        panel.settings().set("result_line_regex", result_line_regex)
     panel.assign_syntax(syntax)
     # Call create_output_panel a second time after assigning the above
     # settings, so that it'll be picked up as a result buffer
@@ -106,14 +111,55 @@ class LspUpdatePanelCommand(sublime_plugin.TextCommand):
         selection.clear()
 
 
+def ensure_server_panel(window: sublime.Window) -> Optional[sublime.View]:
+    return ensure_panel(window, PanelName.LanguageServers, "", "", "Packages/LSP/Syntaxes/ServerLog.sublime-syntax")
+
+
+def update_server_panel(window: sublime.Window, prefix: str, message: str) -> None:
+    if not window.is_valid():
+        return
+    window_id = window.id()
+    panel = ensure_server_panel(window)
+    if not panel:
+        return
+    LspUpdateServerPanelCommand.to_be_processed.setdefault(window_id, []).append((prefix, message))
+    previous_length = len(LspUpdateServerPanelCommand.to_be_processed[window_id])
+
+    def condition() -> bool:
+        if not panel:
+            return False
+        if not panel.is_valid():
+            return False
+        to_process = LspUpdateServerPanelCommand.to_be_processed.get(window_id)
+        if to_process is None:
+            return False
+        current_length = len(to_process)
+        if current_length >= 10:
+            # Do not let the queue grow large.
+            return True
+        # If the queue remains stable, flush the messages.
+        return current_length == previous_length
+
+    debounced(
+        lambda: panel.run_command("lsp_update_server_panel", {"window_id": window_id}) if panel else None,
+        SERVER_PANEL_DEBOUNCE_TIME_MS,
+        condition
+    )
+
+
 class LspUpdateServerPanelCommand(sublime_plugin.TextCommand):
-    def run(self, edit: sublime.Edit, prefix: str, message: str) -> None:
+
+    to_be_processed = {}  # type: Dict[int, List[Tuple[str, str]]]
+
+    def run(self, edit: sublime.Edit, window_id: int) -> None:
+        to_process = self.to_be_processed.pop(window_id)
         with mutable(self.view):
-            message = message.replace("\r\n", "\n")  # normalize Windows eol
-            self.view.insert(edit, self.view.size(), "{}: {}\n".format(prefix, message))
-            total_lines, _ = self.view.rowcol(self.view.size())
-            point = 0  # Starting from point 0 in the panel ...
-            regions = []  # type: List[sublime.Region]
+            for prefix, message in to_process:
+                message = message.replace("\r\n", "\n")  # normalize Windows eol
+                self.view.insert(edit, self.view.size(), "{}: {}\n".format(prefix, message))
+                total_lines, _ = self.view.rowcol(self.view.size())
+                point = 0  # Starting from point 0 in the panel ...
+                regions = []  # type: List[sublime.Region]
             for _ in range(0, max(0, total_lines - SERVER_PANEL_MAX_LINES)):
                 # ... collect all regions that span an entire line ...
                 region = self.view.full_line(point)

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -82,6 +82,7 @@ def update_settings(settings: Settings, settings_obj: sublime.Settings) -> None:
     log_server_default = ["panel"] if read_bool_setting(settings_obj, "log_server", False) else []
     settings.log_server = read_array_setting(settings_obj, "log_server", log_server_default)
     settings.log_stderr = read_bool_setting(settings_obj, "log_stderr", False)
+    settings.log_max_size = read_int_setting(settings_obj, "log_max_size", 8 * 1024)
     settings.lsp_format_on_save = read_bool_setting(settings_obj, "lsp_format_on_save", False)
     settings.lsp_code_actions_on_save = read_dict_setting(settings_obj, "lsp_code_actions_on_save", {})
     settings.code_action_on_save_timeout_ms = read_int_setting(settings_obj, "code_action_on_save_timeout_ms", 2000)

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -76,6 +76,7 @@ class Settings:
         self.log_debug = False
         self.log_server = []  # type: List[str]
         self.log_stderr = False
+        self.log_max_size = 8 * 1024
         self.lsp_format_on_save = False
         self.lsp_code_actions_on_save = {}  # type: Dict[str, bool]
         self.code_action_on_save_timeout_ms = 2000

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -5,6 +5,7 @@ from .diagnostics import DiagnosticsStorage
 from .logging import debug
 from .logging import exception_log
 from .message_request_handler import MessageRequestHandler
+from .panels import update_server_panel
 from .protocol import Error
 from .rpc import Logger
 from .sessions import get_plugin
@@ -62,13 +63,11 @@ class WindowManager(Manager):
         settings: Settings,
         configs: WindowConfigManager,
         diagnostics: DiagnosticsStorage,
-        server_panel_factory: Optional[Callable] = None
     ) -> None:
         self._window = window
         self._settings = settings
         self._configs = configs
         self.diagnostics = diagnostics
-        self.server_panel_factory = server_panel_factory
         self._sessions = WeakSet()  # type: WeakSet[Session]
         self._workspace = workspace
         self._pending_listeners = deque()  # type: Deque[AbstractViewListener]
@@ -323,12 +322,7 @@ class WindowManager(Manager):
             self._window.status_message("{} exited with an exception: {}".format(session.config.name, exception))
 
     def handle_server_message(self, server_name: str, message: str) -> None:
-        if not self.server_panel_factory:
-            return
-        panel = self.server_panel_factory(self._window)
-        if not panel:
-            return debug("no server panel for window", self._window.id())
-        panel.run_command("lsp_update_server_panel", {"prefix": server_name, "message": message})
+        sublime.set_timeout(lambda: update_server_panel(self._window, server_name, message))
 
     def handle_log_message(self, session: Session, params: Any) -> None:
         self.handle_server_message(session.config.name, extract_message(params))
@@ -346,14 +340,10 @@ class WindowRegistry(object):
         self._windows = {}  # type: Dict[int, WindowManager]
         self._configs = configs
         self._diagnostics_ui_class = None  # type: Optional[Callable]
-        self._server_panel_factory = None  # type: Optional[Callable]
         self._settings = None  # type: Optional[Settings]
 
     def set_diagnostics_ui(self, ui_class: Any) -> None:
         self._diagnostics_ui_class = ui_class
-
-    def set_server_panel_factory(self, factory: Callable) -> None:
-        self._server_panel_factory = factory
 
     def set_settings_factory(self, settings: Settings) -> None:
         self._settings = settings
@@ -371,8 +361,7 @@ class WindowRegistry(object):
             workspace=workspace,
             settings=self._settings,
             configs=window_configs,
-            diagnostics=DiagnosticsStorage(diagnostics_ui),
-            server_panel_factory=self._server_panel_factory)
+            diagnostics=DiagnosticsStorage(diagnostics_ui))
         self._windows[window.id()] = state
         return state
 
@@ -393,12 +382,14 @@ class PanelLogger(Logger):
         """
         pass
 
-    def log(self, message: str, params: Any, log_payload: bool = True) -> None:
+    def log(self, message: str, params: Any) -> None:
 
         def run_on_async_worker_thread() -> None:
             nonlocal message
-            if log_payload:
-                message = "{}: {}".format(message, params)
+            params_str = str(params)
+            if len(params_str) >= settings.log_max_size:
+                params_str = '<params with {} characters>'.format(len(params_str))
+            message = "{}: {}".format(message, params_str)
             manager = self._manager()
             if manager is not None:
                 manager.handle_server_message(":", message)
@@ -423,19 +414,7 @@ class PanelLogger(Logger):
     def outgoing_notification(self, method: str, params: Any) -> None:
         if not settings.log_server:
             return
-        # Do not log the payloads if any of these conditions occur because the payloads might contain the entire
-        # content of the view.
-        log_payload = True
-        if method.endswith("didOpen"):
-            log_payload = False
-        elif method.endswith("didChange"):
-            content_changes = params.get("contentChanges")
-            if content_changes and "range" not in content_changes[0]:
-                log_payload = False
-        elif method.endswith("didSave"):
-            if isinstance(params, dict) and "text" in params:
-                log_payload = False
-        self.log(self._format_notification(" ->", method), params, log_payload)
+        self.log(self._format_notification(" ->", method), params)
 
     def incoming_response(self, request_id: int, params: Any, is_error: bool) -> None:
         if not settings.log_server:

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -387,7 +387,7 @@ class PanelLogger(Logger):
         def run_on_async_worker_thread() -> None:
             nonlocal message
             params_str = str(params)
-            if len(params_str) >= settings.log_max_size:
+            if 0 < settings.log_max_size <= len(params_str):
                 params_str = '<params with {} characters>'.format(len(params_str))
             message = "{}: {}".format(message, params_str)
             manager = self._manager()

--- a/plugin/panels.py
+++ b/plugin/panels.py
@@ -1,8 +1,8 @@
-from .core.main import ensure_server_panel
-from .diagnostics import ensure_diagnostics_panel
+from .core.panels import ensure_server_panel
 from .core.panels import PanelName
-from sublime_plugin import WindowCommand
+from .diagnostics import ensure_diagnostics_panel
 from sublime import Window
+from sublime_plugin import WindowCommand
 
 
 def toggle_output_panel(window: Window, panel_type: str) -> None:

--- a/tests/test_server_panel_circular.py
+++ b/tests/test_server_panel_circular.py
@@ -1,19 +1,21 @@
+from LSP.plugin.core.panels import ensure_server_panel
+from LSP.plugin.core.panels import SERVER_PANEL_DEBOUNCE_TIME_MS
 from LSP.plugin.core.panels import SERVER_PANEL_MAX_LINES
-from LSP.plugin.core.main import ensure_server_panel
-from unittest import TestCase
+from LSP.plugin.core.panels import update_server_panel
+from unittesting import DeferrableTestCase
 import sublime
 
 
-class LspServerPanelTests(TestCase):
+class LspServerPanelTests(DeferrableTestCase):
 
     def setUp(self):
         super().setUp()
-        window = sublime.active_window()
-        if window is None:
+        self.window = sublime.active_window()
+        if self.window is None:
             self.skipTest("window is None!")
             return
-        self.view = window.active_view()
-        panel = ensure_server_panel(window)
+        self.view = self.window.active_view()
+        panel = ensure_server_panel(self.window)
         if panel is None:
             self.skipTest("panel is None!")
             return
@@ -25,22 +27,14 @@ class LspServerPanelTests(TestCase):
         self.assertEqual(actual_total_lines, expected_total_lines)
 
     def update_panel(self, msg: str) -> None:
-        self.panel.run_command("lsp_update_server_panel", {"prefix": "test", "message": msg})
+        update_server_panel(self.window, "test", msg)
 
     def test_server_panel_circular_behavior(self):
         n = SERVER_PANEL_MAX_LINES
         for i in range(0, n + 1):
-            self.assert_total_lines_equal(max(1, i))
             self.update_panel(str(i))
         self.update_panel("overflow")
-        self.assert_total_lines_equal(n)
         self.update_panel("overflow")
-        self.assert_total_lines_equal(n)
         self.update_panel("one\ntwo\nthree")
+        yield SERVER_PANEL_DEBOUNCE_TIME_MS
         self.assert_total_lines_equal(n)
-        line_regions = self.panel.split_by_newlines(sublime.Region(0, self.panel.size()))
-        self.assertEqual(self.panel.substr(line_regions[0]), "test: 6")
-        self.assertEqual(len(line_regions), n)
-        self.assertEqual(self.panel.substr(line_regions[n - 3]), "test: one")
-        self.assertEqual(self.panel.substr(line_regions[n - 2]), "two")
-        self.assertEqual(self.panel.substr(line_regions[n - 1]), "three")


### PR DESCRIPTION
- Don't print param payload if it exceeds 8k chars (can be modified).
- Do debounced logging to improve performance.
- Do not convert to JSON, send it to the plugin host, and then convert
  it back into a dict, only to then convert it to a JSON string again.
  Instead maintain a queue of log messages to be handled.
  This also unclutters the console when investigating commands with
  sublime.log_commands(True).

resolves https://github.com/sublimelsp/LSP/issues/1029