### PR TITLE
Add diagnostic panel severity level setting

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -41,6 +41,13 @@
   // hint: 4
   "auto_show_diagnostics_panel_level": 2,
 
+  // Only show diagnostics in the panel with a severity equal to or less than:
+  // error: 1
+  // warning: 2
+  // info: 3
+  // hint: 4
+  "diagnostics_panel_include_severity_level": 4,
+
   // Show errors and warnings count in the status bar
   "show_diagnostics_count_in_view_status": false,
 

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -41,13 +41,6 @@
   // hint: 4
   "auto_show_diagnostics_panel_level": 2,
 
-  // Only show diagnostics in the panel with a severity equal to or less than:
-  // error: 1
-  // warning: 2
-  // info: 3
-  // hint: 4
-  "diagnostics_panel_include_severity_level": 4,
-
   // Show errors and warnings count in the status bar
   "show_diagnostics_count_in_view_status": false,
 
@@ -55,13 +48,20 @@
   // under the cursor in status bar if available.
   "show_diagnostics_in_view_status": true,
 
-  // Show the diagnostics with level less than or equal to
-  // the given value.
+  // Show highlights and gutter markers in the file views for diagnostics
+  // with level equal to or less than:
   // error: 1
   // warning: 2
   // info: 3
   // hint: 4
   "show_diagnostics_severity_level": 4,
+
+  // Only show diagnostics in the panel with level equal to or less than:
+  // error: 1
+  // warning: 2
+  // info: 3
+  // hint: 4
+  "diagnostics_panel_include_severity_level": 4,
 
   // Delay showing diagnostics by this many milliseconds.
   // The delay will only kick into action when previously there were

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -65,6 +65,9 @@ def update_settings(settings: Settings, settings_obj: sublime.Settings) -> None:
                                                                                     "auto_show_diagnostics_panel",
                                                                                     'always')
     settings.auto_show_diagnostics_panel_level = read_int_setting(settings_obj, "auto_show_diagnostics_panel_level", 2)
+    settings.diagnostics_panel_include_severity_level = read_int_setting(settings_obj,
+                                                                         "diagnostics_panel_include_severity_level",
+                                                                         4)
     settings.show_diagnostics_count_in_view_status = read_bool_setting(settings_obj,
                                                                        "show_diagnostics_count_in_view_status", False)
     settings.show_diagnostics_in_view_status = read_bool_setting(settings_obj, "show_diagnostics_in_view_status", True)

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -57,6 +57,7 @@ class Settings:
         self.show_view_status = True
         self.auto_show_diagnostics_panel = 'always'
         self.auto_show_diagnostics_panel_level = 2
+        self.diagnostics_panel_include_severity_level = 4
         self.show_diagnostics_count_in_view_status = False
         self.show_diagnostics_in_view_status = True
         self.show_diagnostics_severity_level = 2

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -181,7 +181,7 @@ class SessionBuffer:
                     total_errors += 1
                 elif diagnostic.severity == DiagnosticSeverity.Warning:
                     total_warnings += 1
-                if diagnostic.severity <= settings.show_diagnostics_severity_level:
+                if diagnostic.severity <= settings.diagnostics_panel_include_severity_level:
                     data.panel_contribution.append(format_diagnostic_for_panel(diagnostic))
                 if diagnostic.severity <= settings.auto_show_diagnostics_panel_level:
                     should_show_diagnostics_panel = True


### PR DESCRIPTION
This adds the `diagnostics_panel_include_severity_level` setting, which allows the diagnostics shown in the panel to be controlled independently from the ones shown in the code itself, which uses the `show_diagnostics_severity_level` setting.

This seems to be the least complex way to accomplish what I mentioned [on Discord](https://discord.com/channels/280102180189634562/645268178397560865/725710727712604171). While I may want to show hints and info level diagnostics in the code, which can be extremely helpful, I only want the diagnostic panel to be shown when I save a file and there are warning or error level diagnostics that would cause the code to not run. The `auto_show_diagnostics_panel_level` setting helps control when the panel is shown, but since the panel currently shows _all_ diagnostics that meet the `show_diagnostics_severity_level` setting from _all_ open files, it is very difficult to quickly grok what errors and warnings there are, since there can be a lot of info and hint level diagnostics.

The default for the new `diagnostics_panel_include_severity_level` setting matches the default value for the `show_diagnostics_severity_level` setting, but it may be a good idea to also have this set to whatever the user setting is when they update so that it does not unexpectedly start showing more diagnostics for users that have `show_diagnostics_severity_level` set to a value lower than `4`. I am not sure if that is possible or where to do it though.