### PR TITLE
Import typing based on version rather than try/except

### DIFF
--- a/plugin/core/typing.py
+++ b/plugin/core/typing.py
@@ -1,6 +1,6 @@
-try:
+import sys
 
-    # ST builds >= 4000
+if sys.version_info >= (3, 5, 0):
 
     from mypy_extensions import TypedDict
     from typing import Any
@@ -20,9 +20,7 @@ try:
     from typing import Union
     from typing_extensions import Protocol
 
-except ImportError:
-
-    # ST builds < 4000
+else:
 
     def _make_type(name: str) -> '_TypeMeta':
         return _TypeMeta(name, (Type,), {})  # type: ignore


### PR DESCRIPTION
We know exactly from which python version "typing" import is available
so no need to try and catch.

This also makes pyright type checker work well with the code base.