### PR TITLE
Use the escapeall markdown extension to handle \< and \> in markdown

### DIFF
--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -406,8 +406,18 @@ def minihtml(view: sublime.View, content: Union[str, Dict[str, str], list], allo
     if is_plain_text:
         return text2html(result)
     else:
-        frontmatter_config = mdpopups.format_frontmatter({'allow_code_wrap': True})
-        return mdpopups.md2html(view, frontmatter_config + result)
+        frontmatter = {
+            "allow_code_wrap": True,
+            "markdown_extensions": [
+                {
+                    "pymdownx.escapeall": {
+                        "hardbreak": False,
+                        "nbsp": False
+                    }
+                }
+            ]
+        }
+        return mdpopups.md2html(view, mdpopups.format_frontmatter(frontmatter) + result)
 
 
 REPLACEMENT_MAP = {


### PR DESCRIPTION
This does nothing at the moment, but should render `\<` and `\>` correctly once https://github.com/facelessuser/pymdown-extensions/commit/5fca01fa343b67c211ba5a1b51d4b0a40e939ccc is in https://github.com/facelessuser/sublime-pymdownx/tree/master/st3/pymdownx