### PR TITLE
Fixup: Missing show_diagnostics_severity_level functionality

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -50,6 +50,7 @@
 
   // Show highlights and gutter markers in the file views for diagnostics
   // with level equal to or less than:
+  // none: 0
   // error: 1
   // warning: 2
   // info: 3

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -1,5 +1,6 @@
 from .core.protocol import Diagnostic
 from .core.sessions import Session
+from .core.settings import settings as global_settings
 from .core.types import view2scope
 from .core.typing import Any, Iterable, List, Tuple
 from .core.views import DIAGNOSTIC_SEVERITY
@@ -112,7 +113,8 @@ class SessionView:
             data = data_per_severity.get(severity)
             if data is None:
                 self.view.erase_regions(key)
-            elif data.icon or flags != (sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE):
+            elif ((severity <= global_settings.show_diagnostics_severity_level) and
+                    (data.icon or flags != (sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE))):
                 self.view.add_regions(key, data.regions, data.scope, data.icon, flags)
             else:
                 self.view.erase_regions(key)


### PR DESCRIPTION
Also, allow 0 to get the effect of showing no linter results in the view.
Note that the language server will keep publishing diagnostics in the
background, we cannot control that.

Close #858