### PR TITLE
Print "No documentation available" when there are no docs

### DIFF
--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -65,10 +65,13 @@ class LspResolveDocsCommand(LspTextCommand):
                 lambda res: self.handle_resolve_response(res))
 
     def handle_resolve_response(self, item: Optional[dict]) -> None:
-        if not item:
-            return
-        detail = self.format_documentation(item.get('detail') or "")
-        documentation = self.format_documentation(item.get("documentation") or "")
+        detail = ""
+        documentation = ""
+        if item:
+            detail = self.format_documentation(item.get('detail') or "")
+            documentation = self.format_documentation(item.get("documentation") or "")
+        if not documentation:
+            documentation = "<i>No documentation available.</i>"
         minihtml_content = self.get_content(documentation, detail)
         show = self.update_popup if self.view.is_popup_visible() else self.show_popup
         # NOTE: Update/show popups from the main thread, or else the popup might make the AC widget disappear.


### PR DESCRIPTION
During a resolve request it may happen that the server still returns no docs.
In that case we render "No documentation available" in the popup (in italics).

Close #1074