### PR TITLE
Make use of new ST API goodies since 4075

### DIFF
--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -116,7 +116,7 @@ def extract_variables(window: sublime.Window) -> Dict[str, str]:
 def point_to_offset(point: Point, view: sublime.View) -> int:
     # @see https://microsoft.github.io/language-server-protocol/specifications/specification-3-15/#position
     # If the character value is greater than the line length it defaults back to the line length.
-    return min(view.text_point_utf16(point.row, point.col), view.line(view.text_point(point.row, 0)).b)
+    return view.text_point_utf16(point.row, point.col, clamp_column=True)
 
 
 def offset_to_point(view: sublime.View, offset: int) -> Point:
@@ -210,7 +210,7 @@ def render_text_change(change: sublime.TextChange) -> Dict[str, Any]:
         "range": {
             "start": {"line": change.a.row, "character": change.a.col_utf16},
             "end":   {"line": change.b.row, "character": change.b.col_utf16}},
-        "rangeLength": abs(change.b.pt - change.a.pt),
+        "rangeLength": change.len_utf16,
         "text": change.str
     }
 

--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -784,13 +784,13 @@ class View:
     def rowcol_utf16(self, tp: int) -> Tuple[int, int]:
         ...
 
-    def text_point(self, row: int, col: int) -> int:
+    def text_point(self, row: int, col: int, *, clamp_column: bool = False) -> int:
         ...
 
-    def text_point_utf8(self, row: int, col_utf8: int) -> int:
+    def text_point_utf8(self, row: int, col_utf8: int, *, clamp_column: bool = False) -> int:
         ...
 
-    def text_point_utf16(self, row: int, col_utf16: int) -> int:
+    def text_point_utf16(self, row: int, col_utf16: int, *, clamp_column: bool = False) -> int:
         ...
 
     def visible_region(self) -> Region:
@@ -961,3 +961,5 @@ class TextChange:
     a = ...  # type: HistoricPosition
     b = ...  # type: HistoricPosition
     str = ...  # type: str
+    len_utf8 = ...  # type: int
+    len_utf16 = ...  # type: int


### PR DESCRIPTION
- Use clamp_column=True to restrict to the line from an LSP Range
  to an ST Region.
- Use the correct rangeLength (in UTF-16) when sending incremental
  text sync notifications.