### PR TITLE
Revert "Disable DYNAMIC_COMPLETIONS flag for builds older than 4075"

### DIFF
--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -284,8 +284,7 @@ class CompletionHandler(LSPViewEventListener):
             flags |= sublime.INHIBIT_REORDER
         if isinstance(response, dict):
             response_items = response["items"] or []
-            # TODO: Remove this version check when everyone is past 4074.
-            if response.get("isIncomplete", False) and int(sublime.version()) >= 4075:
+            if response.get("isIncomplete", False):
                 flags |= sublime.DYNAMIC_COMPLETIONS
         elif isinstance(response, list):
             response_items = response


### PR DESCRIPTION
This reverts commit fe1486e95888bae811c9385e61025ac06f4d1b62.

Everyone should have 4075 or higher now.