### PR TITLE
Replace diagnostic status bar with annotations

### DIFF
--- a/annotations.css
+++ b/annotations.css
@@ -1,0 +1,20 @@
+.lsp_annotation {
+    margin: 0;
+    border-width: 0;
+}
+.lsp_annotation .errors {
+    background-color: color(var(--redish) alpha(0.25));
+    color: var(--foreground);
+}
+.lsp_annotation .warnings {
+    background-color: color(var(--yellowish) alpha(0.25));
+    color: var(--foreground);
+}
+.lsp_annotation .info {
+    background-color: color(var(--bluish) alpha(0.25));
+    color: var(--foreground);
+}
+.lsp_annotation .hints {
+    background-color: color(var(--bluish) alpha(0.25));
+    color: var(--foreground);
+}

--- a/plugin/core/css.py
+++ b/plugin/core/css.py
@@ -9,6 +9,8 @@ class CSS:
         self.notification = sublime.load_resource("Packages/LSP/notification.css")
         self.notification_classname = "notification"
         self.phantoms = sublime.load_resource("Packages/LSP/phantoms.css")
+        self.annotations = sublime.load_resource("Packages/LSP/annotations.css")
+        self.annotations_classname = "lsp_annotation"
 
 
 _css = None  # type: Optional[CSS]

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -528,6 +528,16 @@ def format_diagnostic_for_html(diagnostic: Diagnostic, base_dir: Optional[str] =
     return '<pre class="{}">{}</pre>'.format(DIAGNOSTIC_SEVERITY[diagnostic.severity - 1][1], content)
 
 
+def format_diagnostic_for_annotation(diagnostic: Diagnostic) -> str:
+    diagnostic_message = text2html(diagnostic.message)
+    if diagnostic.source:
+        content = "[{}] {}".format(diagnostic.source, diagnostic_message)
+    else:
+        content = diagnostic_message
+    return '<body id="annotation"><style>{0}</style><div class="{1}"><div class="{2}">{3}</div></div></body>'.format(
+        css().annotations, css().annotations_classname, DIAGNOSTIC_SEVERITY[diagnostic.severity - 1][1], content)
+
+
 def create_phantom_html(content: str, severity: str) -> str:
     return """<body id=inline-error>
                 <style>{0}</style>

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -71,7 +71,7 @@ class AbstractViewListener(metaclass=ABCMeta):
         raise NotImplementedError()
 
     @abstractmethod
-    def update_diagnostic_in_status_bar_async(self) -> None:
+    def update_active_diagnostic_async(self) -> None:
         raise NotImplementedError()
 
 

--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -919,6 +919,9 @@ class View:
     def transform_region_from(self, region: Region, change_id: Any) -> Region:
         ...
 
+    def style_for_scope(self, scope: str) -> Dict[str, Any]:
+        ...
+
 
 class Phantom:
     region = ...  # type: Region


### PR DESCRIPTION
A diagnostic annotation appears when the (first) region of the
selection intersects with a diagnostic.

This needs a bit more testing.