### PR TITLE
Remove 'rls' from the default configs

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -225,12 +225,7 @@
       //   }
       // }
     },
-    "rls":
-    {
-      "command": ["rustup", "run", "nightly", "rls"],
-      "languageId": "rust" // will match source.rust
-    },
-     "rust-analyzer":
+    "rust-analyzer":
     {
       "command": ["rust-analyzer"],
       "languageId": "rust" // will match source.rust


### PR DESCRIPTION
rust-analyzer is the recommended language server these days.