### PR TITLE
Pass copy of configuration to on_workspace_configuration

### DIFF
--- a/plugin/core/collections.py
+++ b/plugin/core/collections.py
@@ -2,6 +2,7 @@
 Module with additional collections.
 """
 from .typing import Optional, Dict, Any
+from copy import deepcopy
 
 
 class DottedDict:
@@ -73,6 +74,19 @@ class DottedDict:
                 return
             current = next_current
         current.pop(keys[-1], None)
+
+    def copy(self, path: Optional[str] = None) -> Any:
+        """
+        Get a copy of the value from the dictionary or copy of whole dictionary.
+
+        :param      path:  The path, e.g. foo.bar.baz, or None.
+
+        :returns:   A copy of the value stored at the path, or None if it doesn't exist.
+                    Note that this cannot distinguish between None values and
+                    paths that don't exist. If the path is None, returns a copy of the
+                    entire dictionary.
+        """
+        return deepcopy(self.get(path))
 
     def __bool__(self) -> bool:
         """

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -20,6 +20,7 @@ from .views import extract_variables
 from .views import SYMBOL_KINDS
 from .workspace import is_subpath_of
 from abc import ABCMeta, abstractmethod
+from copy import deepcopy
 from weakref import WeakSet
 import os
 import sublime
@@ -729,7 +730,7 @@ class Session(Client):
         items = []  # type: List[Any]
         requested_items = params.get("items") or []
         for requested_item in requested_items:
-            configuration = self.config.settings.get(requested_item.get('section') or None)
+            configuration = deepcopy(self.config.settings.get(requested_item.get('section') or None))
             if self._plugin:
                 self._plugin.on_workspace_configuration(requested_item, configuration)
             items.append(configuration)

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -730,8 +730,9 @@ class Session(Client):
         items = []  # type: List[Any]
         requested_items = params.get("items") or []
         for requested_item in requested_items:
-            configuration = deepcopy(self.config.settings.get(requested_item.get('section') or None))
+            configuration = self.config.settings.get(requested_item.get('section') or None)
             if self._plugin:
+                configuration = deepcopy(configuration)
                 self._plugin.on_workspace_configuration(requested_item, configuration)
             items.append(configuration)
         self.send_response(Response(request_id, sublime.expand_variables(items, self._template_variables())))

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -20,7 +20,6 @@ from .views import extract_variables
 from .views import SYMBOL_KINDS
 from .workspace import is_subpath_of
 from abc import ABCMeta, abstractmethod
-from copy import deepcopy
 from weakref import WeakSet
 import os
 import sublime
@@ -730,9 +729,8 @@ class Session(Client):
         items = []  # type: List[Any]
         requested_items = params.get("items") or []
         for requested_item in requested_items:
-            configuration = self.config.settings.get(requested_item.get('section') or None)
+            configuration = self.config.settings.copy(requested_item.get('section') or None)
             if self._plugin:
-                configuration = deepcopy(configuration)
                 self._plugin.on_workspace_configuration(requested_item, configuration)
             items.append(configuration)
         self.send_response(Response(request_id, sublime.expand_variables(items, self._template_variables())))

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -117,3 +117,16 @@ class DottedDictTests(TestCase):
         self.verify(d, "a.b.y", 2)
         d.clear()
         self.assertFalse(d)
+
+    def test_copy_whole(self) -> None:
+        d = DottedDict({"a": {"b": {"c": {"x": "x", "y": "y"}}}})
+        d_copy = d.copy()
+        d_copy['a'] = None
+        self.assertNotEqual(d.get()['a'], d_copy['a'])
+
+    def test_copy_partial(self) -> None:
+        d = DottedDict({"a": {"b": {"c": 'd'}}})
+        d_copy = d.copy('a.b')
+        self.assertEqual(d_copy['c'], 'd')
+        d_copy['c'] = None
+        self.assertNotEqual(d.get('a.b.c'), d_copy['c'])


### PR DESCRIPTION
Since the purpose of the "on_workspace_configuration" is for plugins to
modify the dict, don't send original dict as plugin can't possibly keep
track of what was modified and remove modifications on next API call.