### PR TITLE
Remove unnecessary log message when websocket server is not created

### DIFF
--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -736,8 +736,6 @@ class RemoteLogger(Logger):
         if RemoteLogger._ws_server:
             json_data = json.dumps(data, sort_keys=True, check_circular=False, separators=(',', ':'))
             RemoteLogger._ws_server.send_message_to_all(json_data)
-        else:
-            debug('Failed to broadcast a remote log message')
 
 
 class RouterLogger(Logger):


### PR DESCRIPTION
There will already be a relevant log message earlier in the console if
_ws_server server was failed to be created so there is no need to spam
console with more logs.