### PR TITLE
Ruby server: use stdio instead of socket

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -498,7 +498,7 @@
       "command":
       [
         "solargraph",
-        "socket"
+        "stdio"
       ],
       "languageId": "ruby",
       "scopes":
@@ -512,7 +512,6 @@
         "Packages/Rails/Ruby on Rails.sublime-syntax",
         "Packages/Rails/HTML (Rails).sublime-syntax"
       ],
-      "tcp_port": 7658,
       // Enable RuboCop linting
       // "initializationOptions": {
       //   "diagnostics": true


### PR DESCRIPTION
The suggested configuration with TCP port is problematic:

* It doesn't pass port number to the command and assumes it will use 7658
* It doesn't allow multiple servers running at the same time
* Solargraph is the only server in sample configuration that uses sockets