### PR TITLE
Add LSP: Troubleshoot Server to Command Palette

### DIFF
--- a/Commands/Default.sublime-commands
+++ b/Commands/Default.sublime-commands
@@ -20,6 +20,10 @@
         "command": "lsp_parse_vscode_package_json"
     },
     {
+        "caption": "LSP: Troubleshoot Server",
+        "command": "lsp_troubleshoot_server"
+    },
+    {
         "caption": "LSP: Setup Language Server",
         "command": "lsp_setup_language_server",
         "args": {}

--- a/boot.py
+++ b/boot.py
@@ -41,4 +41,6 @@ from .plugin.symbols import LspSelectionAddCommand
 from .plugin.symbols import LspSelectionClearCommand
 from .plugin.symbols import LspSelectionSetCommand
 from .plugin.symbols import LspWorkspaceSymbolsCommand
+from .plugin.tooling import LspCopyToClipboardFromBase64Command
 from .plugin.tooling import LspParseVscodePackageJson
+from .plugin.tooling import LspTroubleshootServerCommand

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -32,6 +32,9 @@ class WindowConfigManager(object):
         self._temp_disabled_configs = set()  # type: Set[str]
         self.all = self._create_window_configs()
 
+    def get_configs(self) -> List[ClientConfig]:
+        return sorted(self.all, key=lambda config: config.name)
+
     def match_scope(self, scope: str) -> Generator[ClientConfig, None, None]:
         """
         Yields configurations which match one of their document selectors to the given scope.

--- a/plugin/core/css.py
+++ b/plugin/core/css.py
@@ -9,6 +9,8 @@ class CSS:
         self.notification = sublime.load_resource("Packages/LSP/notification.css")
         self.notification_classname = "notification"
         self.phantoms = sublime.load_resource("Packages/LSP/phantoms.css")
+        self.sheets = sublime.load_resource("Packages/LSP/sheets.css")
+        self.sheets_classname = "lsp_sheet"
 
 
 _css = None  # type: Optional[CSS]

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -125,6 +125,9 @@ class WindowManager(Manager):
         self.total_error_count = 0
         self.total_warning_count = 0
 
+    def get_config_manager(self) -> WindowConfigManager:
+        return self._configs
+
     def on_load_project_async(self) -> None:
         # TODO: Also end sessions that were previously enabled in the .sublime-project, but now disabled or removed
         # from the .sublime-project.

--- a/plugin/tooling.py
+++ b/plugin/tooling.py
@@ -1,8 +1,22 @@
+from .core.css import css
+from .core.registry import windows
+from .core.transports import create_transport
+from .core.transports import Transport
+from .core.transports import TransportCallbacks
+from .core.types import ClientConfig
+from .core.typing import Any, Callable, Dict, List, Optional
+from .core.version import __version__
+from .core.views import extract_variables
+from .core.views import make_command_link
+from base64 import b64decode
+from base64 import b64encode
+from subprocess import list2cmdline
+import json
+import mdpopups
+import os
 import sublime
 import sublime_plugin
-import json
 import textwrap
-from .core.typing import Optional
 
 
 class LspParseVscodePackageJson(sublime_plugin.ApplicationCommand):
@@ -77,3 +91,160 @@ class LspParseVscodePackageJson(sublime_plugin.ApplicationCommand):
                 else:
                     self.writeline4('{}{}'.format(line, terminator))
         self.writeline("}")
+
+
+class LspTroubleshootServerCommand(sublime_plugin.WindowCommand, TransportCallbacks):
+
+    def run(self) -> None:
+        window = self.window
+        active_view = window.active_view()
+        configs = [c for c in windows.lookup(window).get_config_manager().get_configs() if c.enabled]
+        config_names = [config.name for config in configs]
+        if config_names:
+            window.show_quick_panel(config_names, lambda index: self.on_selected(index, configs, active_view),
+                                    placeholder='Select server to troubleshoot')
+
+    def on_selected(self, selected_index: int, configs: List[ClientConfig], active_view: sublime.View) -> None:
+        if selected_index == -1:
+            return
+        config = configs[selected_index]
+        output_sheet = mdpopups.new_html_sheet(
+            self.window, 'Server: {}'.format(config.name), '# Running server test...',
+            css=css().sheets, wrapper_class=css().sheets_classname)
+        sublime.set_timeout_async(lambda: self.test_run_server_async(config, self.window, active_view, output_sheet))
+
+    def test_run_server_async(self, config: ClientConfig, window: sublime.Window,
+                              active_view: sublime.View, output_sheet: sublime.HtmlSheet) -> None:
+        self.test_runner = ServerTestRunner(
+            config, window,
+            lambda output, exit_code: self.update_sheet(config, active_view, output_sheet, output, exit_code))
+
+    def update_sheet(self, config: ClientConfig, active_view: sublime.View, output_sheet: sublime.HtmlSheet,
+                     server_output: str, exit_code: int) -> None:
+        self.test_runner = None
+        frontmatter = mdpopups.format_frontmatter({'allow_code_wrap': True})
+        contents = self.get_contents(config, active_view, server_output, exit_code)
+        # The href needs to be encoded to avoid having markdown parser ruin it.
+        copy_link = make_command_link('lsp_copy_to_clipboard_from_base64', '<kbd>Copy to clipboard</kbd>',
+                                      {'contents': b64encode(contents.encode()).decode()})
+        formatted = '{}{}\n{}'.format(frontmatter, copy_link, contents)
+        mdpopups.update_html_sheet(output_sheet, formatted, css=css().sheets, wrapper_class=css().sheets_classname)
+
+    def get_contents(self, config: ClientConfig, active_view: sublime.View, server_output: str, exit_code: int) -> str:
+        lines = []
+
+        def l(s: str):
+            lines.append(s)
+
+        l('# Troubleshooting: {}'.format(config.name))
+
+        l('## Version')
+        l(' - LSP: {}'.format('.'.join([str(n) for n in __version__])))
+        l(' - Sublime Text: {}'.format(sublime.version()))
+
+        l('## System PATH')
+        lines += [' - {}'.format(p) for p in os.environ['PATH'].split(os.pathsep)]
+
+        l('## Server Test Run')
+        l(' - exit code: {}\n - output\n```\n{}\n```'.format(exit_code, server_output))
+
+        l('## Server Configuration')
+        l(' - command\n```js\n{}\n```'.format(config.binary_args))
+        l(' - shell command\n```sh\n{}\n```'.format(list2cmdline(config.binary_args)))
+        l(' - languages')
+        languages = [
+            {
+                'language_id': lang.id,
+                'document_selector': lang.document_selector,
+                'feature_selector': lang.feature_selector,
+            } for lang in config.languages
+        ]
+        l('```js\n{}\n```'.format(self.json_dump(languages)))
+        l(' - init_options')
+        l('```js\n{}\n```'.format(self.json_dump(config.init_options)))
+        l(' - settings')
+        l('```js\n{}\n```'.format(self.json_dump(config.settings.get())))
+        l(' - env')
+        l('```\n{}\n```'.format(self.json_dump(config.env)))
+
+        l('\n## Active view')
+        if active_view:
+            l(' - File name\n```\n{}\n```'.format(active_view.file_name()))
+            l(' - Settings')
+            keys = ['auto_complete_selector', 'lsp_active', 'syntax']
+            settings = {}
+            view_settings = active_view.settings()
+            for key in keys:
+                settings[key] = view_settings.get(key)
+            l('```js\n{}\n```'.format(self.json_dump(settings)))
+        else:
+            l('no active view found!')
+
+        window = self.window
+        l('\n## Project / Workspace')
+        l(' - folders')
+        l('```js\n{}\n```'.format(window.folders()))
+        is_project = bool(window.project_file_name())
+        l(' - is project: {}'.format(is_project))
+        if is_project:
+            l(' - project data:\n```js\n{}\n```'.format(self.json_dump(window.project_data())))
+
+        l('\n## LSP configuration\n')
+        lsp_settings = self.read_resource('Packages/User/LSP.sublime-settings')
+        l('```js\n{}\n```'.format(lsp_settings) if lsp_settings else 'no LSP settings')
+
+        return '\n'.join(lines)
+
+
+    def json_dump(self, contents: Any) -> str:
+        return json.dumps(contents, indent=2, sort_keys=True, ensure_ascii=False)
+
+    def read_resource(self, path: str) -> Optional[str]:
+        try:
+            return sublime.load_resource(path)
+        except Exception as e:
+            return None
+
+
+class LspCopyToClipboardFromBase64Command(sublime_plugin.ApplicationCommand):
+    def run(self, contents: str):
+        sublime.set_clipboard(b64decode(contents).decode())
+
+
+class ServerTestRunner(TransportCallbacks):
+    """
+    Used to start the server and collect any potential stderr output and the exit code.
+
+    Server is automatically closed after defined timeout.
+    """
+
+    CLOSE_TIMEOUT_SEC = 2
+
+    def __init__(self, config: ClientConfig, window: sublime.Window, on_close: Callable[[str, int], None]):
+        self._on_close = on_close
+        self._transport = None  # type: Optional[Transport]
+        self._stderr_lines = []
+        try:
+            cwd = window.folders()[0] if window.folders() else None
+            variables = extract_variables(window)
+            self._transport = create_transport(config, cwd, window, self, variables)
+            sublime.set_timeout_async(self.force_close_transport, self.CLOSE_TIMEOUT_SEC * 1000)
+        except Exception as ex:
+            self.on_transport_close(-1, ex)
+
+    def force_close_transport(self) -> None:
+        if self._transport:
+            self._transport.close()
+
+    def on_payload(self, payload: Dict[str, Any]) -> None:
+        pass
+
+    def on_stderr_message(self, message: str) -> None:
+        self._stderr_lines.append(message)
+
+    def on_transport_close(self, exit_code: int, exception: Optional[Exception]) -> None:
+        close_callback = self._on_close
+        self._on_close = None
+        self._transport = None
+        output = str(exception) if exception else '\n'.join(self._stderr_lines).rstrip()
+        sublime.set_timeout(lambda: close_callback(output, exit_code))

--- a/plugin/tooling.py
+++ b/plugin/tooling.py
@@ -191,8 +191,11 @@ class LspTroubleshootServerCommand(sublime_plugin.WindowCommand, TransportCallba
             line(' - project data:\n{}'.format(self.json_dump(window.project_data())))
 
         line('\n## LSP configuration\n')
-        lsp_settings = sublime.decode_value(self.read_resource('Packages/User/LSP.sublime-settings'))
-        line(self.json_dump(lsp_settings or '<missing>') if lsp_settings else 'no LSP settings')
+        lsp_settings_contents = self.read_resource('Packages/User/LSP.sublime-settings')
+        if lsp_settings_contents != None:
+            line(self.json_dump(sublime.decode_value(lsp_settings_contents)))
+        else:
+            line('<not found>')
 
         line('## System PATH')
         lines += [' - {}'.format(p) for p in os.environ['PATH'].split(os.pathsep)]

--- a/plugin/tooling.py
+++ b/plugin/tooling.py
@@ -192,7 +192,7 @@ class LspTroubleshootServerCommand(sublime_plugin.WindowCommand, TransportCallba
 
         line('\n## LSP configuration\n')
         lsp_settings_contents = self.read_resource('Packages/User/LSP.sublime-settings')
-        if lsp_settings_contents != None:
+        if lsp_settings_contents is not None:
             line(self.json_dump(sublime.decode_value(lsp_settings_contents)))
         else:
             line('<not found>')

--- a/plugin/tooling.py
+++ b/plugin/tooling.py
@@ -211,7 +211,7 @@ class LspTroubleshootServerCommand(sublime_plugin.WindowCommand, TransportCallba
 
 
 class LspCopyToClipboardFromBase64Command(sublime_plugin.ApplicationCommand):
-    def run(self, contents: str) -> None:
+    def run(self, contents: str = '') -> None:
         sublime.set_clipboard(b64decode(contents).decode())
 
 

--- a/plugin/tooling.py
+++ b/plugin/tooling.py
@@ -206,7 +206,7 @@ class LspTroubleshootServerCommand(sublime_plugin.WindowCommand, TransportCallba
     def read_resource(self, path: str) -> Optional[str]:
         try:
             return sublime.load_resource(path)
-        except Exception as e:
+        except Exception:
             return None
 
 
@@ -225,7 +225,7 @@ class ServerTestRunner(TransportCallbacks):
     CLOSE_TIMEOUT_SEC = 2
 
     def __init__(self, config: ClientConfig, window: sublime.Window, on_close: Callable[[str, int], None]) -> None:
-        self._on_close = on_close  # type: Optional[Callable[[str, int], None]]
+        self._on_close = on_close  # type: Callable[[str, int], None]
         self._transport = None  # type: Optional[Transport]
         self._stderr_lines = []  # type: List[str]
         try:
@@ -247,8 +247,6 @@ class ServerTestRunner(TransportCallbacks):
         self._stderr_lines.append(message)
 
     def on_transport_close(self, exit_code: int, exception: Optional[Exception]) -> None:
-        close_callback = self._on_close
-        self._on_close = None
         self._transport = None
         output = str(exception) if exception else '\n'.join(self._stderr_lines).rstrip()
-        sublime.set_timeout(lambda: close_callback(output, exit_code))
+        sublime.set_timeout(lambda: self._on_close(output, exit_code))

--- a/plugin/tooling.py
+++ b/plugin/tooling.py
@@ -199,7 +199,6 @@ class LspTroubleshootServerCommand(sublime_plugin.WindowCommand, TransportCallba
 
         return '\n'.join(lines)
 
-
     def json_dump(self, contents: Any) -> str:
         return json.dumps(contents, indent=2, sort_keys=True, ensure_ascii=False)
 

--- a/plugin/tooling.py
+++ b/plugin/tooling.py
@@ -146,9 +146,6 @@ class LspTroubleshootServerCommand(sublime_plugin.WindowCommand, TransportCallba
         line(' - LSP: {}'.format('.'.join([str(n) for n in __version__])))
         line(' - Sublime Text: {}'.format(sublime.version()))
 
-        line('## System PATH')
-        lines += [' - {}'.format(p) for p in os.environ['PATH'].split(os.pathsep)]
-
         line('## Server Test Run')
         line(' - exit code: {}\n - output\n{}'.format(exit_code, self.code_block(server_output)))
 
@@ -194,13 +191,16 @@ class LspTroubleshootServerCommand(sublime_plugin.WindowCommand, TransportCallba
             line(' - project data:\n{}'.format(self.json_dump(window.project_data())))
 
         line('\n## LSP configuration\n')
-        lsp_settings = self.read_resource('Packages/User/LSP.sublime-settings')
-        line(self.code_block(lsp_settings, 'js') if lsp_settings else 'no LSP settings')
+        lsp_settings = sublime.decode_value(self.read_resource('Packages/User/LSP.sublime-settings'))
+        line(self.json_dump(lsp_settings) if lsp_settings else 'no LSP settings')
+
+        line('## System PATH')
+        lines += [' - {}'.format(p) for p in os.environ['PATH'].split(os.pathsep)]
 
         return '\n'.join(lines)
 
     def json_dump(self, contents: Any) -> str:
-        return self.code_block(json.dumps(contents, indent=2, sort_keys=True, ensure_ascii=False), 'js')
+        return self.code_block(json.dumps(contents, indent=2, sort_keys=True, ensure_ascii=False), 'json')
 
     def code_block(self, contents: str, lang: str = '') -> str:
         return '```{}\n{}\n```'.format(lang, contents)

--- a/plugin/tooling.py
+++ b/plugin/tooling.py
@@ -192,7 +192,7 @@ class LspTroubleshootServerCommand(sublime_plugin.WindowCommand, TransportCallba
 
         line('\n## LSP configuration\n')
         lsp_settings = sublime.decode_value(self.read_resource('Packages/User/LSP.sublime-settings'))
-        line(self.json_dump(lsp_settings) if lsp_settings else 'no LSP settings')
+        line(self.json_dump(lsp_settings or '<missing>') if lsp_settings else 'no LSP settings')
 
         line('## System PATH')
         lines += [' - {}'.format(p) for p in os.environ['PATH'].split(os.pathsep)]

--- a/plugin/tooling.py
+++ b/plugin/tooling.py
@@ -137,25 +137,25 @@ class LspTroubleshootServerCommand(sublime_plugin.WindowCommand, TransportCallba
                      server_output: str, exit_code: int) -> str:
         lines = []
 
-        def l(s: str) -> None:
+        def line(s: str) -> None:
             lines.append(s)
 
-        l('# Troubleshooting: {}'.format(config.name))
+        line('# Troubleshooting: {}'.format(config.name))
 
-        l('## Version')
-        l(' - LSP: {}'.format('.'.join([str(n) for n in __version__])))
-        l(' - Sublime Text: {}'.format(sublime.version()))
+        line('## Version')
+        line(' - LSP: {}'.format('.'.join([str(n) for n in __version__])))
+        line(' - Sublime Text: {}'.format(sublime.version()))
 
-        l('## System PATH')
+        line('## System PATH')
         lines += [' - {}'.format(p) for p in os.environ['PATH'].split(os.pathsep)]
 
-        l('## Server Test Run')
-        l(' - exit code: {}\n - output\n```\n{}\n```'.format(exit_code, server_output))
+        line('## Server Test Run')
+        line(' - exit code: {}\n - output\n```\n{}\n```'.format(exit_code, server_output))
 
-        l('## Server Configuration')
-        l(' - command\n```js\n{}\n```'.format(config.binary_args))
-        l(' - shell command\n```sh\n{}\n```'.format(list2cmdline(config.binary_args)))
-        l(' - languages')
+        line('## Server Configuration')
+        line(' - command\n```js\n{}\n```'.format(config.binary_args))
+        line(' - shell command\n```sh\n{}\n```'.format(list2cmdline(config.binary_args)))
+        line(' - languages')
         languages = [
             {
                 'language_id': lang.id,
@@ -163,39 +163,39 @@ class LspTroubleshootServerCommand(sublime_plugin.WindowCommand, TransportCallba
                 'feature_selector': lang.feature_selector,
             } for lang in config.languages
         ]
-        l('```js\n{}\n```'.format(self.json_dump(languages)))
-        l(' - init_options')
-        l('```js\n{}\n```'.format(self.json_dump(config.init_options)))
-        l(' - settings')
-        l('```js\n{}\n```'.format(self.json_dump(config.settings.get())))
-        l(' - env')
-        l('```\n{}\n```'.format(self.json_dump(config.env)))
+        line('```js\n{}\n```'.format(self.json_dump(languages)))
+        line(' - init_options')
+        line('```js\n{}\n```'.format(self.json_dump(config.init_options)))
+        line(' - settings')
+        line('```js\n{}\n```'.format(self.json_dump(config.settings.get())))
+        line(' - env')
+        line('```\n{}\n```'.format(self.json_dump(config.env)))
 
-        l('\n## Active view')
+        line('\n## Active view')
         if active_view:
-            l(' - File name\n```\n{}\n```'.format(active_view.file_name()))
-            l(' - Settings')
+            line(' - File name\n```\n{}\n```'.format(active_view.file_name()))
+            line(' - Settings')
             keys = ['auto_complete_selector', 'lsp_active', 'syntax']
             settings = {}
             view_settings = active_view.settings()
             for key in keys:
                 settings[key] = view_settings.get(key)
-            l('```js\n{}\n```'.format(self.json_dump(settings)))
+            line('```js\n{}\n```'.format(self.json_dump(settings)))
         else:
-            l('no active view found!')
+            line('no active view found!')
 
         window = self.window
-        l('\n## Project / Workspace')
-        l(' - folders')
-        l('```js\n{}\n```'.format(window.folders()))
+        line('\n## Project / Workspace')
+        line(' - folders')
+        line('```js\n{}\n```'.format(window.folders()))
         is_project = bool(window.project_file_name())
-        l(' - is project: {}'.format(is_project))
+        line(' - is project: {}'.format(is_project))
         if is_project:
-            l(' - project data:\n```js\n{}\n```'.format(self.json_dump(window.project_data())))
+            line(' - project data:\n```js\n{}\n```'.format(self.json_dump(window.project_data())))
 
-        l('\n## LSP configuration\n')
+        line('\n## LSP configuration\n')
         lsp_settings = self.read_resource('Packages/User/LSP.sublime-settings')
-        l('```js\n{}\n```'.format(lsp_settings) if lsp_settings else 'no LSP settings')
+        line('```js\n{}\n```'.format(lsp_settings) if lsp_settings else 'no LSP settings')
 
         return '\n'.join(lines)
 

--- a/sheets.css
+++ b/sheets.css
@@ -1,0 +1,12 @@
+.lsp_sheet {
+    padding:  1rem;
+}
+.lsp_sheet h1 {
+    margin-top: 0;
+}
+.lsp_sheet h2,
+.lsp_sheet h3,
+.lsp_sheet h4,
+.lsp_sheet p {
+    margin-top: 1rem;
+}

--- a/stubs/mdpopups.pyi
+++ b/stubs/mdpopups.pyi
@@ -50,6 +50,35 @@ def md2html(
 ) -> str: ...
 
 
+def new_html_sheet(
+    window: sublime.Window,
+    name: str,
+    contents: str,
+    md: bool = True,
+    css=None,  # type: Optional[str]
+    flags: int = 0,
+    group: int = -1,
+    wrapper_class=None,  # type: Optional[str]
+    template_vars=None,  # type: Optional[str]
+    template_env_options=None,  # type: Optional[dict]
+    nl2br: bool = True,
+    allow_code_wrap: bool = False
+) -> sublime.HtmlSheet: ...
+
+
+def update_html_sheet(
+    sheet: sublime.HtmlSheet,
+    contents: str,
+    md: bool = True,
+    css=None,  # type: Optional[str]
+    wrapper_class=None,  # type: Optional[str]
+    template_vars=None,  # type: Optional[str]
+    template_env_options=None,  # type: Optional[dict]
+    nl2br: bool = True,
+    allow_code_wrap: bool = False
+) -> None: ...
+
+
 def scope2style(
     view: sublime.View,
     scope: str,

--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -442,7 +442,8 @@ class Window:
                          on_select: Callable,
                          flags: int = ...,
                          selected_index: int = ...,
-                         on_highlight: Optional[Callable] = ...) -> None:
+                         on_highlight: Optional[Callable] = ...,
+                         placeholder: Optional[str] = ...) -> None:
         ...
 
     def is_sidebar_visible(self) -> bool:
@@ -618,6 +619,19 @@ class Sheet:
         ...
 
     def view(self) -> 'Optional[View]':
+        ...
+
+
+class HtmlSheet:
+    sheet_id = ...  # type: Any
+
+    def __init__(self, id: Any) -> None:
+        ...
+
+    def set_name(self, name: str) -> None:
+        ...
+
+    def set_contents(self, contents: str) -> None:
         ...
 
 


### PR DESCRIPTION
Opens a sheet with all information that should be necessary to diagnose
problems with a server. Important part of that is that it runs selected
server to catch and show its stderr output. Something that is a pain to
do manually.