### PR TITLE
Improve code actions tests stability

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -152,10 +152,11 @@ class TextDocumentTestCase(DeferrableTestCase):
 
     def await_message(self, method: str, promise: Optional[YieldPromise] = None) -> 'Generator':
         """
-        Awaits until the server responds with data returned for a request with specified method.
-        If server has already received a request with specified method before, it will immediately
-        return the response for that previous request. If it hasn't received such request yet, it
-        will wait for it and then respond or we're time out.
+        Awaits until server receives a request with a specified method.
+
+        If the server has already received a request with a specified method before, it will
+        immediately return the response for that previous request. If it hasn't received such
+        request yet, it will wait for it and then respond.
 
         :param      method: The method type that we are awaiting response for.
         :param      promise: The optional promise to fullfill on response.

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -151,6 +151,17 @@ class TextDocumentTestCase(DeferrableTestCase):
         return False
 
     def await_message(self, method: str, promise: Optional[YieldPromise] = None) -> 'Generator':
+        """
+        Awaits until the server responds with data returned for a request with specified method.
+        If server has already received a request with specified method before, it will immediately
+        return the response for that previous request. If it hasn't received such request yet, it
+        will wait for it and then respond or we're time out.
+
+        :param      method: The method type that we are awaiting response for.
+        :param      promise: The optional promise to fullfill on response.
+
+        :returns:   A generator with resolved value.
+        """
         self.assertIsNotNone(self.session)
         assert self.session  # mypy
         if promise is None:
@@ -234,7 +245,7 @@ class TextDocumentTestCase(DeferrableTestCase):
         assert self.view  # type: Optional[sublime.View]
         self.view.run_command("select_all")
         self.view.run_command("left_delete")
-        self.view.run_command("lsp_save")
+        self.view.run_command("save")
         yield from self.await_message("textDocument/didChange")
         yield from self.await_message("textDocument/didSave")
 

--- a/tests/test_code_actions.py
+++ b/tests/test_code_actions.py
@@ -83,6 +83,7 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
         self.set_response('textDocument/codeAction', [code_action])
         self.view.run_command('lsp_save')
         yield from self.await_message('textDocument/codeAction')
+        yield from self.await_message('textDocument/didSave')
         self.assertEquals(entire_content(self.view), 'const x = 1;')
         self.assertEquals(self.view.is_dirty(), False)
 
@@ -115,6 +116,7 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
         self.view.run_command('lsp_save')
         yield from self.await_message('textDocument/codeAction')
         yield from self.await_message('textDocument/codeAction')
+        yield from self.await_message('textDocument/didSave')
         self.assertEquals(entire_content(self.view), 'const x = 1;\nAnd again!')
         self.assertEquals(self.view.is_dirty(), False)
 
@@ -129,6 +131,7 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
         self.set_response('textDocument/codeAction', [code_action])
         self.view.run_command('lsp_save')
         yield from self.await_message('textDocument/codeAction')
+        yield from self.await_message('textDocument/didSave')
         self.assertEquals(entire_content(self.view), 'const x = 1;')
         self.assertEquals(self.view.is_dirty(), False)
 
@@ -136,8 +139,9 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
         yield from self._setup_document_with_missing_semicolon()
         initial_content = 'const x = 1'
         self.view.run_command('lsp_save')
+        yield from self.await_message('textDocument/didSave')
         self.assertEquals(entire_content(self.view), initial_content)
-        yield lambda: not self.view.is_dirty()
+        self.assertEquals(self.view.is_dirty(), False)
 
     def test_does_not_apply_unsupported_kind(self) -> Generator:
         yield from self._setup_document_with_missing_semicolon()
@@ -149,6 +153,7 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
         )
         self.set_response('textDocument/codeAction', [code_action])
         self.view.run_command('lsp_save')
+        yield from self.await_message('textDocument/didSave')
         self.assertEquals(entire_content(self.view), 'const x = 1')
 
     def _setup_document_with_missing_semicolon(self) -> Generator:


### PR DESCRIPTION
 * Await "textDocument/didSave" to ensure that we only test document
   state after "lsp_save" command has done its job.
 * Trigger "save" command instead of "lsp_save" on tearing down tests
   as there is no point in triggering save actions in that case.