### PR TITLE
Don't report empty line to stderr handler

### DIFF
--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -159,11 +159,14 @@ class JsonRpcTransport(Transport):
         try:
             while self._stderr:
                 if self._closed:
+                    # None message already posted, just return
+                    return
+                message = self._stderr.readline().decode('utf-8', 'replace')
+                if message == '':
                     break
-                message = self._stderr.readline().decode('utf-8', 'replace').rstrip()
                 callback_object = self._callback_object()
                 if callback_object:
-                    callback_object.on_stderr_message(message)
+                    callback_object.on_stderr_message(message.rstrip())
                 else:
                     break
         except (BrokenPipeError, AttributeError):


### PR DESCRIPTION
Break out of stderr loop on empty message.

We don't want to break on server returning a newline so check the
contents before doing rstrip() on the message.

This avoids printing some spurious empty messages to the stderr callback.