### PR TITLE
Report errors returned from initialize request

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -657,8 +657,9 @@ class Session(Client):
         code_action_kinds = self.get_capability('codeActionProvider.codeActionKinds')
         if code_action_kinds:
             debug('{}: supported code action kinds: {}'.format(self.config.name, code_action_kinds))
-        self._init_callback(self, False)
-        self._init_callback = None
+        if self._init_callback:
+            self._init_callback(self, False)
+            self._init_callback = None
 
     def _handle_initialize_error(self, result: Any) -> None:
         self._init_error = (result.get('code', -1), Exception(result.get('message', 'Error initializing server')))

--- a/plugin/tooling.py
+++ b/plugin/tooling.py
@@ -98,7 +98,7 @@ class LspTroubleshootServerCommand(sublime_plugin.WindowCommand, TransportCallba
     def run(self) -> None:
         window = self.window
         active_view = window.active_view()
-        configs = windows.lookup(window).get_config_manager().get_configs()
+        configs = [c for c in windows.lookup(window).get_config_manager().get_configs() if c.enabled]
         config_names = [config.name for config in configs]
         if config_names:
             window.show_quick_panel(config_names, lambda index: self.on_selected(index, configs, active_view),

--- a/plugin/tooling.py
+++ b/plugin/tooling.py
@@ -181,7 +181,7 @@ class LspTroubleshootServerCommand(sublime_plugin.WindowCommand, TransportCallba
             if isinstance(settings['syntax'], str):
                 syntax = sublime.syntax_from_path(settings['syntax'])
                 if syntax:
-                    line(' - root scope\n{}'.format(self.code_block(syntax.scope)))
+                    line(' - base scope\n{}'.format(self.code_block(syntax.scope)))
         else:
             line('no active view found!')
 

--- a/plugin/tooling.py
+++ b/plugin/tooling.py
@@ -98,7 +98,7 @@ class LspTroubleshootServerCommand(sublime_plugin.WindowCommand, TransportCallba
     def run(self) -> None:
         window = self.window
         active_view = window.active_view()
-        configs = [c for c in windows.lookup(window).get_config_manager().get_configs() if c.enabled]
+        configs = windows.lookup(window).get_config_manager().get_configs()
         config_names = [config.name for config in configs]
         if config_names:
             window.show_quick_panel(config_names, lambda index: self.on_selected(index, configs, active_view),
@@ -178,6 +178,10 @@ class LspTroubleshootServerCommand(sublime_plugin.WindowCommand, TransportCallba
             for key in keys:
                 settings[key] = view_settings.get(key)
             line(self.json_dump(settings))
+            if settings['syntax']:
+                syntax = sublime.syntax_from_path(settings['syntax'])
+                if syntax:
+                    line(' - root scope\n{}'.format(self.code_block(syntax.scope)))
         else:
             line('no active view found!')
 

--- a/plugin/tooling.py
+++ b/plugin/tooling.py
@@ -178,7 +178,7 @@ class LspTroubleshootServerCommand(sublime_plugin.WindowCommand, TransportCallba
             for key in keys:
                 settings[key] = view_settings.get(key)
             line(self.json_dump(settings))
-            if settings['syntax']:
+            if isinstance(settings['syntax'], str):
                 syntax = sublime.syntax_from_path(settings['syntax'])
                 if syntax:
                     line(' - root scope\n{}'.format(self.code_block(syntax.scope)))

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -34,9 +34,6 @@ class MockManager(Manager):
     def on_post_exit_async(self, session: Session, exit_code: int, exception: Optional[Exception]) -> None:
         pass
 
-    def on_post_initialize(self, session: Session) -> None:
-        pass
-
     def update_diagnostics_panel_async(self) -> None:
         pass
 


### PR DESCRIPTION
- The "Manager.on_post_initialize" abstract method replaced with callback as Manager needs to have access to "initiating_view" to reset status also on error.
- Also, call the new callback on failure during "initialize". That was missing, causing the session to not be GC'ed due to missing clearing of self._new_session
- Remove showing of exception in the status bar as those are useless due to disappearing too quickly and having limited space.
- Include exception error in the "crash dialog", if any.
- Allow Troubleshooting disabled configs because when the server crashes it gets disabled and then it's tricky to test why it crashed. Also, print the root scope of the syntax.