### PR TITLE
Make symbol highlight faster by reducing the debounce time

### DIFF
--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -153,7 +153,7 @@ class DocumentSyncListener(LSPViewEventListener, AbstractViewListener):
     ACTIVE_DIAGNOSTIC = "lsp_active_diagnostic"
     code_actions_debounce_time = 800
     color_boxes_debounce_time = 500
-    highlights_debounce_time = 500
+    highlights_debounce_time = 150
 
     @classmethod
     def applies_to_primary_view_only(cls) -> bool:

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -153,7 +153,7 @@ class DocumentSyncListener(LSPViewEventListener, AbstractViewListener):
     ACTIVE_DIAGNOSTIC = "lsp_active_diagnostic"
     code_actions_debounce_time = 800
     color_boxes_debounce_time = 500
-    highlights_debounce_time = 150
+    highlights_debounce_time = 300
 
     @classmethod
     def applies_to_primary_view_only(cls) -> bool:


### PR DESCRIPTION
This makes the highlights show up a lot faster. (I haven't noticed any perf issue with this, but I like how much the highlight feels faster)