### PR TITLE
Auto-create links with pymdownx magiclink

### DIFF
--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -415,6 +415,11 @@ def minihtml(view: sublime.View, content: Union[str, Dict[str, str], list], allo
                         "hardbreak": False,
                         "nbsp": False
                     }
+                },
+                {
+                    "pymdownx.magiclink": {
+                        "repo_url_shortener": True
+                    }
                 }
             ]
         }

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -251,6 +251,11 @@ class ViewsTest(DeferrableTestCase):
         expect = ""
         self.assertEqual(minihtml(self.view, content, allowed_formats=FORMAT_STRING), expect)
 
+    def test_minihtml_magiclinks(self) -> None:
+        content = {'value': 'https://github.com/sublimelsp/LSP', 'kind': 'markdown'}
+        expect = '<p><a href="https://github.com/sublimelsp/LSP">https://github.com/sublimelsp/LSP</a></p>'
+        self.assertEqual(minihtml(self.view, content, allowed_formats=FORMAT_MARKUP_CONTENT), expect)
+
     def _strip_style_attributes(self, content: str) -> str:
         return re.sub(r'\s+style="[^"]+"', '', content)
 


### PR DESCRIPTION
Close #1280 

Just a heads up: when I set the front matter to
```js
        frontmatter = {
            "allow_code_wrap": True,
            "markdown_extensions": [
                {
                    "pymdownx.escapeall": {
                        "hardbreak": False,
                        "nbsp": False
                    }
                },
                {
                    "pymdownx.magiclink": {
                        "hide_protocol": True,
                        "repo_url_shortener": True,
                        "social_url_shortener": True
                    }
                }
            ]
        }
```
magiclinks don't work. Removing `hide_protocol` and `social_url_shortener` from the `pymdownx.magiclink` makes MagicLink work. I don't understand why.