### PR TITLE
Capabilities per SessionBuffer

### DIFF
--- a/Syntaxes/ServerLog.sublime-syntax
+++ b/Syntaxes/ServerLog.sublime-syntax
@@ -6,7 +6,7 @@ hidden: true
 scope: output.lsp.log
 
 variables:
-  method: '[[:alnum:]/$]+'
+  method: '[[:alnum:]/$#]+'
   servername: '[[:alnum:]_-]+'
   id: '[^\s:]+'
 

--- a/boot.py
+++ b/boot.py
@@ -44,6 +44,7 @@ from .plugin.symbols import LspSelectionClearCommand
 from .plugin.symbols import LspSelectionSetCommand
 from .plugin.symbols import LspWorkspaceSymbolsCommand
 from .plugin.tooling import LspCopyToClipboardFromBase64Command
+from .plugin.tooling import LspDumpBufferCapabilities
 from .plugin.tooling import LspDumpWindowConfigs
 from .plugin.tooling import LspParseVscodePackageJson
 from .plugin.tooling import LspTroubleshootServerCommand

--- a/language-ids.sublime-settings
+++ b/language-ids.sublime-settings
@@ -1,0 +1,33 @@
+// VSCode language ID -> SublimeText base scope selector
+// These are the "exceptional" language IDs. If a language ID is not in this
+// map, then the rule is that we prepend the ID with "source." and assume
+// that's the base scope selector. For instance, the language ID "julia"
+// would become "source.julia", and the language ID "rust" would become
+// "source.rust".
+//
+// If you believe an entry in this dictionary is missing, please submit a pull
+// request at github.com/sublimelsp/LSP.
+{
+    "bat": "source.dosbatch",
+    "bibtex": "text.bibtex",
+    "cpp": "source.c++",
+    "csharp": "source.cs",
+    "html": "embedding.php | text.html.basic",
+    "javascript": "source.js",
+    "javascriptreact": "source.jsx", // 3rdparty
+    "jsonc": "source.json",
+    "latex": "text.tex.latex",
+    "markdown": "text.html.markdown",
+    "objective-c": "source.objc",
+    "objective-cpp": "source.objc++",
+    "php": "source.php | embedding.php",
+    "ruby": "text.html.ruby | source.ruby",
+    "shaderlab": "source.glsl | source.essl", // 3rdparty
+    "shellscript": "source.shell.bash",
+    "typescript": "source.ts",
+    "typescriptreact": "source.tsx",
+    "txt": "text.plain",
+    "vue": "text.html.vue", // 3rdparty
+    "xml": "text.xml",
+    "xsl": "text.xml", // 3rdparty
+}

--- a/language-ids.sublime-settings
+++ b/language-ids.sublime-settings
@@ -1,9 +1,12 @@
-// VSCode language ID -> SublimeText base scope selector
+// Language ID -> SublimeText base scope selector
 // These are the "exceptional" language IDs. If a language ID is not in this
 // map, then the rule is that we prepend the ID with "source." and assume
 // that's the base scope selector. For instance, the language ID "julia"
 // would become "source.julia", and the language ID "rust" would become
 // "source.rust".
+//
+// The official list is maintained at
+// https://microsoft.github.io/language-server-protocol/specification#textDocumentItem
 //
 // If you believe an entry in this dictionary is missing, please submit a pull
 // request at github.com/sublimelsp/LSP.

--- a/plugin/core/collections.py
+++ b/plugin/core/collections.py
@@ -132,6 +132,8 @@ class DottedDict:
                 self.set(key, value)
 
     def _update_recursive(self, current: Dict[str, Any], prefix: str) -> None:
+        if not current:
+            return self.set(prefix, current)
         for key, value in current.items():
             path = "{}.{}".format(prefix, key)
             if isinstance(value, dict):

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -490,7 +490,7 @@ class _RegistrationData:
                 self.session_buffers.add(sb)
                 sb.register_capability_async(
                     self.registration_id, self.capability_path, self.registration_path, self.options)
-            return
+                return
 
 
 class Session(Client):

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -281,7 +281,7 @@ class DocumentSelector:
 
     def matches(self, view: sublime.View) -> bool:
         """Does this selector match the view? A selector with no filters matches all views."""
-        return any(filter(lambda f: f.matches(view), self.filters)) if self.filters else True  # type: ignore
+        return any(f.matches(view) for f in self.filters) if self.filters else True
 
 
 class LanguageConfig:

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -242,7 +242,7 @@ class DocumentFilter:
         self.pattern = pattern
         self.feature_selector = feature_selector
         if language:
-            # This the connection between VSCode language IDs and ST selectors.
+            # This the connection between Language IDs and ST selectors.
             lang_id_map = sublime.load_settings("language-ids.sublime-settings")
             self.selector = lang_id_map.get(language, "source.{}".format(language))  # type: Optional[str]
         else:

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -15,6 +15,7 @@ from .rpc import Logger
 from .sessions import get_plugin
 from .sessions import Manager
 from .sessions import Session
+from .sessions import SessionViewProtocol
 from .settings import userprefs
 from .transports import create_transport
 from .types import ClientConfig
@@ -72,6 +73,10 @@ class AbstractViewListener(metaclass=ABCMeta):
 
     @abstractmethod
     def update_diagnostic_in_status_bar_async(self) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def session_views_async(self) -> Iterable[SessionViewProtocol]:
         raise NotImplementedError()
 
 

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -484,6 +484,18 @@ class DocumentSyncListener(LSPViewEventListener, AbstractViewListener):
 
     # --- Public utility methods ---------------------------------------------------------------------------------------
 
+    def get_capability_async(self, session: Session, capability_path: str) -> Optional[Any]:
+        for sv in self.session_views_async():
+            if sv.session == session:
+                return sv.get_capability(capability_path)
+        return None
+
+    def has_capability_async(self, session: Session, capability_path: str) -> bool:
+        for sv in self.session_views_async():
+            if sv.session == session:
+                return sv.has_capability(capability_path)
+        return False
+
     def purge_changes_async(self) -> None:
         for sv in self.session_views_async():
             sv.purge_changes_async()

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -34,7 +34,7 @@
                 "languageId": {
                   "type": "string",
                   "default": "somelang",
-                  "markdownDescription": "The VSCode \"Language ID\". This value serves two purposes:\n\n1. It is sent to the language server so that it knows with what kind of file it is dealing with.\n2. When `\"document_selector\"` is not provided, this is the connection between your files and language servers.\n\nFor more information, refer to the [textDocumentItem of the LSP specification](https://microsoft.github.io/language-server-protocol/specification#textDocumentItem)."
+                  "markdownDescription": "The \"Language ID\". This value serves two purposes:\n\n1. It is sent to the language server so that it knows with what kind of file it is dealing with.\n2. When `\"document_selector\"` is not provided, this is the connection between your files and language servers.\n\nFor more information, refer to the [textDocumentItem of the LSP specification](https://microsoft.github.io/language-server-protocol/specification#textDocumentItem)."
                 },
                 "document_selector": {
                   "type": "string",

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -130,3 +130,10 @@ class DottedDictTests(TestCase):
         self.assertEqual(d_copy['c'], 'd')
         d_copy['c'] = None
         self.assertNotEqual(d.get('a.b.c'), d_copy['c'])
+
+    def test_update_empty_dict(self) -> None:
+        d = DottedDict({})
+        d.update({"a": {}})
+        self.assertEqual(d.get(), {"a": {}})
+        d.update({"a": {"b": {}}})
+        self.assertEqual(d.get(), {"a": {"b": {}}})

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -134,6 +134,19 @@ class SessionTest(unittest.TestCase):
 
         session.capabilities.assign({
             'textDocumentSync': {
+                "didOpen": {},
+                "didClose": {},
+                "change": TextDocumentSyncKindFull,
+                "save": True}})  # A boolean with value true means "send didSave"
+        self.assertTrue(session.should_notify_did_open())
+        self.assertTrue(session.should_notify_did_close())
+        self.assertEqual(session.text_sync_kind(), TextDocumentSyncKindFull)
+        self.assertTrue(session.should_notify_did_change())
+        self.assertFalse(session.should_notify_will_save())
+        self.assertEqual(session.should_notify_did_save(), (True, False))
+
+        session.capabilities.assign({
+            'textDocumentSync': {
                 "openClose": False,
                 "change": TextDocumentSyncKindNone,
                 "save": {},  # An empty dict means "send didSave"


### PR DESCRIPTION
Each SessionBuffer has its own capabilities dictionary. This is
to account for dynamic registrations which use a DocumentSelector.

This diff makes OmniSharp somewhat work OK. It is a good example
of a server that registers *all* of its capabilities dynamically,
even textDocumentSync. Because textDocumentSync can be registered
dynamically, we need to account for the possibility of a
SessionBuffer's life starting out without document synchronization,
only to later "obtain" document sync dynamically. This is accounted
for in this diff.

A follow-up pull request will implement the `pattern` requirement
of a DocumentFilter.

This diff also implements the notion of a DocumentSelector. It is
a straightforward translation from the specification. A language server
may register a capability with a DocumentSelector consisting of a
`language` entry. This entry is the "Language ID". Since an arbitrary
language server doesn't know about SublimeText base scopes, we will
have to maintain this translation in a global settings file via
language-ids.sublime-settings.

We may have to swap the LanguageConfig class with the DocumentSelector.

Fixes #1219
Fixes #1217 