### PR TITLE
Hide the scheme in markdown magic links

### DIFF
--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -418,6 +418,10 @@ def minihtml(view: sublime.View, content: Union[str, Dict[str, str], list], allo
                 },
                 {
                     "pymdownx.magiclink": {
+                        # links are displayed without the initial ftp://, http://, https://, or ftps://.
+                        "hide_protocol": True,
+                        # GitHub, Bitbucket, and GitLab commit, pull, and issue links are are rendered in a shorthand
+                        # syntax.
                         "repo_url_shortener": True
                     }
                 }

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -253,7 +253,7 @@ class ViewsTest(DeferrableTestCase):
 
     def test_minihtml_magiclinks(self) -> None:
         content = {'value': 'https://github.com/sublimelsp/LSP', 'kind': 'markdown'}
-        expect = '<p><a href="https://github.com/sublimelsp/LSP">https://github.com/sublimelsp/LSP</a></p>'
+        expect = '<p><a href="https://github.com/sublimelsp/LSP">github.com/sublimelsp/LSP</a></p>'
         self.assertEqual(minihtml(self.view, content, allowed_formats=FORMAT_MARKUP_CONTENT), expect)
 
     def _strip_style_attributes(self, content: str) -> str:


### PR DESCRIPTION
Follow-up on #1281. It's a bit more fancy to hide the scheme in magic links.