### PR TITLE
Add wcmatch library (for st builds >=4070)

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -1,15 +1,6 @@
 {
     "*": {
-        "3124 - 4069": [
-            "pygments",
-            "python-markdown",
-            "mdpopups",
-            "python-jinja2",
-            "markupsafe",
-            "pymdownx",
-            "pyyaml"
-        ],
-        ">=4070": [
+        ">=3124": [
             "pygments",
             "python-markdown",
             "mdpopups",

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,6 +1,6 @@
 {
     "*": {
-        ">=3124": [
+        "3124 - 4069": [
             "pygments",
             "python-markdown",
             "mdpopups",
@@ -8,6 +8,16 @@
             "markupsafe",
             "pymdownx",
             "pyyaml"
+        ],
+        ">=4070": [
+            "pygments",
+            "python-markdown",
+            "mdpopups",
+            "python-jinja2",
+            "markupsafe",
+            "pymdownx",
+            "pyyaml",
+            "wcmatch"
         ]
     }
 }


### PR DESCRIPTION
As preparation for a follow-up PR for #1282, this adds the wcmatch library as another dependency.