### PR TITLE
Add id for color box phantoms [master]

### DIFF
--- a/plugin/color.py
+++ b/plugin/color.py
@@ -98,12 +98,14 @@ class LspColorListener(sublime_plugin.ViewEventListener):
             alpha = color['alpha']
 
             content = """
-            <style>html {{padding: 0}}</style>
+            <style>html {{padding: 0; background-color: var(--background)}}</style>
+            <body id='lsp-color-box'>
             <div style='padding: 0.4em;
                         margin-top: 0.2em;
                         border: 1px solid color(var(--foreground) alpha(0.25));
                         background-color: rgba({}, {}, {}, {})'>
-            </div>""".format(red, green, blue, alpha)
+            </div>
+            </body>""".format(red, green, blue, alpha)
 
             range = Range.from_lsp(color_info['range'])
             region = range_to_region(range, self.view)


### PR DESCRIPTION
This allows styling of the color box phantoms from color schemes.
It also sets the default background color to the color scheme's background to prevent an ugly white 0.2em margin on top, in case the background color for `html` or `body` is not set in "phantom_css" (if used).