### PR TITLE
Fix diagnostics not being displayed in the view for virtual files

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -576,7 +576,7 @@ class Session(Client):
         file_name = uri_to_filename(uri)
         for sb in self.session_buffers_async():
             try:
-                if os.path.samefile(file_name, sb.file_name):
+                if sb.file_name == file_name or os.path.samefile(file_name, sb.file_name):
                     return sb
             except FileNotFoundError:
                 pass


### PR DESCRIPTION
Diagnostics were not displays for default preferences, for example,
since those files don't physically exist on disk.

The purpose of the original is_same_file check was to match also files
that different in case of the drive letter but if they match exactly
then we don't have to call it.