### PR TITLE
Flatten LSPViewEventListener inheritance hierarchy

### DIFF
--- a/plugin/formatting.py
+++ b/plugin/formatting.py
@@ -1,8 +1,8 @@
 from .core.edit import parse_text_edit
 from .core.registry import LspTextCommand
-from .core.registry import LSPViewEventListener
 from .core.registry import sessions_for_view
 from .core.sessions import Session
+from .core.settings import client_configs
 from .core.settings import userprefs
 from .core.typing import Any, Callable, List, Optional, Iterator
 from .core.views import entire_content_region
@@ -22,7 +22,7 @@ class WillSaveWaitTask(SaveTask):
     @classmethod
     def is_applicable(cls, view: sublime.View) -> bool:
         settings = view.settings()
-        return bool(view.file_name()) and LSPViewEventListener.has_supported_syntax({'syntax': settings.get('syntax')})
+        return bool(view.file_name()) and client_configs.is_syntax_supported(str(settings.get('syntax')))
 
     def __init__(self, view: sublime.View, on_complete: Callable[[], None]) -> None:
         super().__init__(view, on_complete)
@@ -60,7 +60,7 @@ class FormattingTask(SaveTask):
         view_format_on_save = settings.get('lsp_format_on_save', None)
         enabled = view_format_on_save if isinstance(view_format_on_save, bool) else userprefs().lsp_format_on_save
         return enabled and bool(view.window()) and bool(view.file_name()) \
-            and LSPViewEventListener.has_supported_syntax({'syntax': settings.get('syntax')})
+            and client_configs.is_syntax_supported(str(settings.get('syntax')))
 
     def run_async(self) -> None:
         super().run_async()


### PR DESCRIPTION
We don't need derived classes and base classes now.