### PR TITLE
Fix MarkedString display in documentation popup

### DIFF
--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -408,7 +408,7 @@ def minihtml(view: sublime.View, content: Union[str, Dict[str, str], list], allo
             is_plain_text = False
             result = "```{}\n{}\n```\n".format(language, value)
     if is_plain_text:
-        return text2html(result)
+        return "<p>{}</p>".format(text2html(result)) if result else ''
     else:
         frontmatter = {
             "allow_code_wrap": True,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -185,7 +185,7 @@ class ViewsTest(DeferrableTestCase):
 
     def test_minihtml_format_string(self) -> None:
         content = "<div>text\n</div>"
-        expect = "&lt;div&gt;text<br>&lt;/div&gt;"
+        expect = "<p>&lt;div&gt;text<br>&lt;/div&gt;</p>"
         self.assertEqual(minihtml(self.view, content, allowed_formats=FORMAT_STRING), expect)
 
     def test_minihtml_format_marked_string(self) -> None:
@@ -200,7 +200,7 @@ class ViewsTest(DeferrableTestCase):
 
     def test_minihtml_handles_markup_content_plaintext(self) -> None:
         content = {'value': 'type TVec2i = specialize TGVec2<Integer>', 'kind': 'plaintext'}
-        expect = "type TVec2i = specialize TGVec2&lt;Integer&gt;"
+        expect = "<p>type TVec2i = specialize TGVec2&lt;Integer&gt;</p>"
         allowed_formats = FORMAT_MARKED_STRING | FORMAT_MARKUP_CONTENT
         self.assertEqual(minihtml(self.view, content, allowed_formats=allowed_formats), expect)
 


### PR DESCRIPTION
A plain markdown text (MarkedString) was rendered differently from
MarkupContent for example. For MarkupContent mdpopups would add
a paragraph while for MarkedString, we've only used text2html that
didn't add paragraph.

Checked also hover popups with MarkedString and it renders the same.