### PR TITLE
Fix color box phantoms background in selections

### DIFF
--- a/plugin/color.py
+++ b/plugin/color.py
@@ -98,7 +98,7 @@ class LspColorListener(sublime_plugin.ViewEventListener):
             alpha = color['alpha']
 
             content = """
-            <style>html {{padding: 0; background-color: var(--background)}}</style>
+            <style>html {{padding: 0; background-color: transparent}}</style>
             <body id='lsp-color-box'>
             <div style='padding: 0.4em;
                         margin-top: 0.2em;


### PR DESCRIPTION
I have introduced a regression in https://github.com/sublimelsp/LSP/commit/32aaa5856e936118a9296035b18f35c2ddc63c65:
![colorbox](https://user-images.githubusercontent.com/6579999/92326872-ab986880-f055-11ea-9a8c-49bdf22ae54b.png)
The background color from the scheme is still shown on top when the color box phantom is inside a selection.

By using a complete transparent color (alpha value 0) it should work as expected now, both in selected text and when using "phantom_css" in the color scheme.

This should also be applied to the st4000-exploration branch.