### PR TITLE
Fix: manually invoking signature help should not check the triggers

### DIFF
--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -583,7 +583,9 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         return self._manager  # type: ignore
 
     def sessions(self, capability: Optional[str]) -> Generator[Session, None, None]:
-        yield from self.manager.sessions(self.view, capability)
+        for sb in self.session_buffers_async():
+            if capability is None or sb.has_capability(capability):
+                yield sb.session
 
     def session(self, capability: str, point: Optional[int] = None) -> Optional[Session]:
         return best_session(self.view, self.sessions(capability), point)


### PR DESCRIPTION
Also, find relevant sessions via the stored session views / buffers

This is more direct than going via the manager.