### PR TITLE
Fix padding for "no documentation" text in completions info

### DIFF
--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -7,7 +7,7 @@ from .core.logging import debug
 from .core.edit import parse_text_edit
 from .core.protocol import Request, InsertTextFormat, Range
 from .core.registry import LspTextCommand
-from .core.typing import Any, List, Dict, Optional, Generator
+from .core.typing import Any, List, Dict, Optional, Generator, Union
 from .core.views import FORMAT_STRING, FORMAT_MARKUP_CONTENT, minihtml
 from .core.views import range_to_region
 
@@ -30,7 +30,7 @@ class LspResolveDocsCommand(LspTextCommand):
             minihtml_content = self.get_content(documentation, detail)
             self.show_popup(minihtml_content)
 
-    def format_documentation(self, content: str) -> str:
+    def format_documentation(self, content: Union[str, Dict[str, str]]) -> str:
         return minihtml(self.view, content, allowed_formats=FORMAT_STRING | FORMAT_MARKUP_CONTENT)
 
     def get_content(self, documentation: str, detail: str) -> str:
@@ -70,7 +70,7 @@ class LspResolveDocsCommand(LspTextCommand):
             detail = self.format_documentation(item.get('detail') or "")
             documentation = self.format_documentation(item.get("documentation") or "")
         if not documentation:
-            documentation = "<i>No documentation available.</i>"
+            documentation = self.format_documentation({"kind": "markdown", "value": "*No documentation available.*"})
         minihtml_content = self.get_content(documentation, detail)
         show = self.update_popup if self.view.is_popup_visible() else self.show_popup
         # NOTE: Update/show popups from the main thread, or else the popup might make the AC widget disappear.


### PR DESCRIPTION
Always go through minihtml so that default wrapper element is added.