### PR TITLE
Print a debug message instead of asserting when registering a plugin

### DIFF
--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -39,19 +39,19 @@ class ClientConfigs:
         self._notify_listener()
 
     def add_external_config(self, name: str, s: sublime.Settings, file: str) -> None:
-        assert name not in self.external
-        assert name not in self.all
+        if name in self.external:
+            return debug(name, "is already registered")
         config = ClientConfig.from_sublime_settings(name, s, file)
         self.external[name] = config
         self.all[name] = config
         self._notify_listener()
 
     def remove_external_config(self, name: str) -> None:
-        assert name in self.external
-        assert name in self.all
-        self.external.pop(name)
-        self.all.pop(name)
-        self._notify_listener()
+        self.external.pop(name, None)
+        if self.all.pop(name, None):
+            self._notify_listener()
+        else:
+            debug(name, "was not registered")
 
     def update_configs(self) -> None:
         global _settings_obj


### PR DESCRIPTION
When a plugin was already registered, and then called `register_plugin`
again, we would hit an assertion error. Let's print a debug message
instead so that we can make a smooth transition to explicitly registering
plugins instead of the current way where we register them "immediately"
in _forcefully_register_plugins.