### PR TITLE
More granular inhibit completion options

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -112,7 +112,7 @@
   "show_symbol_action_links": false,
 
   // Disable Sublime Text's snippet completions.
-  "inhibit_explicit_completions": false,
+  "inhibit_snippet_completions": false,
 
   // Disable Sublime Text's word completions. When set to `true`, this also disables Sublime Text's internal completion
   // sorting algorithm and instead uses the sorting defined by the relevant language server.

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -111,8 +111,12 @@
   // Show symbol action links in hover popup if available
   "show_symbol_action_links": false,
 
-  // Disable Sublime Text's explicit and word completion.
-  "only_show_lsp_completions": false,
+  // Disable Sublime Text's snippet completions.
+  "inhibit_explicit_completions": false,
+
+  // Disable Sublime Text's word completions. When set to `true`, this also disables Sublime Text's internal completion
+  // sorting algorithm and instead uses the sorting defined by the relevant language server.
+  "inhibit_word_completions": true,
 
   // Show symbol references in Sublime's quick panel instead of the bottom panel.
   "show_references_in_quick_panel": false,

--- a/docs/features.md
+++ b/docs/features.md
@@ -161,8 +161,9 @@ Add these settings to LSP settings, your Sublime settings, Syntax-specific setti
 
 ### Package settings (LSP)
 
-* `only_show_lsp_completions` `false` *disable sublime word completion and snippets from autocomplete lists*
-* `show_code_actions` `annotation` *Show code actions: "annotation", "bulb" *
+* `inhibit_word_completions` `true` *disable sublime word completion*
+* `inhibit_explicit_completions` `true` *disable sublime snippet completion*
+* `show_code_actions` `annotation` *Show code actions: "annotation", "bulb"*
 * `code_action_on_save_timeout_ms` `2000` *the amount of time the code actions on save are allowed to run for*
 * `show_references_in_quick_panel` `false` *show symbol references in Sublime's quick panel instead of the bottom panel*
 * `show_view_status` `true` *show permanent language server status in the status bar*
@@ -177,7 +178,7 @@ Add these settings to LSP settings, your Sublime settings, Syntax-specific setti
 * `document_highlight_scopes`: *customize your sublime text scopes for document highlighting*
 * `diagnostics_gutter_marker` `"dot"` *gutter marker for code diagnostics: "dot", "circle", "bookmark", "sign" or ""*
 * `show_symbol_action_links` `false` *show links to symbol actions like go to, references and rename in the hover popup*
-* `disabled_capabilities`, `[]` *Turn off client capabilities (features): "hover", "completion", "documentHighlight", "colorProvider", "signatureHelp"
+* `disabled_capabilities`, `[]` *Turn off client capabilities (features): "hover", "completion", "documentHighlight", "colorProvider", "signatureHelp"*
 * `log_debug` `false` *show debug logging in the sublime console*
 * `log_server` `[]` *log communication from and to language servers*
 * `log_stderr` `false` *show language server stderr output in the console*

--- a/docs/features.md
+++ b/docs/features.md
@@ -162,7 +162,7 @@ Add these settings to LSP settings, your Sublime settings, Syntax-specific setti
 ### Package settings (LSP)
 
 * `inhibit_word_completions` `true` *disable sublime word completion*
-* `inhibit_explicit_completions` `true` *disable sublime snippet completion*
+* `inhibit_snippet_completions` `false` *disable sublime snippet completion*
 * `show_code_actions` `annotation` *Show code actions: "annotation", "bulb"*
 * `code_action_on_save_timeout_ms` `2000` *the amount of time the code actions on save are allowed to run for*
 * `show_references_in_quick_panel` `false` *show symbol references in Sublime's quick panel instead of the bottom panel*

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -131,6 +131,8 @@ class Settings:
     disabled_capabilities = None  # type: List[str]
     document_highlight_scopes = None  # type: Dict[str, str]
     document_highlight_style = None  # type: str
+    inhibit_explicit_completions = None  # type: bool
+    inhibit_word_completions = None  # type: bool
     log_debug = None  # type: bool
     log_max_size = None  # type: int
     log_server = None  # type: List[str]
@@ -198,6 +200,15 @@ class Settings:
             self.auto_show_diagnostics_panel = auto_show_diagnostics_panel
         else:
             self.auto_show_diagnostics_panel = "always"
+
+        # Backwards-compatible with "only_show_lsp_completions"
+        only_show_lsp_completions = s.get("only_show_lsp_completions")
+        if isinstance(only_show_lsp_completions, bool):
+            self.inhibit_explicit_completions = only_show_lsp_completions
+            self.inhibit_word_completions = only_show_lsp_completions
+        else:
+            r("inhibit_explicit_completions", False)
+            r("inhibit_word_completions", True)
 
     def show_diagnostics_panel_always(self) -> bool:
         return self.auto_show_diagnostics_panel == "always"

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -131,7 +131,7 @@ class Settings:
     disabled_capabilities = None  # type: List[str]
     document_highlight_scopes = None  # type: Dict[str, str]
     document_highlight_style = None  # type: str
-    inhibit_explicit_completions = None  # type: bool
+    inhibit_snippet_completions = None  # type: bool
     inhibit_word_completions = None  # type: bool
     log_debug = None  # type: bool
     log_max_size = None  # type: int
@@ -204,10 +204,10 @@ class Settings:
         # Backwards-compatible with "only_show_lsp_completions"
         only_show_lsp_completions = s.get("only_show_lsp_completions")
         if isinstance(only_show_lsp_completions, bool):
-            self.inhibit_explicit_completions = only_show_lsp_completions
+            self.inhibit_snippet_completions = only_show_lsp_completions
             self.inhibit_word_completions = only_show_lsp_completions
         else:
-            r("inhibit_explicit_completions", False)
+            r("inhibit_snippet_completions", False)
             r("inhibit_word_completions", True)
 
     def show_diagnostics_panel_always(self) -> bool:

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -526,7 +526,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         if any(trigger.get('server', None) == session.config.name for trigger in completion_triggers):
             return
         # This is to make ST match with labels that have a weird prefix like a space character.
-        # settings.set('auto_complete_preserve_order', 'none')
+        settings.set('auto_complete_preserve_order', 'none')
         trigger_chars = session.get_capability('completionProvider.triggerCharacters') or []
         if trigger_chars:
             completion_triggers.append({

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -544,9 +544,11 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
                             can_resolve_completion_items: bool) -> None:
         response_items = []  # type: List[Dict]
         flags = 0
-        if userprefs().only_show_lsp_completions:
-            flags |= sublime.INHIBIT_WORD_COMPLETIONS
+        prefs = userprefs()
+        if prefs.inhibit_explicit_completions:
             flags |= sublime.INHIBIT_EXPLICIT_COMPLETIONS
+        if prefs.inhibit_word_completions:
+            flags |= sublime.INHIBIT_WORD_COMPLETIONS
             flags |= sublime.INHIBIT_REORDER
         if isinstance(response, dict):
             response_items = response["items"] or []

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -526,7 +526,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         if any(trigger.get('server', None) == session.config.name for trigger in completion_triggers):
             return
         # This is to make ST match with labels that have a weird prefix like a space character.
-        settings.set('auto_complete_preserve_order', 'none')
+        # settings.set('auto_complete_preserve_order', 'none')
         trigger_chars = session.get_capability('completionProvider.triggerCharacters') or []
         if trigger_chars:
             completion_triggers.append({
@@ -545,11 +545,10 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         response_items = []  # type: List[Dict]
         flags = 0
         prefs = userprefs()
-        if prefs.inhibit_explicit_completions:
+        if prefs.inhibit_snippet_completions:
             flags |= sublime.INHIBIT_EXPLICIT_COMPLETIONS
         if prefs.inhibit_word_completions:
             flags |= sublime.INHIBIT_WORD_COMPLETIONS
-            flags |= sublime.INHIBIT_REORDER
         if isinstance(response, dict):
             response_items = response["items"] or []
             if response.get("isIncomplete", False):
@@ -560,6 +559,8 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         LspResolveDocsCommand.completions = response_items
         items = [format_completion(response_item, index, can_resolve_completion_items)
                  for index, response_item in enumerate(response_items)]
+        if items:
+            flags |= sublime.INHIBIT_REORDER
         resolve(completion_list, items, flags)
 
     def _on_complete_error(self, error: dict, completion_list: sublime.CompletionList) -> None:

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -315,15 +315,20 @@
               "default": false,
               "markdownDescription": "Show symbol action links in hover popup if available."
             },
-            "inhibit_explicit_completions": {
+            "only_show_lsp_completions": {
               "type": "boolean",
               "default": false,
-              "markdownDescription": "Disable Sublime Text's snippet completions."
+              "deprecationMessage": "This setting is deprecated. Use a combination of \"inhibit_snippet_completions\" and \"inhibit_word_completions\" instead."
+            },
+            "inhibit_snippet_completions": {
+              "type": "boolean",
+              "default": false,
+              "markdownDescription": "Disable Sublime Text's (and your own) snippet completions. Note that your language server may still provide completion items of the \"snippet\" kind."
             },
             "inhibit_word_completions": {
               "type": "boolean",
-              "default": false,
-              "markdownDescription": "Disable Sublime Text's word completions. When set to `true`, this also disables Sublime Text's internal completion sorting algorithm and instead uses the sorting defined by the relevant language server."
+              "default": true,
+              "markdownDescription": "Disable Sublime Text's word completions. \"word\" completion means Sublime Text's internal completer that takes words from the current buffer you're editing and presents them in the auto-complete widget. When set to `true`, this also disables Sublime Text's internal completion sorting algorithm and instead uses the sorting defined by the relevant language server."
             },
             "show_references_in_quick_panel": {
               "type": "boolean",

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -328,7 +328,7 @@
             "inhibit_word_completions": {
               "type": "boolean",
               "default": true,
-              "markdownDescription": "Disable Sublime Text's word completions. \"word\" completion means Sublime Text's internal completer that takes words from the current buffer you're editing and presents them in the auto-complete widget. When set to `true`, this also disables Sublime Text's internal completion sorting algorithm and instead uses the sorting defined by the relevant language server."
+              "markdownDescription": "Disable Sublime Text's word completions. \"word\" completion means Sublime Text's internal completer that takes words from the current buffer you're editing and presents them in the auto-complete widget."
             },
             "show_references_in_quick_panel": {
               "type": "boolean",

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -315,10 +315,15 @@
               "default": false,
               "markdownDescription": "Show symbol action links in hover popup if available."
             },
-            "only_show_lsp_completions": {
+            "inhibit_explicit_completions": {
               "type": "boolean",
               "default": false,
-              "markdownDescription": "Disable Sublime Text's explicit and word completion."
+              "markdownDescription": "Disable Sublime Text's snippet completions."
+            },
+            "inhibit_word_completions": {
+              "type": "boolean",
+              "default": false,
+              "markdownDescription": "Disable Sublime Text's word completions. When set to `true`, this also disables Sublime Text's internal completion sorting algorithm and instead uses the sorting defined by the relevant language server."
             },
             "show_references_in_quick_panel": {
               "type": "boolean",


### PR DESCRIPTION
Replace "only_show_lsp_completions" with:

- "inhibit_explicit_completions"
- "inhibit_word_completions"

When inhibit_word_completions is enabled, this will also cause LSP
to disable ST's completion ordering and instead use the ordering of
the relevant language server.

Resolves #1166