### PR TITLE
Fix: TCP port number is zero in the error message

### DIFF
--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -228,7 +228,7 @@ def create_transport(config: ClientConfig, cwd: Optional[str], window: sublime.W
     if tcp_port:
         sock = _connect_tcp(tcp_port)
         if sock is None:
-            raise RuntimeError("Failed to connect on port {}".format(config.tcp_port))
+            raise RuntimeError("Failed to connect on port {}".format(tcp_port))
         reader = sock.makefile('rwb')  # type: IO[bytes]
         writer = reader
     else:


### PR DESCRIPTION
When failing to connect to a language server that is hosting a TCP
server, and when we choose a free TCP port, the error message shows
"Failed to connect on port 0", whereas that should be
"Failed to connect on port ${port}".