### PR TITLE
Add support for DottedDict

### DIFF
--- a/messages/3154-0.12.0.txt
+++ b/messages/3154-0.12.0.txt
@@ -1,0 +1,3 @@
+=> 3154-0.12.0
+
+- Backport support for dotted settings (#1321) (Rafał Chłodnicki)

--- a/plugin/core/collections.py
+++ b/plugin/core/collections.py
@@ -1,0 +1,145 @@
+"""
+Module with additional collections.
+"""
+from .typing import Optional, Dict, Any
+from copy import deepcopy
+
+
+class DottedDict:
+
+    __slots__ = ('_d',)
+
+    def __init__(self, d: Optional[Dict[str, Any]] = None) -> None:
+        """
+        Construct a DottedDict, optionally from an existing dictionary.
+
+        :param      d:    An existing dictionary.
+        """
+        self._d = {}  # type: Dict[str, Any]
+        if d is not None:
+            self.update(d)
+
+    @classmethod
+    def from_base_and_override(cls, base: "DottedDict", override: Optional[Dict[str, Any]]) -> "DottedDict":
+        result = DottedDict(base.copy())
+        if override:
+            result.update(override)
+        return result
+
+    def get(self, path: Optional[str] = None) -> Any:
+        """
+        Get a value from the dictionary.
+
+        :param      path:  The path, e.g. foo.bar.baz, or None.
+
+        :returns:   The value stored at the path, or None if it doesn't exist.
+                    Note that this cannot distinguish between None values and
+                    paths that don't exist. If the path is None, returns the
+                    entire dictionary.
+        """
+        if path is None:
+            return self._d
+        current = self._d  # type: Any
+        keys = path.split('.')
+        for key in keys:
+            if isinstance(current, dict):
+                current = current.get(key)
+            else:
+                return None
+        return current
+
+    def set(self, path: str, value: Any) -> None:
+        """
+        Set a value in the dictionary.
+
+        :param      path:   The path, e.g. foo.bar.baz
+        :param      value:  The value
+        """
+        current = self._d
+        keys = path.split('.')
+        for i in range(0, len(keys) - 1):
+            key = keys[i]
+            next_current = current.get(key)
+            if not isinstance(next_current, dict):
+                next_current = {}
+                current[key] = next_current
+            current = next_current
+        current[keys[-1]] = value
+
+    def remove(self, path: str) -> None:
+        """
+        Remove a key from the dictionary.
+
+        :param      path:  The path, e.g. foo.bar.baz
+        """
+        current = self._d
+        keys = path.split('.')
+        for i in range(0, len(keys) - 1):
+            key = keys[i]
+            next_current = current.get(key)
+            if not isinstance(next_current, dict):
+                return
+            current = next_current
+        current.pop(keys[-1], None)
+
+    def copy(self, path: Optional[str] = None) -> Any:
+        """
+        Get a copy of the value from the dictionary or copy of whole dictionary.
+
+        :param      path:  The path, e.g. foo.bar.baz, or None.
+
+        :returns:   A copy of the value stored at the path, or None if it doesn't exist.
+                    Note that this cannot distinguish between None values and
+                    paths that don't exist. If the path is None, returns a copy of the
+                    entire dictionary.
+        """
+        return deepcopy(self.get(path))
+
+    def __bool__(self) -> bool:
+        """
+        If this collection has at least one key-value pair, return True, else return False.
+        """
+        return bool(self._d)
+
+    def __contains__(self, path: str) -> bool:
+        value = self.get(path)
+        return value is not None and value is not False
+
+    def clear(self) -> None:
+        """
+        Remove all key-value pairs.
+        """
+        self._d.clear()
+
+    def assign(self, d: Dict[str, Any]) -> None:
+        """
+        Overwrites the old stored dictionary with a fresh new dictionary.
+
+        :param      d:    The new dictionary to store
+        """
+        self._d = d
+
+    def update(self, d: Dict[str, Any]) -> None:
+        """
+        Overwrite and/or add new key-value pairs to the collection.
+
+        :param      d:    The overriding dictionary. Can contain nested dictionaries.
+        """
+        for key, value in d.items():
+            if isinstance(value, dict):
+                self._update_recursive(value, key)
+            else:
+                self.set(key, value)
+
+    def _update_recursive(self, current: Dict[str, Any], prefix: str) -> None:
+        if not current:
+            return self.set(prefix, current)
+        for key, value in current.items():
+            path = "{}.{}".format(prefix, key)
+            if isinstance(value, dict):
+                self._update_recursive(value, path)
+            else:
+                self.set(path, value)
+
+    def __repr__(self) -> str:
+        return "{}({})".format(self.__class__.__name__, repr(self._d))

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -371,7 +371,8 @@ class Session(object):
         items = []  # type: List[Any]
         requested_items = params.get("items") or []
         for requested_item in requested_items:
-            items.append(self.config.settings.get(requested_item.get('section', None)))
+            configuration = self.config.settings.copy(requested_item.get('section') or None)
+            items.append(configuration)
         self.client.send_response(Response(request_id, items))
 
     def _handle_register_capability(self, params: Any, request_id: Any) -> None:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -135,7 +135,7 @@ def get_initialize_params(workspace_folders: List[WorkspaceFolder], config: Clie
         "capabilities": capabilities
     }
     if config.init_options is not None:
-        initializeParams['initializationOptions'] = config.init_options
+        initializeParams['initializationOptions'] = config.init_options.get()
 
     return initializeParams
 
@@ -371,14 +371,7 @@ class Session(object):
         items = []  # type: List[Any]
         requested_items = params.get("items") or []
         for requested_item in requested_items:
-            if 'section' in requested_item:
-                section = requested_item['section']
-                if section:
-                    items.append(get_dotted_value(self.config.settings, section))
-                else:
-                    items.append(self.config.settings)
-            else:
-                items.append(self.config.settings)
+            items.append(self.config.settings.get(requested_item.get('section', None)))
         self.client.send_response(Response(request_id, items))
 
     def _handle_register_capability(self, params: Any, request_id: Any) -> None:

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -113,10 +113,10 @@ class ClientConfigs(object):
 
         all_config_names = set(self._default_settings) | set(self._global_settings)
         for config_name in all_config_names.difference(set(self._external_configs)):
-            merged_settings = self._default_settings.get(config_name, dict())
+            merged_settings = DottedDict(self._default_settings.get(config_name, dict()))
             user_settings = self._global_settings.get(config_name, dict())
             merged_settings.update(user_settings)
-            self.all.append(read_client_config(config_name, merged_settings))
+            self.all.append(read_client_config(config_name, merged_settings.get()))
 
         debug('global configs', list('{}={}'.format(c.name, c.enabled) for c in self.all))
         if self._listener:

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -1,3 +1,4 @@
+from .collections import DottedDict
 from .logging import debug
 from .types import Settings, ClientConfig, LanguageConfig
 from .typing import List, Optional, Dict, Callable
@@ -170,7 +171,16 @@ def read_language_configs(client_config: dict) -> List[LanguageConfig]:
     return list(map(read_language_config, client_config.get("languages", [])))
 
 
-def read_client_config(name: str, client_config: Dict) -> ClientConfig:
+def read_client_config(name: str, client_config: Dict, base_settings_path: Optional[str] = None) -> ClientConfig:
+    if base_settings_path:
+        base = sublime.decode_value(sublime.load_resource(base_settings_path))
+        settings = DottedDict(base.get("settings", {}))
+        init_options = DottedDict(base.get("initializationOptions", {}))
+    else:
+        settings = DottedDict()
+        init_options = DottedDict()
+    settings.update(client_config.get("settings", {}))  # overrides from the user
+    init_options.update(client_config.get("initializationOptions", {}))  # overrides from the user
     languages = read_language_configs(client_config)
 
     return ClientConfig(
@@ -182,8 +192,8 @@ def read_client_config(name: str, client_config: Dict) -> ClientConfig:
         client_config.get("languageId", ""),
         languages,
         client_config.get("enabled", False),
-        client_config.get("initializationOptions", dict()),
-        client_config.get("settings", dict()),
+        init_options,
+        settings,
         client_config.get("env", dict()),
         client_config.get("tcp_host", None),
         client_config.get("tcp_mode", None),
@@ -202,8 +212,8 @@ def update_client_config(config: ClientConfig, settings: dict) -> ClientConfig:
         settings.get("languageId", default_language.id),
         read_language_configs(settings) or config.languages,
         settings.get("enabled", config.enabled),
-        settings.get("init_options", config.init_options),
-        settings.get("settings", config.settings),
+        DottedDict.from_base_and_override(config.init_options, settings.get("init_options")),
+        DottedDict.from_base_and_override(config.settings, settings.get("settings")),
         settings.get("env", config.env),
         settings.get("tcp_host", config.tcp_host),
         settings.get("tcp_mode", config.tcp_mode),

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -1,3 +1,4 @@
+from .collections import DottedDict
 from .typing import Optional, List, Dict, Any, Iterator, Protocol
 
 
@@ -55,8 +56,8 @@ class ClientConfig(object):
                  languageId: Optional[str] = None,
                  languages: List[LanguageConfig] = [],
                  enabled: bool = True,
-                 init_options: dict = dict(),
-                 settings: dict = dict(),
+                 init_options: DottedDict = DottedDict(),
+                 settings: DottedDict = DottedDict(),
                  env: dict = dict(),
                  tcp_host: Optional[str] = None,
                  tcp_mode: Optional[str] = None,

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -561,7 +561,8 @@ class WindowManager(object):
 
         session.client.send_notification(Notification.initialized())
         if session.config.settings:
-            session.client.send_notification(Notification.didChangeConfiguration({'settings': session.config.settings}))
+            session.client.send_notification(
+                Notification.didChangeConfiguration({'settings': session.config.settings.get()}))
         if session.has_capability("textDocumentSync"):
             self.documents.add_session(session)
         self._window.status_message("{} initialized".format(session.config.name))

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -109,7 +109,7 @@ class TextDocumentTestCase(DeferrableTestCase):
             self.assertFalse(True)
         window = sublime.active_window()
         self.assertTrue(window)
-        self.config.init_options["serverResponse"] = server_capabilities
+        self.config.init_options.set("serverResponse", server_capabilities)
         add_config(self.config)
         self.wm = windows.lookup(window)
         self.wm._configs.all.append(self.config)

--- a/tests/test_configurations.py
+++ b/tests/test_configurations.py
@@ -1,4 +1,3 @@
-from LSP.plugin.core.configurations import _merge_dicts
 from LSP.plugin.core.configurations import ConfigManager
 from LSP.plugin.core.configurations import is_supported_syntax
 from LSP.plugin.core.configurations import WindowConfigManager
@@ -28,24 +27,6 @@ class GlobalConfigManagerTests(unittest.TestCase):
         win.set_project_data({'settings': {'LSP': {TEST_CONFIG.name: {"enabled": False}}}})
         window_mgr = manager.for_window(win)
         self.assertFalse(window_mgr.all[0].enabled)
-
-
-class MergeDictsTests(unittest.TestCase):
-
-    def test_preserves_against_empty(self):
-
-        # merge against one empty dict
-        self.assertEqual(_merge_dicts({'a': 1}, {}), {'a': 1})
-        self.assertEqual(_merge_dicts({}, {'a': 1}), {'a': 1})
-
-        # first-level collision
-        self.assertEqual(_merge_dicts({'a': 2}, {'a': 1}), {'a': 1})
-
-        # replace number value with dict
-        self.assertEqual(_merge_dicts({'a': 2}, {'a': {'b': 4}}), {'a': {'b': 4}})
-
-        # update existing child dict.
-        self.assertEqual(_merge_dicts({'a': {'b': 2, 'c': 3}}, {'a': {'b': 4}}), {'a': {'b': 4, 'c': 3}})
 
 
 class WindowConfigManagerTests(unittest.TestCase):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,3 +1,4 @@
+from LSP.plugin.core.collections import DottedDict
 from LSP.plugin.core.protocol import TextDocumentSyncKindFull, TextDocumentSyncKindNone, TextDocumentSyncKindIncremental
 from LSP.plugin.core.protocol import WorkspaceFolder
 from LSP.plugin.core.sessions import clear_dotted_value
@@ -118,14 +119,11 @@ class SessionTest(unittest.TestCase):
     def test_initialize_params(self) -> None:
         wf = WorkspaceFolder.from_path("/foo/bar/baz")
         params = get_initialize_params(
-            [wf], ClientConfig(name="test", binary_args=[""], tcp_port=None, init_options=None))
-        self.assertNotIn("initializationOptions", params)
-        params = get_initialize_params(
-            [wf], ClientConfig(name="test", binary_args=[""], tcp_port=None, init_options={}))
+            [wf], ClientConfig(name="test", binary_args=[""], tcp_port=None, init_options=DottedDict()))
         self.assertIn("initializationOptions", params)
         self.assertEqual(params["initializationOptions"], {})
         params = get_initialize_params(
-            [wf], ClientConfig(name="test", binary_args=[""], tcp_port=None, init_options={"foo": "bar"}))
+            [wf], ClientConfig(name="test", binary_args=[""], tcp_port=None, init_options=DottedDict({"foo": "bar"})))
         self.assertIn("initializationOptions", params)
         self.assertEqual(params["initializationOptions"], {"foo": "bar"})
 


### PR DESCRIPTION
The public "read_client_config" API now takes an optional third argument
"base_settings_path" which must be passed by subclasses of LanguageHandler
to properly handle settings merging. It's an opt-in so without it
everything should work as before (no support for merging dotted settings).