### PR TITLE
Add support for LanguageHandler.additional_variables

### DIFF
--- a/messages/3154-0.12.0.txt
+++ b/messages/3154-0.12.0.txt
@@ -1,3 +1,6 @@
 => 3154-0.12.0
 
 - Backport support for dotted settings (#1321) (Rafał Chłodnicki)
+- Add support for "LanguageHandler.additional_variables" plugin API (Rafał Chłodnicki)
+- Add support for expanding "cache_path", "temp_dir" and "home" variables in "command", "settings"
+  and "initializationOptions"  (Rafał Chłodnicki)

--- a/messages/3154-0.12.0.txt
+++ b/messages/3154-0.12.0.txt
@@ -1,6 +1,6 @@
 => 3154-0.12.0
 
 - Backport support for dotted settings (#1321) (Rafał Chłodnicki)
-- Add support for "LanguageHandler.additional_variables" plugin API (Rafał Chłodnicki)
+- Add support for "LanguageHandler.additional_variables" plugin API (#1324) (Rafał Chłodnicki)
 - Add support for expanding "cache_path", "temp_dir" and "home" variables in "command", "settings"
-  and "initializationOptions"  (Rafał Chłodnicki)
+  and "initializationOptions" (#1324) (Rafał Chłodnicki)

--- a/messages/3154-0.12.0.txt
+++ b/messages/3154-0.12.0.txt
@@ -2,5 +2,5 @@
 
 - Backport support for dotted settings (#1321) (Rafał Chłodnicki)
 - Add support for "LanguageHandler.additional_variables" plugin API (#1324) (Rafał Chłodnicki)
-- Add support for expanding "cache_path", "temp_dir" and "home" variables in "command", "settings"
+- Add support for expanding "$cache_path", "$temp_dir" and "$home" variables in "command", "settings"
   and "initializationOptions" (#1324) (Rafał Chłodnicki)

--- a/plugin/core/clients.py
+++ b/plugin/core/clients.py
@@ -2,14 +2,15 @@ from .protocol import WorkspaceFolder
 from .sessions import create_session, Session
 from .settings import ClientConfig, settings
 from .typing import List, Dict, Tuple, Callable, Optional
+from .views import extract_variables
 import os
 import sublime
 
 
 def get_window_env(window: sublime.Window, config: ClientConfig) -> Tuple[List[str], Dict[str, str]]:
-
     # Create a dictionary of Sublime Text variables
-    variables = window.extract_variables()
+    variables = extract_variables(window)
+    variables.update(config.additional_variables)
 
     # Expand language server command line environment variables
     expanded_args = list(

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -150,6 +150,7 @@ class WindowConfigManager(object):
                 settings,
                 env,
                 overrides.get("tcp_host", client_config.tcp_host),
+                overrides.get("tcp_mode", client_config.tcp_mode),
                 overrides.get("experimental_capabilities", client_config.experimental_capabilities),
                 client_config.additional_variables
             )

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -151,6 +151,7 @@ class WindowConfigManager(object):
                 env,
                 overrides.get("tcp_host", client_config.tcp_host),
                 overrides.get("experimental_capabilities", client_config.experimental_capabilities),
+                client_config.additional_variables
             )
 
         return client_config

--- a/plugin/core/handlers.py
+++ b/plugin/core/handlers.py
@@ -18,7 +18,7 @@ class LanguageHandler(metaclass=abc.ABCMeta):
 
     @classmethod
     def additional_variables(cls) -> Optional[Dict[str, str]]:
-        return {}
+        return None
 
     @classmethod
     def instantiate_all(cls) -> 'List[LanguageHandler]':

--- a/plugin/core/handlers.py
+++ b/plugin/core/handlers.py
@@ -1,6 +1,6 @@
 from .logging import debug
 from .types import ClientConfig
-from .typing import List, Callable, Optional, Type
+from .typing import Dict, List, Callable, Optional, Type
 import abc
 
 
@@ -15,6 +15,10 @@ class LanguageHandler(metaclass=abc.ABCMeta):
     @abc.abstractproperty
     def config(self) -> ClientConfig:
         raise NotImplementedError
+
+    @classmethod
+    def additional_variables(cls) -> Optional[Dict[str, str]]:
+        return {}
 
     @classmethod
     def instantiate_all(cls) -> 'List[LanguageHandler]':

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -62,9 +62,11 @@ def load_handlers() -> None:
 
 def register_language_handler(handler: LanguageHandler) -> None:
     debug("received config {} from {}".format(handler.name, handler.__class__.__name__))
-    handler_config = handler.config
-    handler_config.additional_variables = handler.additional_variables()
-    client_configs.add_external_config(handler_config)
+    config = handler.config
+    additional_variables = handler.additional_variables()
+    if additional_variables:
+        config.additional_variables = additional_variables
+    client_configs.add_external_config(config)
     if handler.on_start:
         client_start_listeners[handler.name] = handler.on_start
     if handler.on_initialized:

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -62,7 +62,9 @@ def load_handlers() -> None:
 
 def register_language_handler(handler: LanguageHandler) -> None:
     debug("received config {} from {}".format(handler.name, handler.__class__.__name__))
-    client_configs.add_external_config(handler.config)
+    handler_config = handler.config
+    handler_config.additional_variables = handler.additional_variables()
+    client_configs.add_external_config(handler_config)
     if handler.on_start:
         client_start_listeners[handler.name] = handler.on_start
     if handler.on_initialized:

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -217,5 +217,6 @@ def update_client_config(config: ClientConfig, settings: dict) -> ClientConfig:
         settings.get("env", config.env),
         settings.get("tcp_host", config.tcp_host),
         settings.get("tcp_mode", config.tcp_mode),
-        settings.get("experimental_capabilities", config.experimental_capabilities)
+        settings.get("experimental_capabilities", config.experimental_capabilities),
+        config.additional_variables
     )

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -61,7 +61,8 @@ class ClientConfig(object):
                  env: dict = dict(),
                  tcp_host: Optional[str] = None,
                  tcp_mode: Optional[str] = None,
-                 experimental_capabilities: dict = dict()) -> None:
+                 experimental_capabilities: dict = dict(),
+                 additional_variables: dict = dict()) -> None:
         self.name = name
         self.binary_args = binary_args
         self.tcp_port = tcp_port
@@ -75,6 +76,7 @@ class ClientConfig(object):
         self.settings = settings
         self.env = env
         self.experimental_capabilities = experimental_capabilities
+        self.additional_variables = additional_variables
 
 
 def syntax_language(config: ClientConfig, syntax: str) -> Optional[LanguageConfig]:

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -62,7 +62,7 @@ class ClientConfig(object):
                  tcp_host: Optional[str] = None,
                  tcp_mode: Optional[str] = None,
                  experimental_capabilities: dict = dict(),
-                 additional_variables: dict = dict()) -> None:
+                 additional_variables: Dict[str, str] = dict()) -> None:
         self.name = name
         self.binary_args = binary_args
         self.tcp_port = tcp_port

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -1,9 +1,11 @@
-import sublime
-import linecache
 from .protocol import Point, Range, Notification, Request
 from .typing import Optional, Dict, Any
 from .url import filename_to_uri
 from .url import uri_to_filename
+import linecache
+import os
+import sublime
+import tempfile
 
 
 def get_line(window: Optional[sublime.Window], file_name: str, row: int) -> str:
@@ -23,6 +25,14 @@ def get_line(window: Optional[sublime.Window], file_name: str, row: int) -> str:
         # get from linecache
         # linecache row is not 0 based, so we increment it by 1 to get the correct line.
         return linecache.getline(file_name, row + 1).strip()
+
+
+def extract_variables(window: sublime.Window) -> Dict[str, str]:
+    variables = window.extract_variables()
+    variables["cache_path"] = sublime.cache_path()
+    variables["temp_dir"] = tempfile.gettempdir()
+    variables["home"] = os.path.expanduser('~')
+    return variables
 
 
 def point_to_offset(point: Point, view: sublime.View) -> int:

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -560,9 +560,7 @@ class WindowManager(object):
         self._handlers.on_initialized(session.config.name, self._window, session.client)
 
         session.client.send_notification(Notification.initialized())
-        if session.config.settings:
-            session.client.send_notification(
-                Notification.didChangeConfiguration({'settings': session.config.settings.get()}))
+        session.maybe_send_did_change_configuration()
         if session.has_capability("textDocumentSync"):
             self.documents.add_session(session)
         self._window.status_message("{} initialized".format(session.config.name))


### PR DESCRIPTION
Adds support for LanguageHandler.additional_variables() classmethod,
to match LSP4 AbstractPlugin API.

Also backports support for expanding variables in "settings",
"initializationOptions" and "command" options. Includes support for
built-in variables "cache_path", "temp_dir" and "home".