### PR TITLE
Prevent accidental view input after triggering document symbols

### DIFF
--- a/Keymaps/Default (Linux).sublime-keymap
+++ b/Keymaps/Default (Linux).sublime-keymap
@@ -335,4 +335,16 @@
     //         }
     //     ]
     // },
+    // Internal key-binding
+    {
+        "keys": [
+            "<character>"
+        ],
+        "command": "noop",
+        "context": [
+            {
+                "key": "setting.lsp_suppress_input",
+            }
+        ]
+    },
 ]

--- a/Keymaps/Default (OSX).sublime-keymap
+++ b/Keymaps/Default (OSX).sublime-keymap
@@ -335,4 +335,16 @@
     //         }
     //     ]
     // },
+    // Internal key-binding
+    {
+        "keys": [
+            "<character>"
+        ],
+        "command": "noop",
+        "context": [
+            {
+                "key": "setting.lsp_suppress_input",
+            }
+        ]
+    },
 ]

--- a/Keymaps/Default (Windows).sublime-keymap
+++ b/Keymaps/Default (Windows).sublime-keymap
@@ -335,4 +335,16 @@
     //         }
     //     ]
     // },
+    // Internal key-binding
+    {
+        "keys": [
+            "<character>"
+        ],
+        "command": "noop",
+        "context": [
+            {
+                "key": "setting.lsp_suppress_input",
+            }
+        ]
+    },
 ]

--- a/plugin/symbols.py
+++ b/plugin/symbols.py
@@ -12,6 +12,9 @@ import sublime
 import sublime_plugin
 
 
+SUPPRESS_INPUT_SETTING_KEY = 'lsp_suppress_input'
+
+
 def unpack_lsp_kind(kind: int) -> Tuple[int, str, str, str]:
     if 1 <= kind <= len(SYMBOL_KINDS):
         return SYMBOL_KINDS[kind - 1]
@@ -76,7 +79,7 @@ class LspDocumentSymbolsCommand(LspTextCommand):
         self.is_first_selection = False
 
     def run(self, edit: sublime.Edit) -> None:
-        self.view.settings().set('lsp_supress_input', True)
+        self.view.settings().set(SUPPRESS_INPUT_SETTING_KEY, True)
         session = self.best_session(self.capability)
         if session:
             session.send_request(
@@ -85,7 +88,7 @@ class LspDocumentSymbolsCommand(LspTextCommand):
                 lambda error: sublime.set_timeout(self.handle_response_error(error)))
 
     def handle_response(self, response: Any) -> None:
-        self.view.settings().erase('lsp_supress_input')
+        self.view.settings().erase(SUPPRESS_INPUT_SETTING_KEY)
         window = self.view.window()
         if window and isinstance(response, list) and len(response) > 0:
             self.old_regions = [sublime.Region(r.a, r.b) for r in self.view.sel()]
@@ -99,7 +102,7 @@ class LspDocumentSymbolsCommand(LspTextCommand):
             self.view.run_command("lsp_selection_clear")
 
     def handle_response_error(self, error: Any) -> None:
-        self.view.settings().erase('lsp_supress_input')
+        self.view.settings().erase(SUPPRESS_INPUT_SETTING_KEY)
         print_to_status_bar(error)
 
     def region(self, index: int) -> sublime.Region:

--- a/plugin/symbols.py
+++ b/plugin/symbols.py
@@ -84,8 +84,8 @@ class LspDocumentSymbolsCommand(LspTextCommand):
         if session:
             session.send_request(
                 Request.documentSymbols({"textDocument": text_document_identifier(self.view)}),
-                lambda response: sublime.set_timeout(self.handle_response(response)),
-                lambda error: sublime.set_timeout(self.handle_response_error(error)))
+                lambda response: sublime.set_timeout(lambda: self.handle_response(response)),
+                lambda error: sublime.set_timeout(lambda: self.handle_response_error(error)))
 
     def handle_response(self, response: Any) -> None:
         self.view.settings().erase(SUPPRESS_INPUT_SETTING_KEY)

--- a/plugin/symbols.py
+++ b/plugin/symbols.py
@@ -1,5 +1,6 @@
 from .core.protocol import Request, Range
 from .core.registry import LspTextCommand
+from .core.rpc import print_to_status_bar
 from .core.typing import Any, List, Optional, Tuple, Dict, Generator
 from .core.views import location_to_encoded_filename
 from .core.views import range_to_region
@@ -80,7 +81,8 @@ class LspDocumentSymbolsCommand(LspTextCommand):
         if session:
             session.send_request(
                 Request.documentSymbols({"textDocument": text_document_identifier(self.view)}),
-                self.handle_response, self.handle_response_error)
+                lambda response: sublime.set_timeout(self.handle_response(response)),
+                lambda error: sublime.set_timeout(self.handle_response_error(error)))
 
     def handle_response(self, response: Any) -> None:
         self.view.settings().erase('lsp_supress_input')
@@ -96,8 +98,9 @@ class LspDocumentSymbolsCommand(LspTextCommand):
                 self.on_highlighted)
             self.view.run_command("lsp_selection_clear")
 
-    def handle_response_error(self, response: Any) -> None:
+    def handle_response_error(self, error: Any) -> None:
         self.view.settings().erase('lsp_supress_input')
+        print_to_status_bar(error)
 
     def region(self, index: int) -> sublime.Region:
         return self.regions[index][0]


### PR DESCRIPTION
After triggering LSP's "Document Symbols", the user might start typing
the query immediately and if the server response is delayed the query
would end up changing the view. This is a stop-gap solution to avoid
such accidental input until https://github.com/sublimehq/sublime_text/issues/3338
is implemented.

Resolves #1323