### PR TITLE
Better 'cannot start' message

### DIFF
--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -250,8 +250,8 @@ class WindowManager(Manager):
                     self._window, initiating_view, workspace_folders, config)
                 if cannot_start_reason:
                     config.erase_view_status(initiating_view)
-                    self._window.status_message(cannot_start_reason)
-                    return
+                    message = "cannot start {}: {}".format(config.name, cannot_start_reason)
+                    return self._window.status_message(message)
             config.set_view_status(initiating_view, "starting...")
             session = Session(self, self._create_logger(config.name), workspace_folders, config, plugin_class)
             cwd = workspace_folders[0].path if workspace_folders else None


### PR DESCRIPTION
It's nicer to have a common prefix format for all helper plugins. This also means helper plugins don't have to bother with writing out their name for all error messages.