### PR TITLE
Trigger autocomplete popup on "editor.action.triggerSuggest" command

### DIFF
--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -89,8 +89,12 @@ class LspCompleteCommand(sublime_plugin.TextCommand):
             self.view.run_command("lsp_apply_document_edit", {'changes': edits})
         command = item.get("command")
         if command:
+            if command['command'] == "editor.action.triggerSuggest":
+                sublime.set_timeout(lambda: self.view.run_command("auto_complete"))
+                return
             debug('Running server command "{}" for view {}'.format(command, self.view.id()))
-            self.view.run_command("lsp_execute", {"command_name": command})
+            args = {"command_name": command["command"], "command_args": command.get("arguments")}
+            self.view.run_command("lsp_execute", args)
 
 
 class LspCompleteInsertTextCommand(LspCompleteCommand):

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -89,9 +89,6 @@ class LspCompleteCommand(sublime_plugin.TextCommand):
             self.view.run_command("lsp_apply_document_edit", {'changes': edits})
         command = item.get("command")
         if command:
-            if command['command'] == "editor.action.triggerSuggest":
-                sublime.set_timeout(lambda: self.view.run_command("auto_complete"))
-                return
             debug('Running server command "{}" for view {}'.format(command, self.view.id()))
             args = {"command_name": command["command"], "command_args": command.get("arguments")}
             self.view.run_command("lsp_execute", args)

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -17,6 +17,7 @@ class LspExecuteCommand(LspTextCommand):
             event: Optional[dict] = None) -> None:
         # Handle VSCode-specific command for triggering suggestions popup.
         if command_name == "editor.action.triggerSuggest":
+            # Triggered for set_timeout as suggestions popup doesn't trigger otherwise.
             sublime.set_timeout(lambda: self.view.run_command("auto_complete"))
             return
         session = self.best_session(self.capability)

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -15,6 +15,9 @@ class LspExecuteCommand(LspTextCommand):
             command_name: Optional[str] = None,
             command_args: Optional[List[Any]] = None,
             event: Optional[dict] = None) -> None:
+        if command_name == "editor.action.triggerSuggest":
+            sublime.set_timeout(lambda: self.view.run_command("auto_complete"))
+            return
         session = self.best_session(self.capability)
         if session and command_name:
             window = self.view.window()

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -17,7 +17,7 @@ class LspExecuteCommand(LspTextCommand):
             event: Optional[dict] = None) -> None:
         # Handle VSCode-specific command for triggering suggestions popup.
         if command_name == "editor.action.triggerSuggest":
-            # Triggered for set_timeout as suggestions popup doesn't trigger otherwise.
+            # Triggered from set_timeout as suggestions popup doesn't trigger otherwise.
             sublime.set_timeout(lambda: self.view.run_command("auto_complete"))
             return
         session = self.best_session(self.capability)

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -15,6 +15,7 @@ class LspExecuteCommand(LspTextCommand):
             command_name: Optional[str] = None,
             command_args: Optional[List[Any]] = None,
             event: Optional[dict] = None) -> None:
+        # Handle VSCode-specific command for triggering suggestions popup.
         if command_name == "editor.action.triggerSuggest":
             sublime.set_timeout(lambda: self.view.run_command("auto_complete"))
             return


### PR DESCRIPTION
This is VSCode specific behavior that unfortunately CSS language server
(and possibly other) uses.

Also fixes arguments passed to "lsp_execute" as those were not correct.

Resolves #1139