### PR TITLE
Act as a TCP server for langservers that want to connect to the client

### DIFF
--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -220,7 +220,7 @@ def create_transport(config: ClientConfig, cwd: Optional[str], window: sublime.W
 
     if listener_socket:
         assert isinstance(tcp_port, int) and tcp_port > 0
-        process, reader, writer = _await_tcp_connection(config.name, tcp_port, listener_socket, start_subprocess)
+        process, sock, reader, writer = _await_tcp_connection(config.name, tcp_port, listener_socket, start_subprocess)
     else:
         process = start_subprocess()
         if tcp_port:
@@ -315,7 +315,7 @@ def _await_tcp_connection(
     tcp_port: int,
     listener_socket: socket.socket,
     subprocess_starter: Callable[[], subprocess.Popen]
-) -> Tuple[subprocess.Popen, IO[bytes], IO[bytes]]:
+) -> Tuple[subprocess.Popen, socket.socket, IO[bytes], IO[bytes]]:
 
     # After we have accepted one client connection, we can close the listener socket.
     with closing(listener_socket):
@@ -337,7 +337,7 @@ def _await_tcp_connection(
         reader = sock.makefile('rwb')  # type: IO[bytes]
         writer = reader
         assert data.process
-        return data.process, reader, writer
+        return data.process, sock, reader, writer
 
 
 def _connect_tcp(port: int) -> Optional[socket.socket]:

--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -176,27 +176,6 @@ class JsonRpcTransport(Transport):
         self._send_queue.put_nowait(None)
 
 
-def _fixup_startup_args(args: List[str]) -> Any:
-    if sublime.platform() == "windows":
-        startupinfo = subprocess.STARTUPINFO()  # type: ignore
-        startupinfo.dwFlags |= subprocess.SW_HIDE | subprocess.STARTF_USESHOWWINDOW  # type: ignore
-        executable_arg = args[0]
-        fname, ext = os.path.splitext(executable_arg)
-        if len(ext) < 1:
-            path_to_executable = shutil.which(executable_arg)
-            # what extensions should we append so CreateProcess can find it?
-            # node has .cmd
-            # dart has .bat
-            # python has .exe wrappers - not needed
-            for extension in ['.cmd', '.bat']:
-                if path_to_executable and path_to_executable.lower().endswith(extension):
-                    args[0] = executable_arg + extension
-                    break
-    else:
-        startupinfo = None
-    return startupinfo
-
-
 def create_transport(config: ClientConfig, cwd: Optional[str], window: sublime.Window,
                      callback_object: TransportCallbacks, variables: Dict[str, str]) -> JsonRpcTransport:
     tcp_port = None  # type: Optional[int]
@@ -273,6 +252,27 @@ def kill_all_subprocesses() -> None:
             p.wait()
         except Exception:
             pass
+
+
+def _fixup_startup_args(args: List[str]) -> Any:
+    if sublime.platform() == "windows":
+        startupinfo = subprocess.STARTUPINFO()  # type: ignore
+        startupinfo.dwFlags |= subprocess.SW_HIDE | subprocess.STARTF_USESHOWWINDOW  # type: ignore
+        executable_arg = args[0]
+        fname, ext = os.path.splitext(executable_arg)
+        if len(ext) < 1:
+            path_to_executable = shutil.which(executable_arg)
+            # what extensions should we append so CreateProcess can find it?
+            # node has .cmd
+            # dart has .bat
+            # python has .exe wrappers - not needed
+            for extension in ['.cmd', '.bat']:
+                if path_to_executable and path_to_executable.lower().endswith(extension):
+                    args[0] = executable_arg + extension
+                    break
+    else:
+        startupinfo = None
+    return startupinfo
 
 
 def _start_subprocess(


### PR DESCRIPTION
Needed for getting SonarLint to work. This language server assumes that the editor is playing the role of a TCP server.

Dug old code up from this commit: f1a53fc45466d008392a17f1c768c26723b14b27

It's a bit simplified with respect to configuration in the following sense:

- We don't start a listener socket on every ethernet device, only localhost.
- In the config, set `tcp_port` to `-1` to start a listener socket with an arbitrary OS-chosen port, or
- set `tcp_port` to `X` where `X < -1` to start a listener socket listening on port `-X`.