### PR TITLE
Add function to open a file asynchronously

### DIFF
--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -7,6 +7,7 @@ from .css import unload as unload_css
 from .handlers import LanguageHandler
 from .logging import set_debug_logging, set_exception_logging
 from .panels import destroy_output_panels
+from .promise import opening_files
 from .protocol import Response
 from .protocol import WorkspaceFolder
 from .registry import windows
@@ -21,6 +22,7 @@ from .settings import userprefs
 from .transports import kill_all_subprocesses
 from .types import ClientConfig
 from .typing import Optional, List, Type, Callable, Dict, Tuple
+import os
 import weakref
 
 
@@ -153,3 +155,12 @@ class Listener(sublime_plugin.EventListener):
 
     def on_pre_close_window(self, w: sublime.Window) -> None:
         windows.discard(w)
+
+    def on_load(self, view: sublime.View) -> None:
+        file_name = view.file_name()
+        if not file_name:
+            return
+        for fn, tup in opening_files.items():
+            if fn == file_name or os.path.samefile(fn, file_name):
+                opening_files.pop(fn)
+                return tup[1](view)

--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -7,7 +7,6 @@ from .css import unload as unload_css
 from .handlers import LanguageHandler
 from .logging import set_debug_logging, set_exception_logging
 from .panels import destroy_output_panels
-from .promise import opening_files
 from .protocol import Response
 from .protocol import WorkspaceFolder
 from .registry import windows
@@ -22,6 +21,7 @@ from .settings import userprefs
 from .transports import kill_all_subprocesses
 from .types import ClientConfig
 from .typing import Optional, List, Type, Callable, Dict, Tuple
+from .windows import opening_files
 import os
 import weakref
 

--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -163,4 +163,5 @@ class Listener(sublime_plugin.EventListener):
         for fn, tup in opening_files.items():
             if fn == file_name or os.path.samefile(fn, file_name):
                 opening_files.pop(fn)
-                return tup[1](view)
+                tup[1](view)
+                break

--- a/plugin/core/promise.py
+++ b/plugin/core/promise.py
@@ -1,8 +1,6 @@
-from .typing import Any, Callable, List, Dict, Tuple, Optional
+from .typing import Any, Callable, List
 import functools
 import threading
-import sublime
-import os
 
 ResolveFunc = Callable[..., None]  # Optional argument not supported in Callable so using "..."
 FullfillFunc = Callable[[ResolveFunc], None]
@@ -186,32 +184,3 @@ class Promise:
     def _get_value(self) -> Any:
         with self.mutex:
             return self.value
-
-
-opening_files = {}  # type: Dict[str, Tuple[Promise, Callable[[Optional[sublime.View]], None]]]
-
-
-def open_file(window: sublime.Window, file_path: str, flags: int = 0, group: int = -1) -> Promise:
-    """Open a file asynchronously. It is only safe to call this function from the UI thread."""
-    view = window.open_file(file_path, flags, group)
-    if not view.is_loading():
-        # It's already loaded. Possibly already open in a tab.
-        return Promise.resolve(view)
-
-    # Is the view opening right now? Then return the associated unresolved promise
-    for fn, value in opening_files.items():
-        if fn == file_path or os.path.samefile(fn, file_path):
-            # Return the unresolved promise. A future on_load event will resolve the promise.
-            return value[0]
-
-    # Prepare a new promise to be resolved by a future on_load event (see the event listener in main.py)
-    def fullfill(resolve: ResolveFunc) -> None:
-        global opening_files
-        # Save the promise in the first element of the tuple -- except we cannot yet do that here
-        opening_files[file_path] = (None, resolve)  # type: ignore
-
-    promise = Promise(fullfill)
-    tup = opening_files[file_path]
-    # Save the promise in the first element of the tuple so that the for-loop above can return it
-    opening_files[file_path] = (promise, tup[1])
-    return promise

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -10,6 +10,8 @@ from .message_request_handler import MessageRequestHandler
 from .panels import update_server_panel
 from .protocol import Diagnostic
 from .protocol import Error
+from .promise import Promise
+from .promise import ResolveFunc
 from .protocol import Point
 from .sessions import get_plugin
 from .sessions import Logger
@@ -19,7 +21,7 @@ from .sessions import SessionViewProtocol
 from .settings import userprefs
 from .transports import create_transport
 from .types import ClientConfig
-from .typing import Optional, Any, Dict, Deque, List, Generator, Tuple, Mapping, Iterable
+from .typing import Optional, Any, Dict, Deque, List, Generator, Tuple, Mapping, Iterable, Callable
 from .views import diagnostic_to_phantom
 from .views import extract_variables
 from .workspace import disable_in_project
@@ -506,6 +508,35 @@ class WindowRegistry(object):
 
     def discard(self, window: sublime.Window) -> None:
         self._windows.pop(window.id(), None)
+
+
+opening_files = {}  # type: Dict[str, Tuple[Promise, Callable[[Optional[sublime.View]], None]]]
+
+
+def open_file(window: sublime.Window, file_path: str, flags: int = 0, group: int = -1) -> Promise:
+    """Open a file asynchronously. It is only safe to call this function from the UI thread."""
+    view = window.open_file(file_path, flags, group)
+    if not view.is_loading():
+        # It's already loaded. Possibly already open in a tab.
+        return Promise.resolve(view)
+
+    # Is the view opening right now? Then return the associated unresolved promise
+    for fn, value in opening_files.items():
+        if fn == file_path or os.path.samefile(fn, file_path):
+            # Return the unresolved promise. A future on_load event will resolve the promise.
+            return value[0]
+
+    # Prepare a new promise to be resolved by a future on_load event (see the event listener in main.py)
+    def fullfill(resolve: ResolveFunc) -> None:
+        global opening_files
+        # Save the promise in the first element of the tuple -- except we cannot yet do that here
+        opening_files[file_path] = (None, resolve)  # type: ignore
+
+    promise = Promise(fullfill)
+    tup = opening_files[file_path]
+    # Save the promise in the first element of the tuple so that the for-loop above can return it
+    opening_files[file_path] = (promise, tup[1])
+    return promise
 
 
 class PanelLogger(Logger):


### PR DESCRIPTION
The function `open_file` in promises.py returns a Promise that shall be
resolved once the file is fully loaded. It's only safe to call `open_file`
from the main thread because the `on_load` event callback runs on the main
thread.

I want to use this for workspace edits as well as renames.