### PR TITLE
Allow a plugin to intercept a server command

### DIFF
--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -294,11 +294,7 @@ def run_code_action_or_command(
 
 def execute_server_command(view: sublime.View, config_name: str, command: Mapping[str, Any]) -> Promise:
     session = next((session for session in sessions_for_view(view) if session.config.name == config_name), None)
-    if session:
-        send_request = session.send_request
-        return Promise(lambda resolve: send_request(
-            Request.executeCommand(command), lambda _: resolve(), lambda _: resolve()))
-    return Promise.resolve()
+    return session.run_command(command) if session else Promise.resolve()
 
 
 class LspCodeActionsCommand(LspTextCommand):

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1,6 +1,7 @@
 from .edit import parse_workspace_edit
 from .logging import debug
 from .logging import exception_log
+from .promise import Promise
 from .protocol import CompletionItemTag
 from .protocol import Error
 from .protocol import ErrorCode
@@ -18,7 +19,7 @@ from .types import debounced
 from .types import diff
 from .types import DocumentSelector
 from .types import method_to_capability
-from .typing import Callable, Dict, Any, Optional, List, Tuple, Generator, Type, Protocol
+from .typing import Callable, Dict, Any, Optional, List, Tuple, Generator, Type, Protocol, Mapping
 from .url import uri_to_filename
 from .version import __version__
 from .views import COMPLETION_KINDS
@@ -420,7 +421,7 @@ class AbstractPlugin(metaclass=ABCMeta):
         """
         self.weaksession = weaksession
 
-    def on_workspace_configuration(cls, params: Dict, configuration: Any) -> None:
+    def on_workspace_configuration(self, params: Dict, configuration: Any) -> None:
         """
         Override to augment configuration returned for the workspace/configuration request.
 
@@ -428,6 +429,17 @@ class AbstractPlugin(metaclass=ABCMeta):
         :param      configuration:  The resolved configuration for given params.
         """
         pass
+
+    def on_pre_server_command(self, command: Mapping[str, Any]) -> Optional[Promise]:
+        """
+        Intercept a command that is about to be sent to the language server. Return a `Promise` to signal that you are
+        handling this command in your plugin. The command will then not be sent to the language server.
+
+        :param    command:  The payload containing a "command" and optionally "arguments".
+
+        :returns: An optional promise.
+        """
+        return None
 
 
 _plugins = {}  # type: Dict[str, Type[AbstractPlugin]]
@@ -764,6 +776,13 @@ class Session(TransportCallbacks):
             if extra_vars:
                 variables.update(extra_vars)
         return variables
+
+    def run_command(self, command: Mapping[str, Any]) -> Promise:
+        if self._plugin:
+            promise = self._plugin.on_pre_server_command(command)
+            if promise:
+                return promise
+        return Promise(lambda resolve: self.send_request(Request.executeCommand(command), resolve, resolve))
 
     # --- server request handlers --------------------------------------------------------------------------------------
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -782,7 +782,14 @@ class Session(TransportCallbacks):
             promise = self._plugin.on_pre_server_command(command)
             if promise:
                 return promise
-        return Promise(lambda resolve: self.send_request(Request.executeCommand(command), resolve, resolve))
+        # TODO: Our Promise class should be able to handle errors/exceptions
+        return Promise(
+            lambda resolve: self.send_request(
+                request=Request.executeCommand(command),
+                handler=resolve,
+                error_handler=lambda err: resolve(Error(err["code"], err["message"], err.get("data")))
+            )
+        )
 
     # --- server request handlers --------------------------------------------------------------------------------------
 

--- a/tests/test_single_document.py
+++ b/tests/test_single_document.py
@@ -316,6 +316,13 @@ class SingleDocumentTestCase(TextDocumentTestCase):
         yield from self.await_view_change(9)
         self.assertEqual(self.view.substr(sublime.Region(0, self.view.size())), "bar\nbar\nbar\n")
 
+    def test_run_command(self) -> 'Generator':
+        self.set_response("workspace/executeCommand", {"canReturnAnythingHere": "asdf"})
+        promise = self.session.run_command({"command": "foo", "arguments": ["hello", "there", "general", "kenobi"]})
+        yield from self.await_message("workspace/executeCommand")
+        self.assertTrue(promise.resolved)
+        self.assertEqual(promise.value, {"canReturnAnythingHere": "asdf"})
+
 
 class WillSaveWaitUntilTestCase(TextDocumentTestCase):
 


### PR DESCRIPTION
It's an unfortunate reality that some language servers have elaborate client-specific code. This is a way to handle that.

An `AbstractPlugin` can now define `on_pre_server_command` and intercept a server command. It can then return a Promise to tell the `Session` that it "handled" (or will handle) the command. The `Session` will then not send the command to the server.

Example usage: https://github.com/sublimelsp/LSP-SonarLint/blob/master/src/plugin.py