### PR TITLE
Store inflight requests in SessionView

### DIFF
--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -149,7 +149,7 @@ class CodeActionsManager:
                         if matching_kinds:
                             params = text_document_code_action_params(
                                 view, file_name, request_range, [], matching_kinds)
-                            request = Request.codeAction(params)
+                            request = Request.codeAction(params, view)
                             session.send_request(
                                 request, *filtering_collector(session.config.name, matching_kinds, collector))
                     else:
@@ -158,7 +158,7 @@ class CodeActionsManager:
                         if only_with_diagnostics and not diagnostics:
                             continue
                         params = text_document_code_action_params(view, file_name, request_range, diagnostics)
-                        request = Request.codeAction(params)
+                        request = Request.codeAction(params, view)
                         session.send_request(request, collector.create_collector(config_name))
         if use_cache:
             self._response_cache = (location_cache_key, collector)

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -27,7 +27,7 @@ class LspResolveDocsCommand(LspTextCommand):
             # If those fields appear after the item is resolved we show them in the popup.
             session = self.best_session('completionProvider.resolveProvider')
             if session:
-                session.send_request(Request.resolveCompletionItem(item), self.handle_resolve_response)
+                session.send_request(Request.resolveCompletionItem(item, self.view), self.handle_resolve_response)
                 return
         minihtml_content = self.get_content(documentation, detail)
         self.show_popup(minihtml_content)

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -2,6 +2,7 @@ from .typing import Any, List, Dict, Optional, Union, Mapping, Iterable
 from .url import filename_to_uri
 from .url import uri_to_filename
 import os
+import sublime
 
 
 TextDocumentSyncKindNone = 0
@@ -34,59 +35,49 @@ class DocumentHighlightKind(object):
 
 class Request:
 
-    __slots__ = ('method', 'params')
+    __slots__ = ('method', 'params', 'view')
 
-    def __init__(self, method: str, params: Optional[Mapping[str, Any]] = None) -> None:
+    def __init__(self, method: str, params: Optional[Mapping[str, Any]] = None,
+                 view: Optional[sublime.View] = None) -> None:
         self.method = method
         self.params = params
+        self.view = view
 
     @classmethod
     def initialize(cls, params: dict) -> 'Request':
         return Request("initialize", params)
 
     @classmethod
-    def hover(cls, params: dict) -> 'Request':
-        return Request("textDocument/hover", params)
+    def hover(cls, params: dict, view: sublime.View) -> 'Request':
+        return Request("textDocument/hover", params, view)
 
     @classmethod
-    def complete(cls, params: dict) -> 'Request':
-        return Request("textDocument/completion", params)
+    def complete(cls, params: dict, view: sublime.View) -> 'Request':
+        return Request("textDocument/completion", params, view)
 
     @classmethod
-    def signatureHelp(cls, params: dict) -> 'Request':
-        return Request("textDocument/signatureHelp", params)
+    def signatureHelp(cls, params: dict, view: sublime.View) -> 'Request':
+        return Request("textDocument/signatureHelp", params, view)
 
     @classmethod
-    def references(cls, params: dict) -> 'Request':
-        return Request("textDocument/references", params)
+    def references(cls, params: dict, view: sublime.View) -> 'Request':
+        return Request("textDocument/references", params, view)
 
     @classmethod
-    def definition(cls, params: dict) -> 'Request':
-        return Request("textDocument/definition", params)
+    def prepareRename(cls, params: dict, view: sublime.View) -> 'Request':
+        return Request("textDocument/prepareRename", params, view)
 
     @classmethod
-    def typeDefinition(cls, params: dict) -> 'Request':
-        return Request("textDocument/typeDefinition", params)
+    def rename(cls, params: dict, view: sublime.View) -> 'Request':
+        return Request("textDocument/rename", params, view)
 
     @classmethod
-    def declaration(cls, params: dict) -> 'Request':
-        return Request("textDocument/declaration", params)
+    def codeAction(cls, params: dict, view: sublime.View) -> 'Request':
+        return Request("textDocument/codeAction", params, view)
 
     @classmethod
-    def implementation(cls, params: dict) -> 'Request':
-        return Request("textDocument/implementation", params)
-
-    @classmethod
-    def rename(cls, params: dict) -> 'Request':
-        return Request("textDocument/rename", params)
-
-    @classmethod
-    def codeAction(cls, params: dict) -> 'Request':
-        return Request("textDocument/codeAction", params)
-
-    @classmethod
-    def documentColor(cls, params: dict) -> 'Request':
-        return Request('textDocument/documentColor', params)
+    def documentColor(cls, params: dict, view: sublime.View) -> 'Request':
+        return Request('textDocument/documentColor', params, view)
 
     @classmethod
     def executeCommand(cls, params: Mapping[str, Any]) -> 'Request':
@@ -97,28 +88,28 @@ class Request:
         return Request("workspace/symbol", params)
 
     @classmethod
-    def formatting(cls, params: dict) -> 'Request':
-        return Request("textDocument/formatting", params)
+    def formatting(cls, params: dict, view: sublime.View) -> 'Request':
+        return Request("textDocument/formatting", params, view)
 
     @classmethod
-    def willSaveWaitUntil(cls, params: dict) -> 'Request':
-        return Request("textDocument/willSaveWaitUntil", params)
+    def willSaveWaitUntil(cls, params: dict, view: sublime.View) -> 'Request':
+        return Request("textDocument/willSaveWaitUntil", params, view)
 
     @classmethod
-    def rangeFormatting(cls, params: dict) -> 'Request':
-        return Request("textDocument/rangeFormatting", params)
+    def rangeFormatting(cls, params: dict, view: sublime.View) -> 'Request':
+        return Request("textDocument/rangeFormatting", params, view)
 
     @classmethod
-    def documentSymbols(cls, params: dict) -> 'Request':
-        return Request("textDocument/documentSymbol", params)
+    def documentSymbols(cls, params: dict, view: sublime.View) -> 'Request':
+        return Request("textDocument/documentSymbol", params, view)
 
     @classmethod
-    def documentHighlight(cls, params: dict) -> 'Request':
-        return Request("textDocument/documentHighlight", params)
+    def documentHighlight(cls, params: dict, view: sublime.View) -> 'Request':
+        return Request("textDocument/documentHighlight", params, view)
 
     @classmethod
-    def resolveCompletionItem(cls, params: dict) -> 'Request':
-        return Request("completionItem/resolve", params)
+    def resolveCompletionItem(cls, params: dict, view: sublime.View) -> 'Request':
+        return Request("completionItem/resolve", params, view)
 
     @classmethod
     def shutdown(cls) -> 'Request':

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -263,7 +263,7 @@ def will_save(file_name: str, reason: int) -> Notification:
 
 
 def will_save_wait_until(view: sublime.View, reason: int) -> Request:
-    return Request.willSaveWaitUntil(will_save_text_document_params(view, reason))
+    return Request.willSaveWaitUntil(will_save_text_document_params(view, reason), view)
 
 
 def did_save(view: sublime.View, include_text: bool, file_name: Optional[str] = None) -> Notification:
@@ -296,7 +296,7 @@ def text_document_formatting(view: sublime.View) -> Request:
     return Request.formatting({
         "textDocument": text_document_identifier(view),
         "options": formatting_options(view.settings())
-    })
+    }, view)
 
 
 def text_document_range_formatting(view: sublime.View, region: sublime.Region) -> Request:
@@ -304,7 +304,7 @@ def text_document_range_formatting(view: sublime.View, region: sublime.Region) -
         "textDocument": text_document_identifier(view),
         "options": formatting_options(view.settings()),
         "range": region_to_range(view, region).to_lsp()
-    })
+    }, view)
 
 
 def did_change_configuration(d: DottedDict, variables: Dict[str, str]) -> Notification:

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -373,7 +373,8 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             self.purge_changes_async()
             params = text_document_position_params(self.view, pos)
             assert session
-            session.send_request(Request.signatureHelp(params), lambda resp: self._on_signature_help(resp, pos))
+            session.send_request(
+                Request.signatureHelp(params, self.view), lambda resp: self._on_signature_help(resp, pos))
         else:
             # TODO: Refactor popup usage to a common class. We now have sigHelp, completionDocs, hover, and diags
             # all using a popup. Most of these systems assume they have exclusive access to a popup, while in
@@ -461,7 +462,8 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
     def _do_color_boxes_async(self) -> None:
         session = self.session("colorProvider")
         if session:
-            session.send_request(Request.documentColor(document_color_params(self.view)), self._on_color_boxes)
+            session.send_request(
+                Request.documentColor(document_color_params(self.view), self.view), self._on_color_boxes)
 
     def _on_color_boxes(self, response: Any) -> None:
         color_infos = response if response else []
@@ -488,7 +490,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         session = self.session("documentHighlightProvider", point)
         if session:
             params = text_document_position_params(self.view, point)
-            request = Request.documentHighlight(params)
+            request = Request.documentHighlight(params, self.view)
             session.send_request(request, self._on_highlights)
 
     def _on_highlights(self, response: Optional[List]) -> None:
@@ -522,7 +524,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         can_resolve_completion_items = bool(session.get_capability('completionProvider.resolveProvider'))
         config_name = session.config.name
         session.send_request(
-            Request.complete(text_document_position_params(self.view, location)),
+            Request.complete(text_document_position_params(self.view, location), self.view),
             lambda res: self._on_complete_result(res, promise, can_resolve_completion_items, config_name),
             lambda res: self._on_complete_error(res, promise))
 

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -23,9 +23,6 @@ class LspExecuteCommand(LspTextCommand):
             return
         session = self.session_by_name(session_name) if session_name else self.best_session(self.capability)
         if session and command_name:
-            window = self.view.window()
-            if window:
-                window.status_message("Running command {}".format(command_name))
             if command_args:
                 self._expand_variables(command_args)
             self._send_command(session, command_name, command_args)

--- a/plugin/goto.py
+++ b/plugin/goto.py
@@ -49,7 +49,7 @@ class LspGotoCommand(LspTextCommand):
         session = self.best_session(self.capability)
         if session:
             pos = get_position(self.view, event)
-            request = Request(self.method, text_document_position_params(self.view, pos))
+            request = Request(self.method, text_document_position_params(self.view, pos), self.view)
             session.send_request(request, lambda response: self.handle_response(response, side_by_side))
 
     def handle_response(self, response: Any, side_by_side: bool) -> None:

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -87,7 +87,7 @@ class LspHoverCommand(LspTextCommand):
         if session:
             document_position = text_document_position_params(self.view, point)
             session.send_request(
-                Request.hover(document_position),
+                Request.hover(document_position, self.view),
                 lambda response: self.handle_response(response, point))
 
     def handle_code_actions(self, responses: Dict[str, List[CodeActionOrCommand]], point: int) -> None:

--- a/plugin/references.py
+++ b/plugin/references.py
@@ -55,7 +55,7 @@ class LspSymbolReferencesCommand(LspTextCommand):
 
             document_position = text_document_position_params(self.view, pos)
             document_position['context'] = {"includeDeclaration": False}
-            request = Request.references(document_position)
+            request = Request.references(document_position, self.view)
             session.send_request(request, lambda response: self.handle_response(response, pos))
 
     def handle_response(self, response: Optional[List[ReferenceDict]], pos: int) -> None:

--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -71,7 +71,7 @@ class LspSymbolRenameCommand(LspTextCommand):
                 session = self.best_session("{}.prepareProvider".format(self.capability))
                 if session:
                     params = text_document_position_params(self.view, get_position(self.view, event))
-                    request = Request("textDocument/prepareRename", params)
+                    request = Request.prepareRename(params, self.view)
                     session.send_request(request, self.on_prepare_result, self.on_prepare_error)
                     self.event = event
                 else:
@@ -89,7 +89,7 @@ class LspSymbolRenameCommand(LspTextCommand):
         if session:
             params = text_document_position_params(self.view, position)
             params["newName"] = new_name
-            session.send_request(Request.rename(params), self.on_rename_result)
+            session.send_request(Request.rename(params, self.view), self.on_rename_result)
 
     def on_rename_result(self, response: Any) -> None:
         window = self.view.window()

--- a/plugin/symbols.py
+++ b/plugin/symbols.py
@@ -83,7 +83,7 @@ class LspDocumentSymbolsCommand(LspTextCommand):
         session = self.best_session(self.capability)
         if session:
             session.send_request(
-                Request.documentSymbols({"textDocument": text_document_identifier(self.view)}),
+                Request.documentSymbols({"textDocument": text_document_identifier(self.view)}, self.view),
                 lambda response: sublime.set_timeout(lambda: self.handle_response(response)),
                 lambda error: sublime.set_timeout(lambda: self.handle_response_error(error)))
 
@@ -217,7 +217,6 @@ class LspWorkspaceSymbolsCommand(LspTextCommand):
         if symbol_query_input:
             session = self.best_session(self.capability)
             if session:
-                self.view.set_status("lsp_workspace_symbols", "Searching for '{}'...".format(symbol_query_input))
                 request = Request.workspaceSymbol({"query": symbol_query_input})
                 session.send_request(request, lambda r: self._handle_response(
                     symbol_query_input, r), self._handle_error)
@@ -236,7 +235,6 @@ class LspWorkspaceSymbolsCommand(LspTextCommand):
                 window.open_file(location_to_encoded_filename(symbol['location']), sublime.ENCODED_POSITION)
 
     def _handle_response(self, query: str, response: Optional[List[Dict[str, Any]]]) -> None:
-        self.view.erase_status("lsp_workspace_symbols")
         if response:
             matches = response
             window = self.view.window()
@@ -246,7 +244,6 @@ class LspWorkspaceSymbolsCommand(LspTextCommand):
             sublime.message_dialog("No matches found for query string: '{}'".format(query))
 
     def _handle_error(self, error: Dict[str, Any]) -> None:
-        self.view.erase_status("lsp_workspace_symbols")
         reason = error.get("message", "none provided by server :(")
         msg = "command 'workspace/symbol' failed. Reason: {}".format(reason)
         sublime.error_message(msg)


### PR DESCRIPTION
We can now also show the active requests in the status bar.
It looks a bit frantic without a delay so I've added a delay of 100ms.

As an added bonus the "$test" requests also show up in the tests.