### PR TITLE
Expose language_id on SessionBufferProtocol

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,9 +65,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
       - run: echo ::add-path::$HOME/.local/bin
       - run: sudo apt update
-      - run: sudo apt install --no-install-recommends -y x11-xserver-utils python3-pip
+      - run: sudo apt install --no-install-recommends -y x11-xserver-utils
       - run: pip3 install mypy==0.781 flake8==3.8.3 yapf==0.30.0 --user
       - run: mypy -p plugin
       - run: flake8 plugin tests

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -5,6 +5,7 @@ from .core.protocol import WorkspaceFolder
 from .core.sessions import AbstractPlugin
 from .core.sessions import register_plugin
 from .core.sessions import Session
+from .core.sessions import SessionBufferProtocol
 from .core.sessions import unregister_plugin
 from .core.types import ClientConfig
 from .core.types import LanguageConfig
@@ -21,6 +22,7 @@ __all__ = [
     'Request',
     'Response',
     'Session',
+    'SessionBufferProtocol'
     'unregister_plugin',
     'WorkspaceFolder',
 ]

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -22,7 +22,7 @@ __all__ = [
     'Request',
     'Response',
     'Session',
-    'SessionBufferProtocol'
+    'SessionBufferProtocol',
     'unregister_plugin',
     'WorkspaceFolder',
 ]

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -851,9 +851,6 @@ class Session(TransportCallbacks):
         for requested_item in requested_items:
             configuration = self.config.settings.copy(requested_item.get('section') or None)
             if self._plugin:
-                buffer_view = self.get_session_buffer_for_uri_async(requested_item['scopeUri'])
-                if buffer_view:
-                    requested_item['languageId'] = buffer_view.language_id
                 self._plugin.on_workspace_configuration(requested_item, configuration)
             items.append(configuration)
         self.send_response(Response(request_id, sublime.expand_variables(items, self._template_variables())))

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -449,6 +449,19 @@ class AbstractPlugin(metaclass=ABCMeta):
         """
         return None
 
+    def get_view_for_uri(self, uri: str) -> Optional[SessionBufferProtocol]:
+        """
+        Return the view for the requested URI.
+
+        :param    uri:  The URI to get view for
+
+        :returns: An optional view if found for URI.
+        """
+        session = self.weaksession()
+        if session:
+            return session.get_session_buffer_for_uri_async(uri)
+        return None
+
 
 _plugins = {}  # type: Dict[str, Type[AbstractPlugin]]
 
@@ -851,9 +864,6 @@ class Session(TransportCallbacks):
         for requested_item in requested_items:
             configuration = self.config.settings.copy(requested_item.get('section') or None)
             if self._plugin:
-                buffer_view = self.get_session_buffer_for_uri_async(requested_item['scopeUri'])
-                if buffer_view:
-                    requested_item['languageId'] = buffer_view.language_id
                 self._plugin.on_workspace_configuration(requested_item, configuration)
             items.append(configuration)
         self.send_response(Response(request_id, sublime.expand_variables(items, self._template_variables())))

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -449,19 +449,6 @@ class AbstractPlugin(metaclass=ABCMeta):
         """
         return None
 
-    def get_view_for_uri(self, uri: str) -> Optional[SessionBufferProtocol]:
-        """
-        Return the view for the requested URI.
-
-        :param    uri:  The URI to get view for
-
-        :returns: An optional view if found for URI.
-        """
-        session = self.weaksession()
-        if session:
-            return session.get_session_buffer_for_uri_async(uri)
-        return None
-
 
 _plugins = {}  # type: Dict[str, Type[AbstractPlugin]]
 
@@ -864,6 +851,9 @@ class Session(TransportCallbacks):
         for requested_item in requested_items:
             configuration = self.config.settings.copy(requested_item.get('section') or None)
             if self._plugin:
+                buffer_view = self.get_session_buffer_for_uri_async(requested_item['scopeUri'])
+                if buffer_view:
+                    requested_item['languageId'] = buffer_view.language_id
                 self._plugin.on_workspace_configuration(requested_item, configuration)
             items.append(configuration)
         self.send_response(Response(request_id, sublime.expand_variables(items, self._template_variables())))

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -281,6 +281,7 @@ class SessionBufferProtocol(Protocol):
     session = None  # type: Session
     session_views = None  # type: WeakSet[SessionViewProtocol]
     file_name = None  # type: str
+    language_id = None  # type: str
 
     def register_capability_async(
         self,
@@ -850,6 +851,9 @@ class Session(TransportCallbacks):
         for requested_item in requested_items:
             configuration = self.config.settings.copy(requested_item.get('section') or None)
             if self._plugin:
+                buffer_view = self.get_session_buffer_for_uri_async(requested_item['scopeUri'])
+                if buffer_view:
+                    requested_item['languageId'] = buffer_view.language_id
                 self._plugin.on_workspace_configuration(requested_item, configuration)
             items.append(configuration)
         self.send_response(Response(request_id, sublime.expand_variables(items, self._template_variables())))

--- a/plugin/core/typing.py
+++ b/plugin/core/typing.py
@@ -12,6 +12,7 @@ if sys.version_info >= (3, 5, 0):
     from typing import Iterable
     from typing import Iterator
     from typing import List
+    from typing import Literal
     from typing import Mapping
     from typing import Optional
     from typing import Set
@@ -72,6 +73,9 @@ else:
         pass
 
     class List(Type):  # type: ignore
+        pass
+
+    class Literal(Type):  # type: ignore
         pass
 
     class Mapping(Type):  # type: ignore

--- a/plugin/core/typing.py
+++ b/plugin/core/typing.py
@@ -1,6 +1,6 @@
 import sys
 
-if sys.version_info >= (3, 5, 0):
+if sys.version_info >= (3, 8, 0):
 
     from mypy_extensions import TypedDict
     from typing import Any


### PR DESCRIPTION
To fix https://github.com/sublimelsp/LSP-eslint/issues/36 I need to have
access to the "languageId" of the file that the server is requesting
configuration for.

~~This changes the "params" object so its schema will no longer match
the LSP spec but then it was nowhere stated that the params passed to
on_workspace_configuration() were matching the spec.~~