### PR TITLE
Also restart all servers when the project was saved.

### DIFF
--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -150,6 +150,9 @@ class Listener(sublime_plugin.EventListener):
     def on_load_project_async(self, w: sublime.Window) -> None:
         windows.lookup(w).on_load_project_async()
 
+    def on_post_save_project_async(self, w: sublime.Window) -> None:
+        windows.lookup(w).on_post_save_project_async()
+
     def on_new_window_async(self, w: sublime.Window) -> None:
         sublime.set_timeout(lambda: windows.lookup(w))
 

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -125,6 +125,9 @@ class WindowManager(Manager):
         self._workspace.update()
         self._configs.update()
 
+    def on_post_save_project_async(self) -> None:
+        self.on_load_project_async()
+
     def enable_config_async(self, config_name: str) -> None:
         enable_in_project(self._window, config_name)
         # TODO: Why doesn't enable_in_project cause on_load_project_async to be called?


### PR DESCRIPTION
We don't really know if there were folders added/removed. We also
don't know what settings were changed. Better to be on the safe side and
restart everything. We can always optimize later.