### PR TITLE
Improvements for debug logging

### DIFF
--- a/plugin/core/logging.py
+++ b/plugin/core/logging.py
@@ -5,17 +5,11 @@ import sublime
 
 
 log_debug = False
-log_exceptions = True
 
 
 def set_debug_logging(logging_enabled: bool) -> None:
     global log_debug
     log_debug = logging_enabled
-
-
-def set_exception_logging(logging_enabled: bool) -> None:
-    global log_exceptions
-    log_exceptions = logging_enabled
 
 
 def debug(*args: Any) -> None:
@@ -36,10 +30,9 @@ def trace() -> None:
 
 
 def exception_log(message: str, ex: Exception) -> None:
-    if log_exceptions:
-        print(message)
-        ex_traceback = ex.__traceback__
-        print(''.join(traceback.format_exception(ex.__class__, ex, ex_traceback)))
+    print(message)
+    ex_traceback = ex.__traceback__
+    print(''.join(traceback.format_exception(ex.__class__, ex, ex_traceback)))
 
 
 def printf(*args: Any, prefix: str = 'LSP') -> None:

--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -5,7 +5,6 @@ from .collections import DottedDict
 from .css import load as load_css
 from .css import unload as unload_css
 from .handlers import LanguageHandler
-from .logging import set_debug_logging, set_exception_logging
 from .panels import destroy_output_panels
 from .promise import opening_files
 from .protocol import Response
@@ -113,8 +112,6 @@ def _forcefully_register_plugins() -> None:
 def plugin_loaded() -> None:
     load_settings()
     load_css()
-    set_debug_logging(userprefs().log_debug)
-    set_exception_logging(True)
     _forcefully_register_plugins()  # Remove this function: https://github.com/sublimelsp/LSP/issues/899
     client_configs.update_configs()
 

--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -17,7 +17,6 @@ from .sessions import Session
 from .settings import client_configs
 from .settings import load_settings
 from .settings import unload_settings
-from .settings import userprefs
 from .transports import kill_all_subprocesses
 from .types import ClientConfig
 from .typing import Optional, List, Type, Callable, Dict, Tuple

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -1,5 +1,5 @@
 from .collections import DottedDict
-from .logging import debug
+from .logging import debug, set_debug_logging
 from .protocol import TextDocumentSyncKindNone
 from .typing import Any, Optional, List, Dict, Generator, Callable, Iterable, Union, Set, TypeVar, Tuple
 from threading import RLock
@@ -209,6 +209,8 @@ class Settings:
         else:
             r("inhibit_snippet_completions", False)
             r("inhibit_word_completions", True)
+
+        set_debug_logging(self.log_debug)
 
     def show_diagnostics_panel_always(self) -> bool:
         return self.auto_show_diagnostics_panel == "always"


### PR DESCRIPTION
The log_debug setting is now respected when you change it in
the settings. No need to restart ST.

Also removed `set_exception_logging` because it is always on and hence useless.