### PR TITLE
Register and unregister plugins properly

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -113,7 +113,7 @@ def _register_all_plugins() -> None:
     plugin_classes = []  # type: List[Type[AbstractPlugin]]
     _get_final_subclasses(AbstractPlugin.__subclasses__(), plugin_classes)
     for plugin_class in plugin_classes:
-        register_plugin(plugin_class)
+        register_plugin(plugin_class, notify_listener=False)
     language_handler_classes = []  # type: List[Type[LanguageHandler]]
     _get_final_subclasses(LanguageHandler.__subclasses__(), language_handler_classes)
     for language_handler_class in language_handler_classes:
@@ -175,7 +175,7 @@ def _register_all_plugins() -> None:
                 if session:
                     session.send_response(response)
 
-        register_plugin(LanguageHandlerTransition)
+        register_plugin(LanguageHandlerTransition, notify_listener=False)
 
 
 def _unregister_all_plugins() -> None:

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -65,13 +65,13 @@ class WindowConfigManager(object):
     def update(self) -> None:
         project_settings = (self._window.project_data() or {}).get("settings", {}).get("LSP", {})
         self.all.clear()
-        for name in self._global_configs.keys():
-            config = self._global_configs[name]
-            overrides = project_settings.get(config.name)
+        for name, config in self._global_configs.items():
+            overrides = project_settings.get(name)
             if isinstance(overrides, dict):
-                debug('applying .sublime-project override for', config.name)
-                config = config.update(overrides)
-            self.all[name] = config
+                debug("applying .sublime-project override for", name)
+            else:
+                overrides = {}
+            self.all[name] = config.update(overrides)
         for name in self._temp_disabled_configs:
             self.all[name].enabled = False
         self._window.run_command("lsp_recheck_sessions")


### PR DESCRIPTION
Resolves #899 

Helper packages are encouraged to call register_plugin and unregister_plugin
in their plugin_loaded and plugin_unloaded callbacks, respectively.

There is a bug in Sublime Text's `plugin_loaded` callback. When the package is
in the list of `"ignored_packages"` in
Packages/User/Preferences.sublime-settings, and then removed from that list,
the sublime.Settings object has missing keys/values. To circumvent this, we run
the actual registration one tick later. At that point, the settings object is
fully loaded. At least, it seems that way. For more context,
see https://github.com/sublimehq/sublime_text/issues/3379
and https://github.com/sublimehq/sublime_text/issues/2099