### PR TITLE
use DRAW_EMPTY_AS_OVERWRITE for empty regions

### DIFF
--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -127,15 +127,9 @@ class SessionView:
                 self.view.erase_regions(key)
             elif ((severity <= userprefs().show_diagnostics_severity_level) and
                     (data.icon or flags != (sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE))):
-
-                def handle_same_regions(region: sublime.Region) -> sublime.Region:
-                    # this allows showing diagnostics with same begin and end in the view
-                    if region.a == region.b:
-                        return sublime.Region(region.a, region.a + 1)
-                    return region
-
-                underline_regions = list(map(handle_same_regions, data.regions))
-                self.view.add_regions(key, underline_regions, data.scope, data.icon, flags)
+                # allow showing diagnostics with same begin and end range in the view
+                flags |= sublime.DRAW_EMPTY_AS_OVERWRITE
+                self.view.add_regions(key, data.regions, data.scope, data.icon, flags)
             else:
                 self.view.erase_regions(key)
         listener = self.listener()

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -127,6 +127,7 @@ class SessionView:
                 self.view.erase_regions(key)
             elif ((severity <= userprefs().show_diagnostics_severity_level) and
                     (data.icon or flags != (sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE))):
+
                 def handle_same_regions(region: sublime.Region) -> sublime.Region:
                     # this allows showing diagnostics with same begin and end in the view
                     if region.a == region.b:

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -132,6 +132,7 @@ class SessionView:
                     if region.begin() == region.end():
                         return sublime.Region(region.begin(), region.begin() + 1)
                     return region
+
                 underline_regions = list(map(handle_same_regions, data.regions))
                 self.view.add_regions(key, underline_regions, data.scope, data.icon, flags)
             else:

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -127,13 +127,13 @@ class SessionView:
                 self.view.erase_regions(key)
             elif ((severity <= userprefs().show_diagnostics_severity_level) and
                     (data.icon or flags != (sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE))):
-                def handle_same_regions(region: sublime.Region):
+                def handle_same_regions(region: sublime.Region) -> sublime.Region:
                     # this allows showing diagnostics with same begin and end in the view
                     if region.begin() == region.end():
                         return sublime.Region(region.begin(), region.begin() + 1)
                     return region
-                data.regions = list(map(handle_same_regions, data.regions))
-                self.view.add_regions(key, data.regions, data.scope, data.icon, flags)
+                underline_regions = list(map(handle_same_regions, data.regions))
+                self.view.add_regions(key, underline_regions, data.scope, data.icon, flags)
             else:
                 self.view.erase_regions(key)
         listener = self.listener()

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -127,6 +127,12 @@ class SessionView:
                 self.view.erase_regions(key)
             elif ((severity <= userprefs().show_diagnostics_severity_level) and
                     (data.icon or flags != (sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE))):
+                def handle_same_regions(region: sublime.Region):
+                    # this allows showing diagnostics with same begin and end in the view
+                    if region.begin() == region.end():
+                        return sublime.Region(region.begin(), region.begin() + 1)
+                    return region
+                data.regions = list(map(handle_same_regions, data.regions))
                 self.view.add_regions(key, data.regions, data.scope, data.icon, flags)
             else:
                 self.view.erase_regions(key)

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -128,7 +128,7 @@ class SessionView:
             elif ((severity <= userprefs().show_diagnostics_severity_level) and
                     (data.icon or flags != (sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE))):
                 # allow showing diagnostics with same begin and end range in the view
-                flags |= sublime.DRAW_EMPTY_AS_OVERWRITE
+                flags |= sublime.DRAW_EMPTY
                 self.view.add_regions(key, data.regions, data.scope, data.icon, flags)
             else:
                 self.view.erase_regions(key)

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -129,8 +129,8 @@ class SessionView:
                     (data.icon or flags != (sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE))):
                 def handle_same_regions(region: sublime.Region) -> sublime.Region:
                     # this allows showing diagnostics with same begin and end in the view
-                    if region.begin() == region.end():
-                        return sublime.Region(region.begin(), region.begin() + 1)
+                    if region.a == region.b:
+                        return sublime.Region(region.a, region.a + 1)
                     return region
 
                 underline_regions = list(map(handle_same_regions, data.regions))


### PR DESCRIPTION
This is a follow up PR, based on feedback:
https://github.com/sublimelsp/LSP/pull/1371#discussion_r502964924

Current behavior (that was added with #1371):
![image](https://user-images.githubusercontent.com/22029477/95776001-c351b500-0cc3-11eb-8df6-ca7fefa5a734.png)


DRAW_EMPTY_AS_OVERWRITE:
![Screenshot from 2020-10-12 19-37-59](https://user-images.githubusercontent.com/22029477/95775955-aa490400-0cc3-11eb-9f0d-eee71d51d066.png)


DRAW_EMPTY:
![Screenshot from 2020-10-12 19-37-03](https://user-images.githubusercontent.com/22029477/95775944-a61ce680-0cc3-11eb-8672-11a5da32c47b.png)

---
I think the current behavior is ok, but I think that DRAW_EMPTY_AS_OVERWRITE is also ok.
I wouldn't go with DRAW_EMPTY because it is a vertical line.

The only disadvantage about the DRAW_EMPTY_AS_OVERWRITE is that the line in not squiggly, or a box, or whatever the user set in the LSP.sublime-settings file.
Someone could open an issue telling us that they set `"diagnostics_highlight_style": "box",` 
but they still see a line:
- notice the first line - **box**, 
- notice the line bellow `import Url exposing (Url`  - **line**
![image](https://user-images.githubusercontent.com/22029477/95776882-7373ed80-0cc5-11eb-89b0-6daf19593959.png)
 

Feel free to close this PR if you think that the current behavior is ok,
or feel free to merge this if you think that the behavior of DRAW_EMPTY_AS_OVERWRITE is ok. 