### PR TITLE
Replace version incompatibility dialog with a console message

### DIFF
--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -29,9 +29,9 @@ def plugin_loaded() -> None:
     if window:
         windows.lookup(window).start_active_views()
     if int(sublime.version()) > 4000:
-        sublime.error_message(
+        print(
             """The currently installed version of LSP package is not compatible with Sublime Text 4. """
-            """Please remove and reinstall this package to receive a version compatible with ST4. """
+            """It should get updated to ST4-compatible version automatically by Package Control. """
             """Remember to restart Sublime Text after.""")
 
 

--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -29,10 +29,9 @@ def plugin_loaded() -> None:
     if window:
         windows.lookup(window).start_active_views()
     if int(sublime.version()) > 4000:
-        print(
-            """The currently installed version of LSP package is not compatible with Sublime Text 4. """
-            """It should get updated to ST4-compatible version automatically by Package Control. """
-            """Remember to restart Sublime Text after.""")
+        print("""The currently installed version of LSP package is not compatible with Sublime Text 4. """
+              """It should get updated to ST4-compatible version automatically by Package Control. """
+              """Remember to restart Sublime Text after.""")
 
 
 def plugin_unloaded() -> None:


### PR DESCRIPTION
Latest version of Package Control is triggering update of packages
on updating to new ST version so there is no point in showing this
message now.