### PR TITLE
Fix Config tests

### DIFF
--- a/plugin/core/collections.py
+++ b/plugin/core/collections.py
@@ -143,3 +143,8 @@ class DottedDict:
 
     def __repr__(self) -> str:
         return "{}({})".format(self.__class__.__name__, repr(self._d))
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, DottedDict):
+            return False
+        return self._d == other._d

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -332,6 +332,17 @@ class LanguageConfig:
         return "{}(language_id={}, document_selector={}, feature_selector={})".format(
             self.__class__.__name__, repr(self.id), repr(self.document_selector), repr(self.feature_selector))
 
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, LanguageConfig):
+            return False
+        return self.id == other.id \
+            and self.document_selector == other.document_selector \
+            and self.feature_selector == other.feature_selector
+
+    def __hash__(self) -> int:
+        # needed for functools.lru_cache
+        return hash(id(self))
+
 
 # method -> (capability dotted path, optional registration dotted path)
 # these are the EXCEPTIONS. The general rule is: method foo/bar --> (barProvider, barProvider.id)
@@ -589,8 +600,16 @@ class ClientConfig:
         items = []  # type: List[str]
         for k, v in self.__dict__.items():
             if not k.startswith("_"):
-                items.append("{}={}".format(k, repr(getattr(self, k))))
+                items.append("{}={}".format(k, repr(v)))
         return "{}({})".format(self.__class__.__name__, ", ".join(items))
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, ClientConfig):
+            return False
+        for k, v in self.__dict__.items():
+            if not k.startswith("_") and v != getattr(other, k):
+                return False
+        return True
 
 
 def syntax2scope(syntax_path: str) -> Optional[str]:


### PR DESCRIPTION
The tests for Config relied on a notion of equality. They implicitly relied
on equality of `id` (memory addresses). But now that we always create a new
Config in the WindowManager whether there is an override or not, this did
not work any longer. To solve this, we define what equality means.