### PR TITLE
Re-read workspace folders on starting a server

### DIFF
--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -383,6 +383,9 @@ class WorkspaceFolder:
     def from_path(cls, path: str) -> 'WorkspaceFolder':
         return cls(os.path.basename(path) or path, path)
 
+    def __hash__(self) -> int:
+        return hash((self.name, self.path))
+
     def __repr__(self) -> str:
         return "{}('{}', '{}')".format(self.__class__.__name__, self.name, self.path)
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -770,6 +770,9 @@ class Session(TransportCallbacks):
     def should_notify_did_change(self) -> bool:
         return self.capabilities.should_notify_did_change()
 
+    def should_notify_did_change_workspace_folders(self) -> bool:
+        return self.capabilities.should_notify_did_change_workspace_folders()
+
     def should_notify_will_save(self) -> bool:
         return self.capabilities.should_notify_will_save()
 
@@ -799,16 +802,18 @@ class Session(TransportCallbacks):
     def update_folders(self, folders: List[WorkspaceFolder]) -> None:
         if self.should_notify_did_change_workspace_folders():
             added, removed = diff(self._workspace_folders, folders)
-            params = {
-                "event": {
-                    "added": [a.to_lsp() for a in added],
-                    "removed": [r.to_lsp() for r in removed]
+            if added or removed:
+                params = {
+                    "event": {
+                        "added": [a.to_lsp() for a in added],
+                        "removed": [r.to_lsp() for r in removed]
+                    }
                 }
-            }
-            notification = Notification.didChangeWorkspaceFolders(params)
-            self.send_notification(notification)
+                self.send_notification(Notification.didChangeWorkspaceFolders(params))
         if self._supports_workspace_folders():
             self._workspace_folders = folders
+        else:
+            self._workspace_folders = folders[:1]
 
     def initialize(self, variables: Dict[str, str], transport: Transport, init_callback: InitCallback) -> None:
         self.transport = transport

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -480,6 +480,9 @@ class Capabilities(DottedDict):
     def should_notify_did_change(self) -> bool:
         return self.text_sync_kind() > TextDocumentSyncKindNone
 
+    def should_notify_did_change_workspace_folders(self) -> bool:
+        return "workspace.workspaceFolders.changeNotifications" in self
+
     def should_notify_will_save(self) -> bool:
         return "textDocumentSync.willSave" in self
 

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -122,11 +122,17 @@ class WindowManager(Manager):
         return self._configs
 
     def on_load_project_async(self) -> None:
-        self._workspace.update()
+        self.update_workspace_folders_async()
         self._configs.update()
 
     def on_post_save_project_async(self) -> None:
         self.on_load_project_async()
+
+    def update_workspace_folders_async(self) -> None:
+        if self._workspace.update():
+            workspace_folders = self._workspace.get_workspace_folders()
+            for session in self._sessions:
+                session.update_folders(workspace_folders)
 
     def enable_config_async(self, config_name: str) -> None:
         enable_in_project(self._window, config_name)
@@ -143,10 +149,10 @@ class WindowManager(Manager):
 
     def register_listener_async(self, listener: AbstractViewListener) -> None:
         set_diagnostics_count(listener.view, self.total_error_count, self.total_warning_count)
-        self._pending_listeners.appendleft(listener)
         # Update workspace folders in case the user have changed those since window was created.
         # There is no currently no notification in ST that would notify about folder changes.
-        self._workspace.update()
+        self.update_workspace_folders_async()
+        self._pending_listeners.appendleft(listener)
         if self._new_listener is None:
             self._dequeue_listener_async()
 

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -243,6 +243,9 @@ class WindowManager(Manager):
             # debug('Already starting on this window:', config.name)
             return
         try:
+            # Update folders in case those have been changed by the user. There is no currently
+            # no notification in ST that would notify about changed folder list.
+            self._workspace.update()
             workspace_folders = sorted_workspace_folders(self._workspace.folders, file_path)
             plugin_class = get_plugin(config.name)
             if plugin_class is not None:

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -144,6 +144,9 @@ class WindowManager(Manager):
     def register_listener_async(self, listener: AbstractViewListener) -> None:
         set_diagnostics_count(listener.view, self.total_error_count, self.total_warning_count)
         self._pending_listeners.appendleft(listener)
+        # Update workspace folders in case the user have changed those since window was created.
+        # There is no currently no notification in ST that would notify about folder changes.
+        self._workspace.update()
         if self._new_listener is None:
             self._dequeue_listener_async()
 
@@ -243,9 +246,6 @@ class WindowManager(Manager):
             # debug('Already starting on this window:', config.name)
             return
         try:
-            # Update folders in case those have been changed by the user. There is no currently
-            # no notification in ST that would notify about changed folder list.
-            self._workspace.update()
             workspace_folders = sorted_workspace_folders(self._workspace.folders, file_path)
             plugin_class = get_plugin(config.name)
             if plugin_class is not None:


### PR DESCRIPTION
This is a workaround for a case when user changes workspace folders
manually for which ST provides no notification. We'll just re-read set
folders every time the user starts any server.

Resolves #1374