### PR TITLE
Tests: start and stop session at the TestCase level

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -2,14 +2,11 @@ from LSP.plugin.core.promise import Promise
 from LSP.plugin.core.logging import debug
 from LSP.plugin.core.protocol import Notification, Request
 from LSP.plugin.core.registry import windows
-from LSP.plugin.core.sessions import Session
 from LSP.plugin.core.settings import client_configs
 from LSP.plugin.core.types import ClientConfig, LanguageConfig, ClientStates
 from LSP.plugin.core.typing import Any, Generator, List, Optional, Tuple, Union, Dict
-from LSP.plugin.documents import DocumentSyncListener
 from os import environ
 from os.path import join
-from sublime_plugin import view_event_listeners
 from test_mocks import basic_responses
 from unittesting import DeferrableTestCase
 import sublime
@@ -81,56 +78,53 @@ def expand(s: str, w: sublime.Window) -> str:
     return sublime.expand_variables(s, w.extract_variables())
 
 
-class SessionType:
-    Stdio = 1
-    TcpCreate = 2
-    TcpConnectExisting = 3
-
-
 class TextDocumentTestCase(DeferrableTestCase):
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self.session = None  # type: Optional[Session]
-        # kwargs["tcp"] = True
-        self.config = make_tcp_test_config() if kwargs.get("tcp") else make_stdio_test_config()
-
-    def setUp(self) -> 'Generator':
-        super().setUp()
-        test_name = self.get_test_name()
-        server_capabilities = self.get_test_server_capabilities()
-        self.assertTrue(test_name)
-        self.assertTrue(server_capabilities)
+    @classmethod
+    def setUpClass(cls) -> Generator:
+        super().setUpClass()
+        test_name = cls.get_test_name()
+        server_capabilities = cls.get_test_server_capabilities()
         window = sublime.active_window()
-        self.assertTrue(window)
-        self.config.init_options.set("serverResponse", server_capabilities)
-        add_config(self.config)
-        self.wm = windows.lookup(window)
         filename = expand(join("$packages", "LSP", "tests", "{}.txt".format(test_name)), window)
         open_view = window.find_open_file(filename)
         close_test_view(open_view)
-        self.view = window.open_file(filename)
-        yield {"condition": lambda: not self.view.is_loading(), "timeout": TIMEOUT_TIME}
-        self.assertTrue(self.wm._configs.match_view(self.view))
-        self.init_view_settings()
-        yield {"condition": self.ensure_document_listener_created, "timeout": TIMEOUT_TIME}
+        cls.config = make_stdio_test_config()
+        cls.config.init_options.set("serverResponse", server_capabilities)
+        add_config(cls.config)
+        cls.wm = windows.lookup(window)
+        cls.view = window.open_file(filename)
+        yield {"condition": lambda: not cls.view.is_loading(), "timeout": TIMEOUT_TIME}
         yield {
-            "condition": lambda: self.wm.get_session(self.config.name, self.view.file_name()) is not None,
+            "condition": lambda: cls.wm.get_session(cls.config.name, cls.view.file_name()) is not None,
             "timeout": TIMEOUT_TIME}
-        self.session = self.wm.get_session(self.config.name, self.view.file_name())
-        self.assertIsNotNone(self.session)
-        self.assertEqual(self.session.config.name, self.config.name)
-        yield {"condition": lambda: self.session.state == ClientStates.READY, "timeout": TIMEOUT_TIME}
-        yield from self.await_boilerplate_begin()
+        cls.session = cls.wm.get_session(cls.config.name, cls.view.file_name())
+        yield {"condition": lambda: cls.session.state == ClientStates.READY, "timeout": TIMEOUT_TIME}
+        yield from cls.await_message("initialize")
+        yield from cls.await_message("initialized")
 
-    def get_test_name(self) -> str:
+    def setUp(self) -> Generator:
+        window = sublime.active_window()
+        filename = expand(join("$packages", "LSP", "tests", "{}.txt".format(self.get_test_name())), window)
+        open_view = window.find_open_file(filename)
+        if not open_view:
+            self.__class__.view = window.open_file(filename)
+            yield {"condition": lambda: not self.view.is_loading(), "timeout": TIMEOUT_TIME}
+            self.assertTrue(self.wm._configs.match_view(self.view))
+        self.init_view_settings()
+        yield from self.await_message("textDocument/didOpen")
+
+    @classmethod
+    def get_test_name(cls) -> str:
         return "testfile"
 
-    def get_test_server_capabilities(self) -> dict:
+    @classmethod
+    def get_test_server_capabilities(cls) -> dict:
         return basic_responses["initialize"]
 
-    def init_view_settings(self) -> None:
-        s = self.view.settings().set
+    @classmethod
+    def init_view_settings(cls) -> None:
+        s = cls.view.settings().set
         s("auto_complete_selector", "text")
         s("ensure_newline_at_eof_on_save", False)
         s("rulers", [])
@@ -139,19 +133,8 @@ class TextDocumentTestCase(DeferrableTestCase):
         s("word_wrap", False)
         s("lsp_format_on_save", False)
 
-    def ensure_document_listener_created(self) -> bool:
-        assert self.view
-        # Bug in ST3? Either that, or CI runs with ST window not in focus and that makes ST3 not trigger some
-        # events like on_load_async, on_activated, on_deactivated. That makes things not properly initialize on
-        # opening file (manager missing in DocumentSyncListener)
-        # Revisit this once we're on ST4.
-        for listener in view_event_listeners[self.view.id()]:
-            if isinstance(listener, DocumentSyncListener):
-                sublime.set_timeout_async(listener.on_activated_async)
-                return True
-        return False
-
-    def await_message(self, method: str, promise: Optional[YieldPromise] = None) -> 'Generator':
+    @classmethod
+    def await_message(cls, method: str, promise: Optional[YieldPromise] = None) -> 'Generator':
         """
         Awaits until server receives a request with a specified method.
 
@@ -164,19 +147,19 @@ class TextDocumentTestCase(DeferrableTestCase):
 
         :returns:   A generator with resolved value.
         """
-        self.assertIsNotNone(self.session)
-        assert self.session  # mypy
+        # cls.assertIsNotNone(cls.session)
+        assert cls.session  # mypy
         if promise is None:
             promise = YieldPromise()
 
         def handler(params: Any) -> None:
             promise.fulfill(params)
 
-        def error_handler(params: 'Any') -> None:
+        def error_handler(params: Any) -> None:
             debug("Got error:", params, "awaiting timeout :(")
 
-        self.session.send_request(Request("$test/getReceived", {"method": method}), handler, error_handler)
-        yield from self.await_promise(promise)
+        cls.session.send_request(Request("$test/getReceived", {"method": method}), handler, error_handler)
+        yield from cls.await_promise(promise)
         return promise.result()
 
     def make_server_do_fake_request(self, method: str, params: Any) -> YieldPromise:
@@ -192,6 +175,7 @@ class TextDocumentTestCase(DeferrableTestCase):
         self.session.send_request(req, on_result, on_error)
         return promise
 
+    @classmethod
     def await_promise(self, promise: Union[YieldPromise, Promise]) -> Generator:
         if isinstance(promise, YieldPromise):
             yielder = promise
@@ -205,14 +189,10 @@ class TextDocumentTestCase(DeferrableTestCase):
         sublime.set_timeout_async(lambda: self.session.run_code_action_async(code_action).then(promise.fulfill))
         yield from self.await_promise(promise)
 
-    def set_response(self, method: str, response: 'Any') -> None:
+    def set_response(self, method: str, response: Any) -> None:
         self.assertIsNotNone(self.session)
         assert self.session  # mypy
-        sublime.set_timeout_async(
-            lambda: self.session.send_notification(
-                Notification("$test/setResponse", {"method": method, "response": response})
-            )
-        )
+        self.session.send_notification(Notification("$test/setResponse", {"method": method, "response": response}))
 
     def set_responses(self, responses: List[Tuple[str, Any]]) -> Generator:
         self.assertIsNotNone(self.session)
@@ -244,18 +224,6 @@ class TextDocumentTestCase(DeferrableTestCase):
         self.session.send_request(req, handler, error_handler)
         yield from self.await_promise(promise)
 
-    def await_boilerplate_begin(self) -> 'Generator':
-        yield from self.await_message("initialize")
-        yield from self.await_message("initialized")
-        yield from self.await_message("textDocument/didOpen")
-
-    def await_boilerplate_end(self) -> 'Generator':
-        if self.session:
-            sublime.set_timeout_async(self.session.end_async)
-            yield lambda: self.session.state == ClientStates.STOPPING
-            if self.view:
-                yield lambda: self.wm.get_session(self.config.name, self.view.file_name()) is None
-
     def await_clear_view_and_save(self) -> 'Generator':
         assert self.view  # type: Optional[sublime.View]
         self.view.run_command("select_all")
@@ -281,15 +249,20 @@ class TextDocumentTestCase(DeferrableTestCase):
         self.view.run_command("insert", {"characters": characters})
         return self.view.change_count()
 
-    def tearDown(self) -> 'Generator':
-        yield from self.await_boilerplate_end()
-        super().tearDown()
+    @classmethod
+    def tearDownClass(cls) -> 'Generator':
+        if cls.session and cls.wm:
+            sublime.set_timeout_async(cls.session.end_async)
+            yield lambda: cls.session.state == ClientStates.STOPPING
+            if cls.view:
+                yield lambda: cls.wm.get_session(cls.config.name, cls.view.file_name()) is None
+        cls.session = None
+        cls.wm = None
+        # restore the user's configs
+        remove_config(cls.config)
+        super().tearDownClass()
 
     def doCleanups(self) -> 'Generator':
-        # restore the user's configs
-        try:
+        if self.view and self.view.is_valid():
             close_test_view(self.view)
-        except Exception as ex:
-            print("exception:", str(ex))
-        remove_config(self.config)
         yield from super().doCleanups()

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -2,7 +2,6 @@ from LSP.plugin.core.promise import Promise
 from LSP.plugin.core.logging import debug
 from LSP.plugin.core.protocol import Notification, Request
 from LSP.plugin.core.registry import windows
-from LSP.plugin.core.sessions import Session
 from LSP.plugin.core.settings import client_configs
 from LSP.plugin.core.types import ClientConfig, LanguageConfig, ClientStates
 from LSP.plugin.core.typing import Any, Generator, List, Optional, Tuple, Union, Dict

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -27,10 +27,11 @@ additional_edits = {
 
 class QueryCompletionsTests(TextDocumentTestCase):
 
-    def init_view_settings(self) -> None:
+    @classmethod
+    def init_view_settings(cls) -> None:
         super().init_view_settings()
-        assert self.view
-        self.view.settings().set("auto_complete_selector", "text.plain")
+        assert cls.view
+        cls.view.settings().set("auto_complete_selector", "text.plain")
 
     def type(self, text: str) -> None:
         self.view.run_command('append', {'characters': text})

--- a/tests/test_single_document.py
+++ b/tests/test_single_document.py
@@ -51,10 +51,9 @@ class SingleDocumentTestCase(TextDocumentTestCase):
         pass
 
     def test_did_close(self) -> 'Generator':
-        assert self.view
-        self.view.set_scratch(True)
+        self.assertTrue(self.view)
+        self.assertTrue(self.view.is_valid())
         self.view.close()
-        self.view = None
         yield from self.await_message("textDocument/didClose")
 
     def test_did_change(self) -> 'Generator':
@@ -331,7 +330,8 @@ class SingleDocumentTestCase(TextDocumentTestCase):
 
 class WillSaveWaitUntilTestCase(TextDocumentTestCase):
 
-    def get_test_server_capabilities(self) -> dict:
+    @classmethod
+    def get_test_server_capabilities(cls) -> dict:
         capabilities = deepcopy(super().get_test_server_capabilities())
         capabilities['capabilities']['textDocumentSync']['willSaveWaitUntil'] = True
         return capabilities


### PR DESCRIPTION
The tests run in turbo mode now :) It takes about ~17 seconds to run the ~200 tests. Old time is about ~32 seconds here.

I also removed the `ensure_document_listener_created` method. I don't think this is necessary anymore.