### PR TITLE
Remove is_at_word function

### DIFF
--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -9,7 +9,6 @@ from .core.protocol import DocumentHighlightKind
 from .core.protocol import Range
 from .core.protocol import Request
 from .core.registry import best_session
-from .core.registry import get_position
 from .core.registry import windows
 from .core.sessions import Session
 from .core.settings import userprefs
@@ -51,19 +50,6 @@ _kind2name = {
     DocumentHighlightKind.Read: "read",
     DocumentHighlightKind.Write: "write"
 }
-
-
-def is_at_word(view: sublime.View, event: Optional[dict], point: Optional[int]) -> bool:
-    pos = get_position(view, event, point)
-    return position_is_word(view, pos)
-
-
-def position_is_word(view: sublime.View, position: int) -> bool:
-    point_classification = view.classify(position)
-    if point_classification & SUBLIME_WORD_MASK:
-        return True
-    else:
-        return False
 
 
 def is_transient_view(view: sublime.View) -> bool:

--- a/plugin/goto.py
+++ b/plugin/goto.py
@@ -6,7 +6,6 @@ from .core.sessions import method_to_capability
 from .core.typing import List, Optional, Any
 from .core.views import location_to_encoded_filename
 from .core.views import text_document_position_params
-from .documents import is_at_word
 
 
 def open_location(window: sublime.Window, location: str, side_by_side: bool = True) -> None:
@@ -35,9 +34,6 @@ def highlight_entry(window: Optional[sublime.Window], locations: List[str], idx:
 class LspGotoCommand(LspTextCommand):
 
     method = ''
-
-    def is_enabled(self, event: Optional[dict] = None, point: Optional[int] = None) -> bool:
-        return super().is_enabled(event, point) and is_at_word(self.view, event, point)
 
     def run(
         self,

--- a/plugin/references.py
+++ b/plugin/references.py
@@ -12,7 +12,6 @@ from .core.settings import userprefs
 from .core.typing import List, Dict, Optional, Tuple, TypedDict
 from .core.url import uri_to_filename
 from .core.views import get_line, text_document_position_params
-from .documents import is_at_word
 
 ReferenceDict = TypedDict('ReferenceDict', {'uri': str, 'range': dict})
 
@@ -32,9 +31,6 @@ class LspSymbolReferencesCommand(LspTextCommand):
         self.word_region = None  # type: Optional[sublime.Region]
         self.word = ""
         self.base_dir = None  # type: Optional[str]
-
-    def is_enabled(self, event: Optional[dict] = None, point: Optional[int] = None) -> bool:
-        return super().is_enabled(event, point) and is_at_word(self.view, event, point)
 
     def run(self, edit: sublime.Edit, event: Optional[dict] = None, point: Optional[int] = None) -> None:
         session = self.best_session(self.capability)

--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -9,7 +9,6 @@ from .core.registry import LspTextCommand
 from .core.typing import Any, Optional
 from .core.views import range_to_region
 from .core.views import text_document_position_params
-from .documents import is_at_word
 
 
 class RenameSymbolInputHandler(sublime_plugin.TextInputHandler):
@@ -43,13 +42,6 @@ class RenameSymbolInputHandler(sublime_plugin.TextInputHandler):
 class LspSymbolRenameCommand(LspTextCommand):
 
     capability = 'renameProvider'
-
-    def is_enabled(self, event: Optional[dict] = None, point: Optional[int] = None) -> bool:
-        if self.best_session("renameProvider.prepareProvider"):
-            # The language server will tell us if the selection is on a valid token.
-            return True
-        # TODO: check what kind of scope we're in.
-        return super().is_enabled(event, point) and is_at_word(self.view, event, point)
 
     def input(self, args: dict) -> Optional[sublime_plugin.TextInputHandler]:
         if "new_name" not in args:


### PR DESCRIPTION
We should rely on the language server doing the smart checks. The is_at_word
function goes against this idea. If the language server decides a request
cannot be fulfilled, we will hear that through its (error) response.