### PR TITLE
Fix issues with document state getting out of sync when changing and saving

### DIFF
--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -209,8 +209,8 @@ def text_document_item(view: sublime.View, language_id: str) -> Dict[str, Any]:
     }
 
 
-def versioned_text_document_identifier(view: sublime.View) -> Dict[str, Any]:
-    return {"uri": uri_from_view(view), "version": view.change_count()}
+def versioned_text_document_identifier(view: sublime.View, version: int) -> Dict[str, Any]:
+    return {"uri": uri_from_view(view), "version": version}
 
 
 def text_document_position_params(view: sublime.View, location: int) -> Dict[str, Any]:
@@ -232,10 +232,10 @@ def render_text_change(change: sublime.TextChange) -> Dict[str, Any]:
     }
 
 
-def did_change_text_document_params(view: sublime.View,
+def did_change_text_document_params(view: sublime.View, version: int,
                                     changes: Optional[Iterable[sublime.TextChange]] = None) -> Dict[str, Any]:
     content_changes = []  # type: List[Dict[str, Any]]
-    result = {"textDocument": versioned_text_document_identifier(view), "contentChanges": content_changes}
+    result = {"textDocument": versioned_text_document_identifier(view, version), "contentChanges": content_changes}
     if changes is None:
         # TextDocumentSyncKindFull
         content_changes.append({"text": entire_content(view)})
@@ -268,8 +268,9 @@ def did_open(view: sublime.View, language_id: str) -> Notification:
     return Notification.didOpen(did_open_text_document_params(view, language_id))
 
 
-def did_change(view: sublime.View, changes: Optional[Iterable[sublime.TextChange]] = None) -> Notification:
-    return Notification.didChange(did_change_text_document_params(view, changes))
+def did_change(view: sublime.View, version: int,
+               changes: Optional[Iterable[sublime.TextChange]] = None) -> Notification:
+    return Notification.didChange(did_change_text_document_params(view, version, changes))
 
 
 def will_save(file_name: str, reason: int) -> Notification:

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -141,9 +141,10 @@ class TextChangeListener(sublime_plugin.TextChangeListener):
         if not view:
             return
         change_count = view.change_count()
+        frozen_listeners = WeakSet(self.view_listeners)
 
         def notify() -> None:
-            for listener in list(self.view_listeners):
+            for listener in list(frozen_listeners):
                 listener.on_text_changed_async(change_count, changes)
 
         sublime.set_timeout_async(notify)
@@ -200,6 +201,11 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         added = False
         if session.config.name not in self._session_views:
             self._session_views[session.config.name] = SessionView(self, session)
+            buf = self.view.buffer()
+            if buf:
+                text_change_listener = TextChangeListener.ids_to_listeners.get(buf.buffer_id)
+                if text_change_listener:
+                    text_change_listener.view_listeners.add(self)
             self.view.settings().set("lsp_active", True)
             added = True
         if added:
@@ -645,7 +651,6 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         if not text_change_listener:
             debug("couldn't find a text change listener for", self)
             return
-        text_change_listener.view_listeners.add(self)
         self._text_change_listener_found = True
         self.manager.register_listener_async(self)
         views = buf.views()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -58,10 +58,11 @@ class ViewsTest(DeferrableTestCase):
         })
 
     def test_did_change_full(self) -> None:
-        self.assertEqual(did_change(self.view).params, {
+        version = self.view.change_count()
+        self.assertEqual(did_change(self.view, version).params, {
             "textDocument": {
                 "uri": filename_to_uri(self.mock_file_name),
-                "version": self.view.change_count()
+                "version": version
             },
             "contentChanges": [{"text": "hello world\nfoo bar baz"}]
         })


### PR DESCRIPTION
debounced call was incorrectly running on the sync thread causing potential
race issues when "pending_changes" was modified/checked from different
threads.

Also, made text document version reported in did_change notification
represents document version at the time of the change rather than at the
time of sending the notification. Without it, we sometimes have sent
consecutive notifications with different contents but the same text document
version. Which I imagine servers don't like.