### PR TITLE
New server configuration key: auto_complete_selector

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -250,7 +250,8 @@
           "document_selector": "source.objc++",
           "languageId": "objective-cpp"
         },
-      ]
+      ],
+      "auto_complete_selector": "punctuation.accessor | (meta.preprocessor.include string - punctuation.definition.string.end)",
     },
     "dart": {
       "command": [

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -255,10 +255,10 @@ class SessionViewProtocol(Protocol):
     listener = None  # type: Any
     session_buffer = None  # type: Any
 
-    def on_capability_added_async(self, capability_path: str, options: Dict[str, Any]) -> None:
+    def on_capability_added_async(self, registration_id: str, capability_path: str, options: Dict[str, Any]) -> None:
         ...
 
-    def on_capability_removed_async(self, discarded_capabilities: Dict[str, Any]) -> None:
+    def on_capability_removed_async(self, registration_id: str, discarded_capabilities: Dict[str, Any]) -> None:
         ...
 
     def has_capability_async(self, capability_path: str) -> bool:
@@ -971,6 +971,10 @@ class Session(TransportCallbacks):
             else:
                 # The registration applies globally to all buffers.
                 self.capabilities.register(registration_id, capability_path, registration_path, options)
+                # We must inform our SessionViews of the new capabilities, in case it's for instance a hoverProvider
+                # or a completionProvider for trigger characters.
+                for sv in self.session_views_async():
+                    sv.on_capability_added_async(registration_id, capability_path, options)
         self.send_response(Response(request_id, None))
 
     def m_client_unregisterCapability(self, params: Any, request_id: Any) -> None:
@@ -986,7 +990,12 @@ class Session(TransportCallbacks):
                 self.send_error_response(request_id, Error(ErrorCode.InvalidParams, message))
                 return
             elif not data.selector:
-                self.capabilities.unregister(registration_id, capability_path, registration_path)
+                discarded = self.capabilities.unregister(registration_id, capability_path, registration_path)
+                # We must inform our SessionViews of the removed capabilities, in case it's for instance a hoverProvider
+                # or a completionProvider for trigger characters.
+                if isinstance(discarded, dict):
+                    for sv in self.session_views_async():
+                        sv.on_capability_removed_async(registration_id, discarded)
         self.send_response(Response(request_id, None))
 
     def m_window_workDoneProgress_create(self, params: Any, request_id: Any) -> None:

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -507,7 +507,7 @@ class ClientConfig:
                  binary_args: Optional[List[str]] = None,  # DEPRECATED
                  tcp_port: Optional[int] = None,
                  auto_complete_selector: Optional[str] = None,
-                 allow_completion_triggers_from_server: bool = True,
+                 ignore_server_triggers: bool = False,
                  enabled: bool = True,
                  init_options: DottedDict = DottedDict(),
                  settings: DottedDict = DottedDict(),
@@ -522,7 +522,7 @@ class ClientConfig:
         self.languages = languages
         self.tcp_port = tcp_port
         self.auto_complete_selector = auto_complete_selector
-        self.allow_completion_triggers_from_server = allow_completion_triggers_from_server
+        self.ignore_server_triggers = ignore_server_triggers
         self.enabled = enabled
         self.init_options = init_options
         self.settings = settings
@@ -543,7 +543,7 @@ class ClientConfig:
             languages=_read_language_configs(s),
             tcp_port=s.get("tcp_port"),
             auto_complete_selector=s.get("auto_complete_selector"),
-            allow_completion_triggers_from_server=bool(s.get("allow_completion_triggers_from_server", True)),
+            ignore_server_triggers=bool(s.get("ignore_server_triggers", False)),
             # Default to True, because an LSP plugin is enabled iff it is enabled as a Sublime package.
             enabled=bool(s.get("enabled", True)),
             init_options=init_options,
@@ -560,7 +560,7 @@ class ClientConfig:
             languages=_read_language_configs(d),
             tcp_port=d.get("tcp_port"),
             auto_complete_selector=d.get("auto_complete_selector"),
-            allow_completion_triggers_from_server=bool(d.get("allow_completion_triggers_from_server", True)),
+            ignore_server_triggers=bool(d.get("ignore_server_triggers", False)),
             enabled=d.get("enabled", False),
             init_options=DottedDict(d.get("initializationOptions")),
             settings=DottedDict(d.get("settings")),
@@ -578,8 +578,7 @@ class ClientConfig:
             languages=languages,
             tcp_port=override.get("tcp_port", self.tcp_port),
             auto_complete_selector=override.get("auto_complete_selector", self.auto_complete_selector),
-            allow_completion_triggers_from_server=bool(override.get("allow_completion_triggers_from_server",
-                                                                    self.allow_completion_triggers_from_server)),
+            ignore_server_triggers=bool(override.get("ignore_server_triggers", self.ignore_server_triggers)),
             enabled=override.get("enabled", self.enabled),
             init_options=DottedDict.from_base_and_override(self.init_options, override.get("initializationOptions")),
             settings=DottedDict.from_base_and_override(self.settings, override.get("settings")),

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -507,7 +507,7 @@ class ClientConfig:
                  binary_args: Optional[List[str]] = None,  # DEPRECATED
                  tcp_port: Optional[int] = None,
                  auto_complete_selector: Optional[str] = None,
-                 ignore_server_triggers: bool = False,
+                 ignore_server_trigger_chars: bool = False,
                  enabled: bool = True,
                  init_options: DottedDict = DottedDict(),
                  settings: DottedDict = DottedDict(),
@@ -522,7 +522,7 @@ class ClientConfig:
         self.languages = languages
         self.tcp_port = tcp_port
         self.auto_complete_selector = auto_complete_selector
-        self.ignore_server_triggers = ignore_server_triggers
+        self.ignore_server_trigger_chars = ignore_server_trigger_chars
         self.enabled = enabled
         self.init_options = init_options
         self.settings = settings
@@ -543,7 +543,7 @@ class ClientConfig:
             languages=_read_language_configs(s),
             tcp_port=s.get("tcp_port"),
             auto_complete_selector=s.get("auto_complete_selector"),
-            ignore_server_triggers=bool(s.get("ignore_server_triggers", False)),
+            ignore_server_trigger_chars=bool(s.get("ignore_server_trigger_chars", False)),
             # Default to True, because an LSP plugin is enabled iff it is enabled as a Sublime package.
             enabled=bool(s.get("enabled", True)),
             init_options=init_options,
@@ -560,7 +560,7 @@ class ClientConfig:
             languages=_read_language_configs(d),
             tcp_port=d.get("tcp_port"),
             auto_complete_selector=d.get("auto_complete_selector"),
-            ignore_server_triggers=bool(d.get("ignore_server_triggers", False)),
+            ignore_server_trigger_chars=bool(d.get("ignore_server_trigger_chars", False)),
             enabled=d.get("enabled", False),
             init_options=DottedDict(d.get("initializationOptions")),
             settings=DottedDict(d.get("settings")),
@@ -578,7 +578,8 @@ class ClientConfig:
             languages=languages,
             tcp_port=override.get("tcp_port", self.tcp_port),
             auto_complete_selector=override.get("auto_complete_selector", self.auto_complete_selector),
-            ignore_server_triggers=bool(override.get("ignore_server_triggers", self.ignore_server_triggers)),
+            ignore_server_trigger_chars=bool(
+                override.get("ignore_server_trigger_chars", self.ignore_server_trigger_chars)),
             enabled=override.get("enabled", self.enabled),
             init_options=DottedDict.from_base_and_override(self.init_options, override.get("initializationOptions")),
             settings=DottedDict.from_base_and_override(self.settings, override.get("settings")),

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -507,6 +507,7 @@ class ClientConfig:
                  binary_args: Optional[List[str]] = None,  # DEPRECATED
                  tcp_port: Optional[int] = None,
                  auto_complete_selector: Optional[str] = None,
+                 allow_completion_triggers_from_server: bool = True,
                  enabled: bool = True,
                  init_options: DottedDict = DottedDict(),
                  settings: DottedDict = DottedDict(),
@@ -521,6 +522,7 @@ class ClientConfig:
         self.languages = languages
         self.tcp_port = tcp_port
         self.auto_complete_selector = auto_complete_selector
+        self.allow_completion_triggers_from_server = allow_completion_triggers_from_server
         self.enabled = enabled
         self.init_options = init_options
         self.settings = settings
@@ -541,6 +543,7 @@ class ClientConfig:
             languages=_read_language_configs(s),
             tcp_port=s.get("tcp_port"),
             auto_complete_selector=s.get("auto_complete_selector"),
+            allow_completion_triggers_from_server=bool(s.get("allow_completion_triggers_from_server", True)),
             # Default to True, because an LSP plugin is enabled iff it is enabled as a Sublime package.
             enabled=bool(s.get("enabled", True)),
             init_options=init_options,
@@ -557,6 +560,7 @@ class ClientConfig:
             languages=_read_language_configs(d),
             tcp_port=d.get("tcp_port"),
             auto_complete_selector=d.get("auto_complete_selector"),
+            allow_completion_triggers_from_server=bool(d.get("allow_completion_triggers_from_server", True)),
             enabled=d.get("enabled", False),
             init_options=DottedDict(d.get("initializationOptions")),
             settings=DottedDict(d.get("settings")),
@@ -574,6 +578,8 @@ class ClientConfig:
             languages=languages,
             tcp_port=override.get("tcp_port", self.tcp_port),
             auto_complete_selector=override.get("auto_complete_selector", self.auto_complete_selector),
+            allow_completion_triggers_from_server=bool(override.get("allow_completion_triggers_from_server",
+                self.allow_completion_triggers_from_server)),
             enabled=override.get("enabled", self.enabled),
             init_options=DottedDict.from_base_and_override(self.init_options, override.get("initializationOptions")),
             settings=DottedDict.from_base_and_override(self.settings, override.get("settings")),

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -506,6 +506,7 @@ class ClientConfig:
                  command: Optional[List[str]] = None,
                  binary_args: Optional[List[str]] = None,  # DEPRECATED
                  tcp_port: Optional[int] = None,
+                 auto_complete_selector: Optional[str] = None,
                  enabled: bool = True,
                  init_options: DottedDict = DottedDict(),
                  settings: DottedDict = DottedDict(),
@@ -519,6 +520,7 @@ class ClientConfig:
             self.command = binary_args
         self.languages = languages
         self.tcp_port = tcp_port
+        self.auto_complete_selector = auto_complete_selector
         self.enabled = enabled
         self.init_options = init_options
         self.settings = settings
@@ -538,6 +540,7 @@ class ClientConfig:
             command=read_list_setting(s, "command", []),
             languages=_read_language_configs(s),
             tcp_port=s.get("tcp_port"),
+            auto_complete_selector=s.get("auto_complete_selector"),
             # Default to True, because an LSP plugin is enabled iff it is enabled as a Sublime package.
             enabled=bool(s.get("enabled", True)),
             init_options=init_options,
@@ -553,6 +556,7 @@ class ClientConfig:
             command=d.get("command", []),
             languages=_read_language_configs(d),
             tcp_port=d.get("tcp_port"),
+            auto_complete_selector=d.get("auto_complete_selector"),
             enabled=d.get("enabled", False),
             init_options=DottedDict(d.get("initializationOptions")),
             settings=DottedDict(d.get("settings")),
@@ -569,6 +573,7 @@ class ClientConfig:
             command=override.get("command", self.command),
             languages=languages,
             tcp_port=override.get("tcp_port", self.tcp_port),
+            auto_complete_selector=override.get("auto_complete_selector", self.auto_complete_selector),
             enabled=override.get("enabled", self.enabled),
             init_options=DottedDict.from_base_and_override(self.init_options, override.get("initializationOptions")),
             settings=DottedDict.from_base_and_override(self.settings, override.get("settings")),

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -579,7 +579,7 @@ class ClientConfig:
             tcp_port=override.get("tcp_port", self.tcp_port),
             auto_complete_selector=override.get("auto_complete_selector", self.auto_complete_selector),
             allow_completion_triggers_from_server=bool(override.get("allow_completion_triggers_from_server",
-                self.allow_completion_triggers_from_server)),
+                                                                    self.allow_completion_triggers_from_server)),
             enabled=override.get("enabled", self.enabled),
             init_options=DottedDict.from_base_and_override(self.init_options, override.get("initializationOptions")),
             settings=DottedDict.from_base_and_override(self.settings, override.get("settings")),

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -124,7 +124,7 @@ class SessionBuffer:
         self.capabilities.register(registration_id, capability_path, registration_path, options)
         view = None  # type: Optional[sublime.View]
         for sv in self.session_views:
-            sv.on_capability_added_async(capability_path, options)
+            sv.on_capability_added_async(registration_id, capability_path, options)
             if view is None:
                 view = sv.view
         if view is not None:
@@ -141,7 +141,7 @@ class SessionBuffer:
         if discarded is None:
             return
         for sv in self.session_views:
-            sv.on_capability_removed_async(discarded)
+            sv.on_capability_removed_async(registration_id, discarded)
 
     def get_capability(self, capability_path: str) -> Optional[Any]:
         value = self.capabilities.get(capability_path)

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -132,7 +132,7 @@ class SessionView:
             # from the auto_complete_triggers array once the session is stopped.
             "server": self.session.config.name
         }
-        if not self.session.config.ignore_server_triggers:
+        if not self.session.config.ignore_server_trigger_chars:
             trigger["characters"] = "".join(trigger_chars)
         if isinstance(registration_id, str):
             # This key is not used by Sublime, but is used as a "breadcrumb" as well, for dynamic registrations.

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -132,7 +132,7 @@ class SessionView:
             # from the auto_complete_triggers array once the session is stopped.
             "server": self.session.config.name
         }
-        if self.session.config.allow_completion_triggers_from_server:
+        if not self.session.config.ignore_server_triggers:
             trigger["characters"] = "".join(trigger_chars)
         if isinstance(registration_id, str):
             # This key is not used by Sublime, but is used as a "breadcrumb" as well, for dynamic registrations.

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -126,20 +126,18 @@ class SessionView:
             # If the user did not set up an auto_complete_selector for this server configuration, fallback to the
             # "global" auto_complete_selector of the view.
             selector = str(settings.get("auto_complete_selector"))
-        triggers = settings.get(self.AC_TRIGGERS_KEY) or []  # type: List[Dict[str, str]]
         trigger = {
-            # The trigger characters from the server are always added to the "auto_complete_triggers" entries. To
-            # fine-tune the behavior the user must specify an "auto_complete_selector" in the server configuration.
-            "characters": "".join(trigger_chars),
-            # both the selector must match, as well as at least one of the trigger characters advertised by the server.
             "selector": selector,
             # This key is not used by Sublime, but is used as a "breadcrumb" to figure out what needs to be removed
             # from the auto_complete_triggers array once the session is stopped.
             "server": self.session.config.name
         }
+        if self.session.config.allow_completion_triggers_from_server:
+            trigger["characters"] = "".join(trigger_chars)
         if isinstance(registration_id, str):
             # This key is not used by Sublime, but is used as a "breadcrumb" as well, for dynamic registrations.
             trigger["registration_id"] = registration_id
+        triggers = settings.get(self.AC_TRIGGERS_KEY) or []  # type: List[Dict[str, str]]
         triggers.append(trigger)
         settings.set(self.AC_TRIGGERS_KEY, triggers)
 

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -37,6 +37,16 @@
               },
               "markdownDescription": "The command to start the language server."
             },
+            "ClientAutoCompleteSelector": {
+              "type": "string",
+              "default": "source - string - comment",
+              "markdownDescription": "When specified, this [selector](https://www.sublimetext.com/docs/3/selectors.html) is used as the `\"selector\"` key in an entry of the `\"auto_complete_triggers\"` of the view applicable to this configuration. You don't have to necessarily provide this value. Because your language server registers so-called trigger characters in any case. However, this selector allows you to fine-tune the auto-complete behavior if the registered trigger characters of the language server result in an unpleasent auto-complete experience. Note that the behavior of this selector will depend on the .sublime-syntax in use.\n\nThis value is _not_ applied to the **global** `\"auto_complete_selector\"` setting of the view."
+            },
+            "ClientIgnoreServerTriggers": {
+              "type": "boolean",
+              "default": false,
+              "markdownDescription": "A language server may register a list of characters that, when typed, trigger the auto-complete. These days, there are Sublime syntaxes that are so good that it is possible to detect via a selector when the auto-complete should be triggered. This can result in a much better editor experience. When this is the case for your syntax, choose an appropriate selector for the `\"auto_complete_selector\"` and set this setting to `\"false\"`.\n\n**Hint.** You may look at `view.settings().get(\"auto_complete_triggers\")` in the Console to verify your settings."
+            },
             "ClientInitializationOptions": {
               "type": "object",
               "markdownDescription": "The initializationOptions that are passed to the language server process during the _initialize_ phase. This is a rather free-form dictionary of key-value pairs and is different per language server. Look up documentation of your specific langauge server to see what the possible key-value pairs can be."
@@ -65,39 +75,6 @@
                 "$ref": "#/definitions/LanguageConfig"
               },
             },
-            "LanguageConfig": {
-              "type": "object",
-              "markdownDescription": "A language configuration defines which servers are attached to which views",
-              "properties": {
-                "languageId": {
-                  "type": "string",
-                  "default": "somelang",
-                  "markdownDescription": "The \"Language ID\". This value serves two purposes:\n\n1. It is sent to the language server so that it knows with what kind of file it is dealing with.\n2. When `\"document_selector\"` is not provided, this is the connection between your files and language servers.\n\nFor more information, refer to the [textDocumentItem of the LSP specification](https://microsoft.github.io/language-server-protocol/specification#textDocumentItem)."
-                },
-                "document_selector": {
-                  "type": "string",
-                  "default": "source.somelang",
-                  "markdownDescription": "The Sublime Text selector to attach the language server process to applicable views. If not specified, it defaults to \"source.${languageId}\". This is the connection between your files and language servers. It's a selector that is matched against the current view's base scope. If the selector matches with the base scope of the the file, the associated language server is started. If the selector happens to be of the form \"source.{languageId}\" (which it is in many cases), then you can omit this `\"document_selector\"` key altogether, and LSP will assume the selector is \"source.{languageId}\".\n\nFor more information, refer to the [Sublime Text docs on selectors](https://www.sublimetext.com/docs/3/selectors.html)"
-                },
-                "feature_selector": {
-                  "type": "string",
-                  "default": "source.somelang",
-                  "markdownDescription": "The Sublime Text selector to use to give preference to this language server when multiple servers are attached to a view. For certain capabilities, like code completion, only one language server is chosen. The selector specified here decides which language server is chosen above others."
-                },
-                "syntaxes": {
-                  "type": "array",
-                  "deprecationMessage": "Use \"document_selector\" instead."
-                },
-                "scopes": {
-                  "type": "array",
-                  "deprecationMessage": "Use \"feature_selector\" instead."
-                }
-              },
-              "required": [
-                "languageId"
-              ],
-              "additionalProperties": false
-            },
             // The ClientConfig class
             "ClientConfig": {
               "type": "object",
@@ -119,14 +96,10 @@
                   "markdownDescription": "When specified, the TCP port to use to connect to the language server process. If not specified, STDIO is used as the transport. When set to zero, a free TCP port is chosen. You can use that free TCP port number as a template variable, i.e. as `${tcp_port}` in the `\"command\"`."
                 },
                 "auto_complete_selector": {
-                  "type": "string",
-                  "default": "source - string - comment",
-                  "markdownDescription": "When specified, this [selector](https://www.sublimetext.com/docs/3/selectors.html) is used as the `\"selector\"` key in an entry of the `\"auto_complete_triggers\"` of the view applicable to this configuration. You don't have to necessarily provide this value. Because your language server registers so-called trigger characters in any case. However, this selector allows you to fine-tune the auto-complete behavior if the registered trigger characters of the language server result in an unpleasent auto-complete experience. Note that the behavior of this selector will depend on the .sublime-syntax in use.\n\nThis value is _not_ applied to the **global** `\"auto_complete_selector\"` setting of the view."
+                  "$ref": "#/definitions/ClientAutoCompleteSelector"
                 },
-                "allow_completion_triggers_from_server": {
-                  "type": "boolean",
-                  "default": true,
-                  "markdownDescription": "A language server may register a list of characters that, when typed, trigger the auto-complete. These days, there are Sublime syntaxes that are so good that it is possible to detect via a selector when the auto-complete should be triggered. This can result in a much better editor experience. When this is the case for your syntax, choose an appropriate selector for the `\"auto_complete_selector\"` and set this setting to `\"false\"`.\n\n**Hint.** You may look at `view.settings().get(\"auto_complete_triggers\")` in the Console to verify your settings."
+                "ignore_server_triggers": {
+                  "$ref": "#/definitions/ClientIgnoreServerTriggers"
                 },
                 "languages": {
                   "$ref": "#/definitions/ClientLanguages"
@@ -138,7 +111,7 @@
                   "$ref": "#/definitions/ClientSettings"
                 },
                 "experimental_capabilities": {
-                  "$ref": "#/definitions/ClientExperimentalCapabilities",
+                  "$ref": "#/definitions/ClientExperimentalCapabilities"
                 },
                 "env": {
                   "$ref": "#/definitions/ClientEnv"
@@ -445,8 +418,8 @@
                   "markdownDescription": "The dictionary of your configured language servers or overrides for existing configurations. The keys of this dictionary are free-form. They give a humany-friendly name to the server configuration. They are shown in the bottom-left corner in the status bar once attached to a view (unless you have `\"show_view_status\"` set to `false`).",
                   "additionalProperties": {
                     "$ref": "sublime://settings/LSP#/definitions/ClientConfig"
-                  },
-                },
+                  }
+                }
               }
             }
           }
@@ -469,14 +442,20 @@
               "$ref": "sublime://settings/LSP#/definitions/ClientSettings"
             },
             "experimental_capabilities": {
-              "$ref": "sublime://settings/LSP#/definitions/ClientExperimentalCapabilities",
+              "$ref": "sublime://settings/LSP#/definitions/ClientExperimentalCapabilities"
             },
             "env": {
               "$ref": "sublime://settings/LSP#/definitions/ClientEnv"
             },
-          },
+            "auto_complete_selector": {
+              "$ref": "sublime://settings/LSP#/definitions/ClientAutoCompleteSelector"
+            },
+            "ignore_server_triggers": {
+              "$ref": "sublime://settings/LSP#/definitions/ClientIgnoreServerTriggers"
+            }
+          }
         }
-      },
+      }
     ]
   }
 }

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -75,6 +75,39 @@
                 "$ref": "#/definitions/LanguageConfig"
               },
             },
+            "LanguageConfig": {
+              "type": "object",
+              "markdownDescription": "A language configuration defines which servers are attached to which views",
+              "properties": {
+                "languageId": {
+                  "type": "string",
+                  "default": "somelang",
+                  "markdownDescription": "The \"Language ID\". This value serves two purposes:\n\n1. It is sent to the language server so that it knows with what kind of file it is dealing with.\n2. When `\"document_selector\"` is not provided, this is the connection between your files and language servers.\n\nFor more information, refer to the [textDocumentItem of the LSP specification](https://microsoft.github.io/language-server-protocol/specification#textDocumentItem)."
+                },
+                "document_selector": {
+                  "type": "string",
+                  "default": "source.somelang",
+                  "markdownDescription": "The Sublime Text selector to attach the language server process to applicable views. If not specified, it defaults to \"source.${languageId}\". This is the connection between your files and language servers. It's a selector that is matched against the current view's base scope. If the selector matches with the base scope of the the file, the associated language server is started. If the selector happens to be of the form \"source.{languageId}\" (which it is in many cases), then you can omit this `\"document_selector\"` key altogether, and LSP will assume the selector is \"source.{languageId}\".\n\nFor more information, refer to the [Sublime Text docs on selectors](https://www.sublimetext.com/docs/3/selectors.html)"
+                },
+                "feature_selector": {
+                  "type": "string",
+                  "default": "source.somelang",
+                  "markdownDescription": "The Sublime Text selector to use to give preference to this language server when multiple servers are attached to a view. For certain capabilities, like code completion, only one language server is chosen. The selector specified here decides which language server is chosen above others."
+                },
+                "syntaxes": {
+                  "type": "array",
+                  "deprecationMessage": "Use \"document_selector\" instead."
+                },
+                "scopes": {
+                  "type": "array",
+                  "deprecationMessage": "Use \"feature_selector\" instead."
+                }
+              },
+              "required": [
+                "languageId"
+              ],
+              "additionalProperties": false
+            },
             // The ClientConfig class
             "ClientConfig": {
               "type": "object",

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -118,6 +118,11 @@
                   "default": 0,
                   "markdownDescription": "When specified, the TCP port to use to connect to the language server process. If not specified, STDIO is used as the transport. When set to zero, a free TCP port is chosen. You can use that free TCP port number as a template variable, i.e. as `${tcp_port}` in the `\"command\"`."
                 },
+                "auto_complete_selector": {
+                  "type": "string",
+                  "default": "source - string - comment",
+                  "markdownDescription": "When specified, this [selector](https://www.sublimetext.com/docs/3/selectors.html) is used as the `\"selector\"` key in an entry of the `\"auto_complete_triggers\"` of the view applicable to this configuration. You don't have to necessarily provide this value. Because your language server registers so-called trigger characters in any case. However, this selector allows you to fine-tune the auto-complete behavior if the registered trigger characters of the language server result in an unpleasent auto-complete experience. Note that the behavior of this selector will depend on the .sublime-syntax in use.\n\nThis value is _not_ applied to the **global** `\"auto_complete_selector\"` setting of the view."
+                },
                 "languages": {
                   "$ref": "#/definitions/ClientLanguages"
                 },

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -42,7 +42,7 @@
               "default": "source - string - comment",
               "markdownDescription": "When specified, this [selector](https://www.sublimetext.com/docs/3/selectors.html) is used as the `\"selector\"` key in an entry of the `\"auto_complete_triggers\"` of the view applicable to this configuration. You don't have to necessarily provide this value. Because your language server registers so-called trigger characters in any case. However, this selector allows you to fine-tune the auto-complete behavior if the registered trigger characters of the language server result in an unpleasent auto-complete experience. Note that the behavior of this selector will depend on the .sublime-syntax in use.\n\nThis value is _not_ applied to the **global** `\"auto_complete_selector\"` setting of the view."
             },
-            "ClientIgnoreServerTriggers": {
+            "ClientIgnoreServerTriggerChars": {
               "type": "boolean",
               "default": false,
               "markdownDescription": "A language server may register a list of characters that, when typed, trigger the auto-complete. These days, there are Sublime syntaxes that are so good that it is possible to detect via a selector when the auto-complete should be triggered. This can result in a much better editor experience. When this is the case for your syntax, choose an appropriate selector for the `\"auto_complete_selector\"` and set this setting to `\"false\"`.\n\n**Hint.** You may look at `view.settings().get(\"auto_complete_triggers\")` in the Console to verify your settings."
@@ -131,8 +131,8 @@
                 "auto_complete_selector": {
                   "$ref": "#/definitions/ClientAutoCompleteSelector"
                 },
-                "ignore_server_triggers": {
-                  "$ref": "#/definitions/ClientIgnoreServerTriggers"
+                "ignore_server_trigger_chars": {
+                  "$ref": "#/definitions/ClientIgnoreServerTriggerChars"
                 },
                 "languages": {
                   "$ref": "#/definitions/ClientLanguages"
@@ -483,8 +483,8 @@
             "auto_complete_selector": {
               "$ref": "sublime://settings/LSP#/definitions/ClientAutoCompleteSelector"
             },
-            "ignore_server_triggers": {
-              "$ref": "sublime://settings/LSP#/definitions/ClientIgnoreServerTriggers"
+            "ignore_server_trigger_chars": {
+              "$ref": "sublime://settings/LSP#/definitions/ClientIgnoreServerTriggerChars"
             }
           }
         }

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -39,13 +39,12 @@
             },
             "ClientAutoCompleteSelector": {
               "type": "string",
-              "default": "source - string - comment",
               "markdownDescription": "When specified, this [selector](https://www.sublimetext.com/docs/3/selectors.html) is used as the `\"selector\"` key in an entry of the `\"auto_complete_triggers\"` of the view applicable to this configuration. You don't have to necessarily provide this value. Because your language server registers so-called trigger characters in any case. However, this selector allows you to fine-tune the auto-complete behavior if the registered trigger characters of the language server result in an unpleasent auto-complete experience. Note that the behavior of this selector will depend on the .sublime-syntax in use.\n\nThis value is _not_ applied to the **global** `\"auto_complete_selector\"` setting of the view."
             },
             "ClientIgnoreServerTriggerChars": {
               "type": "boolean",
               "default": false,
-              "markdownDescription": "A language server may register a list of characters that, when typed, trigger the auto-complete. These days, there are Sublime syntaxes that are so good that it is possible to detect via a selector when the auto-complete should be triggered. This can result in a much better editor experience. When this is the case for your syntax, choose an appropriate selector for the `\"auto_complete_selector\"` and set this setting to `\"false\"`.\n\n**Hint.** You may look at `view.settings().get(\"auto_complete_triggers\")` in the Console to verify your settings."
+              "markdownDescription": "A language server may register a list of characters that, when typed, trigger the auto-complete. These days, there are Sublime syntaxes that are so good that it is possible to detect via a selector when the auto-complete should be triggered. This can result in a much better editor experience. When this is the case for your syntax, choose an appropriate selector for the `\"auto_complete_selector\"` and set this setting to `\"true\"`.\n\n**Hint.** You may look at `view.settings().get(\"auto_complete_triggers\")` in the Console to verify your settings."
             },
             "ClientInitializationOptions": {
               "type": "object",

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -123,6 +123,11 @@
                   "default": "source - string - comment",
                   "markdownDescription": "When specified, this [selector](https://www.sublimetext.com/docs/3/selectors.html) is used as the `\"selector\"` key in an entry of the `\"auto_complete_triggers\"` of the view applicable to this configuration. You don't have to necessarily provide this value. Because your language server registers so-called trigger characters in any case. However, this selector allows you to fine-tune the auto-complete behavior if the registered trigger characters of the language server result in an unpleasent auto-complete experience. Note that the behavior of this selector will depend on the .sublime-syntax in use.\n\nThis value is _not_ applied to the **global** `\"auto_complete_selector\"` setting of the view."
                 },
+                "allow_completion_triggers_from_server": {
+                  "type": "boolean",
+                  "default": true,
+                  "markdownDescription": "A language server may register a list of characters that, when typed, trigger the auto-complete. These days, there are Sublime syntaxes that are so good that it is possible to detect via a selector when the auto-complete should be triggered. This can result in a much better editor experience. When this is the case for your syntax, choose an appropriate selector for the `\"auto_complete_selector\"` and set this setting to `\"false\"`.\n\n**Hint.** You may look at `view.settings().get(\"auto_complete_triggers\")` in the Console to verify your settings."
+                },
                 "languages": {
                   "$ref": "#/definitions/ClientLanguages"
                 },


### PR DESCRIPTION
The auto_complete_selector is used to fine-tune the behavior of the AC popping
up. This selector is added to an entry of the "auto_complete_triggers" of the
view, alongside the trigger characters advertised by the language server.

When both the selector and at least one trigger matches, the AC is shown.

Note that we have to notify all SessionViews of new capability registrations,
so that they can update their trigger chars.

Resolves #933 