### PR TITLE
Fix/document highlight cache

### DIFF
--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -512,7 +512,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             if kind is not None:
                 kind2regions[_kind2name[kind]].append(r)
 
-        def render_highlights_on_main_thread():
+        def render_highlights_on_main_thread() -> None:
             self._clear_highlight_regions()
             flags = userprefs().document_highlight_style_to_add_regions_flags()
             for kind_str, regions in kind2regions.items():

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -299,7 +299,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
                 if not self._is_in_higlighted_region(current_region.b):
                     self._clear_highlight_regions()
                 self._when_selection_remains_stable_async(self._do_highlights_async, current_region,
-                                                              after_ms=self.highlights_debounce_time)
+                                                          after_ms=self.highlights_debounce_time)
             self._clear_code_actions_annotation()
             self._when_selection_remains_stable_async(self._do_code_actions, current_region,
                                                       after_ms=self.code_actions_debounce_time)

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -500,8 +500,8 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             session.send_request_async(request, self._on_highlights)
 
     def _on_highlights(self, response: Optional[List]) -> None:
+        self._clear_highlight_regions()
         if not response:
-            self._clear_highlight_regions()
             return
         kind2regions = {}  # type: Dict[str, List[sublime.Region]]
         for kind in range(0, 4):
@@ -511,7 +511,6 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             kind = highlight.get("kind", DocumentHighlightKind.Unknown)
             if kind is not None:
                 kind2regions[_kind2name[kind]].append(r)
-        self._clear_highlight_regions()
         flags = userprefs().document_highlight_style_to_add_regions_flags()
         for kind_str, regions in kind2regions.items():
             if regions:

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -298,7 +298,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             if "documentHighlight" not in userprefs().disabled_capabilities:
                 if not self._is_in_higlighted_region(current_region.b):
                     self._clear_highlight_regions()
-                    self._when_selection_remains_stable_async(self._do_highlights_async, current_region,
+                self._when_selection_remains_stable_async(self._do_highlights_async, current_region,
                                                               after_ms=self.highlights_debounce_time)
             self._clear_code_actions_annotation()
             self._when_selection_remains_stable_async(self._do_code_actions, current_region,
@@ -501,6 +501,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
 
     def _on_highlights(self, response: Optional[List]) -> None:
         if not response:
+            self._clear_highlight_regions()
             return
         kind2regions = {}  # type: Dict[str, List[sublime.Region]]
         for kind in range(0, 4):


### PR DESCRIPTION
Right now when I move the cursor, 
I can see the document highlight underline flashing sometimes.

It is better to render highlights on the main thread to prevent underline flashes.