### PR TITLE
Send back whole action object on choosing action in showMessageRequest

### DIFF
--- a/plugin/core/message_request_handler.py
+++ b/plugin/core/message_request_handler.py
@@ -11,8 +11,8 @@ class MessageRequestHandler():
         self.request_id = request_id
         self.request_sent = False
         self.view = view
-        actions = params.get("actions", [])
-        self.titles = list(action.get("title") for action in actions)
+        self.actions = params.get("actions", [])
+        self.titles = list(action.get("title") for action in self.actions)
         self.message = params.get('message', '')
         self.message_type = params.get('type', 4)
         self.source = source
@@ -25,7 +25,7 @@ class MessageRequestHandler():
             param = None
             index = int(href)
             if index != -1:
-                param = {"title": self.titles[index]}
+                param = self.actions[index]
             response = Response(self.request_id, param)
             self.session.send_response(response)
 


### PR DESCRIPTION
MessageActionItem is specified as only containing the "title" property [1].
Yet, vscode-eslint sends an object with "title" and "id" properties and
expects to get that "id" back when user chooses an action.

Since it's not clear what is expected I'm for now changing behavior to
send back original object. This "spec issue" is discussed in more detail at [2].

[1] https://microsoft.github.io/language-server-protocol/specification#window_showMessageRequest
[2] https://github.com/microsoft/language-server-protocol/issues/230