### PR TITLE
Set haskell-language-server as the default backend

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -299,15 +299,17 @@
         }
       ],
     },
-    "haskell-ide-engine": {
+    "haskell-language-server": {
       "command": [
-        "hie",
+        "haskell-language-server-wrapper",
         "--lsp"
       ],
-      "languages": [
-        {
-          "languageId": "haskell"
-        }
+      "languageId": "haskell",
+      "scopes": [
+        "source.haskell"
+      ],
+      "syntaxes": [
+        "Packages/Haskell/Haskell.sublime-syntax"
       ],
     },
     "ocaml": {


### PR DESCRIPTION
`hie` and `ghcide` are no longer recommended for Haskell IDE users. See @ndmitchell's [post](https://neilmitchell.blogspot.com/2020/09/dont-use-ghcide-anymore-directly.html) on why [haskell-language-server](https://github.com/haskell/haskell-language-server) should be the default.

This PR makes Sublime LSP work out of the box if `haskell-language-server-wrapper` is in PATH. If we get that merged, we can then simplify the [equivalent section](https://github.com/haskell/haskell-language-server/blob/fc3cc65a527a687177df9973d82ed472f56bf309/README.md#using-haskell-language-server-with-sublime-text) in the haskell-language-server README.