### PR TITLE
Add deprecation note for haskell-ide-engine

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -323,6 +323,7 @@
       "syntaxes": ["Packages/Babel/JavaScript (Babel).sublime-syntax", "Packages/JavaScript/JavaScript.sublime-syntax"],
       "languageId": "javascript"
     },
+    // deprecated: please use haskell-language-server, see lsp.readthedocs.io
     "haskell-ide-engine":
     {
       "command":


### PR DESCRIPTION
`hie` and `ghcide` are no longer recommended for Haskell IDE users

https://neilmitchell.blogspot.com/2020/09/dont-use-ghcide-anymore-directly.html