### PR TITLE
Remove the "auto_complete_preserve_order" hack

### DIFF
--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -59,9 +59,6 @@ class SessionView:
             self._increment_hover_count()
         self._clear_auto_complete_triggers(settings)
         self._setup_auto_complete_triggers(settings)
-        # This is to make ST match with labels that have a weird prefix like a space character.
-        # TODO: Maybe remove this?
-        settings.set('auto_complete_preserve_order', 'none')
 
     def __del__(self) -> None:
         settings = self.view.settings()  # type: sublime.Settings


### PR DESCRIPTION
This was from the time that we didn't use the filterText as the trigger.
I don't think it's necessary to have this anymore. We don't need to
overwrite the user's personal preferences.