### PR TITLE
Check for a listener for hover

### DIFF
--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -74,7 +74,8 @@ class LspTextCommand(sublime_plugin.TextCommand):
         return True
 
     def best_session(self, capability: str, point: Optional[int] = None) -> Optional[Session]:
-        return best_session(self.view, self.sessions(capability), point)
+        listener = windows.listener_for_view(self.view)
+        return listener.session(capability, point) if listener else None
 
     def session_by_name(self, name: Optional[str] = None) -> Optional[Session]:
         target = name if name else self.session_name

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -52,6 +52,10 @@ class AbstractViewListener(metaclass=ABCMeta):
         raise NotImplementedError()
 
     @abstractmethod
+    def session(self, capability_path: str, point: Optional[int] = None) -> Optional[Session]:
+        raise NotImplementedError()
+
+    @abstractmethod
     def on_session_initialized_async(self, session: Session) -> None:
         raise NotImplementedError()
 
@@ -517,13 +521,20 @@ class WindowRegistry(object):
         self._configs = configs
 
     def lookup(self, window: sublime.Window) -> WindowManager:
-        if window.id() in self._windows:
-            return self._windows[window.id()]
+        wm = self._windows.get(window.id())
+        if wm:
+            return wm
         workspace = ProjectFolders(window)
         window_configs = self._configs.for_window(window)
         state = WindowManager(window=window, workspace=workspace, configs=window_configs)
         self._windows[window.id()] = state
         return state
+
+    def listener_for_view(self, view: sublime.View) -> Optional[AbstractViewListener]:
+        w = view.window()
+        if not w:
+            return None
+        return self.lookup(w).listener_for_view(view)
 
     def discard(self, window: sublime.Window) -> None:
         self._windows.pop(window.id(), None)

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -65,11 +65,7 @@ class LspHoverCommand(LspTextCommand):
         window = self.view.window()
         if not window:
             return
-        wm = windows.lookup(window)
-        listener = wm.listener_for_view(self.view)
-        if not listener:
-            return
-        self._base_dir = wm.get_project_path(self.view.file_name() or "")
+        self._base_dir = windows.lookup(window).get_project_path(self.view.file_name() or "")
         self._hover = None  # type: Optional[Any]
         self._actions_by_config = {}  # type: Dict[str, List[CodeActionOrCommand]]
         self._diagnostics_by_config = {}  # type: Dict[str, List[Diagnostic]]

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -65,7 +65,11 @@ class LspHoverCommand(LspTextCommand):
         window = self.view.window()
         if not window:
             return
-        self._base_dir = windows.lookup(window).get_project_path(self.view.file_name() or "")
+        wm = windows.lookup(window)
+        listener = wm.listener_for_view(self.view)
+        if not listener:
+            return
+        self._base_dir = wm.get_project_path(self.view.file_name() or "")
         self._hover = None  # type: Optional[Any]
         self._actions_by_config = {}  # type: Dict[str, List[CodeActionOrCommand]]
         self._diagnostics_by_config = {}  # type: Dict[str, List[Diagnostic]]


### PR DESCRIPTION
When there's no ViewListener, the view is not under control of a language
server. So we should not request any textDocument/* requests.

textDocument/hover is the only one where this can happen due to mouse
interaction and transient views during CTRL+P file browsinng.

Fixes #1303