### PR TITLE
Workaround mdpopups CommonMark deficiency

### DIFF
--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -448,6 +448,8 @@ def minihtml(view: sublime.View, content: Union[str, Dict[str, str], list], allo
                 }
             ]
         }
+        # Workaround CommonMark deficiency: two spaces followed by a newline should result in a new paragraph.
+        result = re.sub('(\\S)  \n', '\\1\n\n', result)
         return mdpopups.md2html(view, mdpopups.format_frontmatter(frontmatter) + result)
 
 


### PR DESCRIPTION
Two spaces followed by a newline should result in a new paragraph.

mdpopups doesn't parse this because it assumes Daring Fireball Markdown,
but the LSP world seems to converge towards CommonMark (for one thing,
CommonMark is much better specced).

See: https://github.com/facelessuser/sublime-markdown-popups/issues/103