### PR TITLE
Link to the client configuration also for C/C++

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Documentation is available at [LSP.readthedocs.io](https://LSP.readthedocs.io).
 ## Available Languages<a name="available_languages"></a>
 
 * [Bash](https://lsp.readthedocs.io/en/latest/#bash)
-* [C/C++](https://lsp.readthedocs.io/en/latest/cplusplus/)
+* [C/C++](https://lsp.readthedocs.io/en/latest/#cc)
 * [C#](https://lsp.readthedocs.io/en/latest/#csharp)
 * [CSS/LESS/SASS (SCSS only)](https://lsp.readthedocs.io/en/latest/#css)
 * [D](https://lsp.readthedocs.io/en/latest/#d)


### PR DESCRIPTION
As with all other languages, this one should also link to client
configuration page. That one also links to the guide.