### PR TITLE
Advertise support for regular expression syntax "ECMAScript"

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -115,7 +115,7 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
             "regularExpressions": {
                 "engine": "ECMAScript"
             }
-        }
+        },
         "textDocument": {
             "synchronization": {
                 "dynamicRegistration": True,  # exceptional

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -111,6 +111,11 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
     completion_tag_value_set = [v for k, v in CompletionItemTag.__dict__.items() if not k.startswith('_')]
     first_folder = workspace_folders[0] if workspace_folders else None
     capabilities = {
+        "general": {
+            "regularExpressions": {
+                "engine": "ECMAScript"
+            }
+        }
         "textDocument": {
             "synchronization": {
                 "dynamicRegistration": True,  # exceptional


### PR DESCRIPTION
This is only used for completions at the moment. With respect to completions,
the regex flavor is actually Perl, but Perl is a strict *superset* of ECMAScript.

Because the spec only lists one "well-known" flavor, we restrict ourselves to
this subset to achieve maximum compatibility with language servers that may
check for this particular value.

I have intentionally left out the version because:

- I suspect language servers will not check this value rigorously, and
- I don't actually know what version of ECMAScript corresponds to ST's internal
  implementation.

See: https://github.com/microsoft/language-server-protocol/commit/d1bfc1014be2b530d85223f2b090c8a0c318eaad
See: https://www.sublimetext.com/docs/completions.html#snippets
See: https://www.boost.org/doc/libs/1_64_0/libs/regex/doc/html/boost_regex/syntax/perl_syntax.html