### PR TITLE
Add settings registration class that maintains a registration

### DIFF
--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -3,6 +3,7 @@ from .logging import debug
 from .types import ClientConfig, debounced
 from .types import read_dict_setting
 from .types import Settings
+from .types import SettingsRegistration
 from .types import syntax2scope
 from .typing import Any, Optional, Dict, Callable
 import sublime
@@ -108,6 +109,7 @@ class ClientConfigs:
 
 _settings_obj = None  # type: Optional[sublime.Settings]
 _settings = None  # type: Optional[Settings]
+_settings_registration = None  # type: Optional[SettingsRegistration]
 client_configs = ClientConfigs()
 
 
@@ -124,18 +126,18 @@ def _on_sublime_settings_changed() -> None:
 def load_settings() -> None:
     global _settings_obj
     global _settings
-    global client_configs
+    global _settings_registration
     if _settings_obj is None:
         _settings_obj = sublime.load_settings("LSP.sublime-settings")
         _settings = Settings(_settings_obj)
-        _settings_obj.add_on_change("LSP", _on_sublime_settings_changed)
+        _settings_registration = SettingsRegistration(_settings_obj, _on_sublime_settings_changed)
 
 
 def unload_settings() -> None:
     global _settings_obj
-    global _settings
+    global _settings_registration
     if _settings_obj is not None:
-        _settings_obj.clear_on_change("LSP")
+        _settings_registration = None
         _settings_obj = None
 
 

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -70,6 +70,17 @@ def _settings_style_to_add_regions_flag(style: str) -> int:
     return flags
 
 
+class SettingsRegistration:
+    __slots__ = ("_settings",)
+
+    def __init__(self, settings: sublime.Settings, on_change: Callable[[], None]) -> None:
+        self._settings = settings
+        settings.add_on_change("LSP", on_change)
+
+    def __del__(self) -> None:
+        self._settings.clear_on_change("LSP")
+
+
 class Debouncer:
 
     def __init__(self) -> None:


### PR DESCRIPTION
The registration is cleared once the object dies.

I want to use this for LSP-* helper package settings registrations.