### PR TITLE
Recheck language servers when a settings object changes

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -22,6 +22,7 @@ from .types import debounced
 from .types import diff
 from .types import DocumentSelector
 from .types import method_to_capability
+from .types import SettingsRegistration
 from .typing import Callable, Dict, Any, Optional, List, Tuple, Generator, Type, Protocol, Mapping, Union
 from .url import uri_to_filename
 from .version import __version__
@@ -500,7 +501,7 @@ class AbstractPlugin(metaclass=ABCMeta):
         return False
 
 
-_plugins = {}  # type: Dict[str, Type[AbstractPlugin]]
+_plugins = {}  # type: Dict[str, Tuple[Type[AbstractPlugin], SettingsRegistration]]
 
 
 def _register_plugin_impl(plugin: Type[AbstractPlugin], notify_listener: bool) -> None:
@@ -509,7 +510,8 @@ def _register_plugin_impl(plugin: Type[AbstractPlugin], notify_listener: bool) -
     try:
         settings, base_file = plugin.configuration()
         if client_configs.add_external_config(name, settings, base_file, notify_listener):
-            _plugins[name] = plugin
+            on_change = functools.partial(client_configs.update_external_config, name, settings, base_file)
+            _plugins[name] = (plugin, SettingsRegistration(settings, on_change))
     except Exception as ex:
         exception_log('Failed to register plugin "{}"'.format(name), ex)
 
@@ -578,7 +580,8 @@ def unregister_plugin(plugin: Type[AbstractPlugin]) -> None:
 
 def get_plugin(name: str) -> Optional[Type[AbstractPlugin]]:
     global _plugins
-    return _plugins.get(name, None)
+    tup = _plugins.get(name, None)
+    return tup[0] if tup else None
 
 
 class Logger(metaclass=ABCMeta):

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -58,6 +58,12 @@ class ClientConfigs:
         if self.all.pop(name, None):
             self._notify_listener()
 
+    def update_external_config(self, name: str, s: sublime.Settings, file: str) -> None:
+        config = ClientConfig.from_sublime_settings(name, s, file)
+        self.external[name] = config
+        self.all[name] = config
+        self._notify_listener()
+
     def update_configs(self) -> None:
         global _settings_obj
         if _settings_obj is None:


### PR DESCRIPTION
Fixes #1440

But it doesn't work for example for pyright, because it changes the dev_environment setting in on_settings_read, which is only done once at plugin registration.