### PR TITLE
Add more plugin callbacks

### DIFF
--- a/plugin/core/collections.py
+++ b/plugin/core/collections.py
@@ -1,6 +1,7 @@
 """
 Module with additional collections.
 """
+import sublime
 from .typing import Optional, Dict, Any
 from copy import deepcopy
 
@@ -130,6 +131,16 @@ class DottedDict:
                 self._update_recursive(value, key)
             else:
                 self.set(key, value)
+
+    def resolve(self, variables: Dict[str, str]) -> "DottedDict":
+        """
+        Resolve a DottedDict that may potentially contain template variables like $folder
+
+        :param      variables:  The variables
+
+        :returns:   A copy of this DottedDict, but with the variables replaced
+        """
+        return DottedDict(sublime.expand_variables(self._d, variables))
 
     def _update_recursive(self, current: Dict[str, Any], prefix: str) -> None:
         if not current:

--- a/plugin/core/collections.py
+++ b/plugin/core/collections.py
@@ -1,9 +1,9 @@
 """
 Module with additional collections.
 """
-import sublime
 from .typing import Optional, Dict, Any
 from copy import deepcopy
+import sublime
 
 
 class DottedDict:
@@ -132,7 +132,7 @@ class DottedDict:
             else:
                 self.set(key, value)
 
-    def resolve(self, variables: Dict[str, str]) -> "DottedDict":
+    def create_resolved(self, variables: Dict[str, str]) -> "DottedDict":
         """
         Resolve a DottedDict that may potentially contain template variables like $folder
 

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -1,4 +1,3 @@
-from .collections import DottedDict
 from .css import css
 from .protocol import CompletionItemTag
 from .protocol import Diagnostic
@@ -320,12 +319,6 @@ def text_document_range_formatting(view: sublime.View, region: sublime.Region) -
         "options": formatting_options(view.settings()),
         "range": region_to_range(view, region).to_lsp()
     }, view)
-
-
-def did_change_configuration(d: DottedDict, variables: Dict[str, str]) -> Notification:
-    settings = d.get()
-    settings = sublime.expand_variables(settings, variables)
-    return Notification.didChangeConfiguration({"settings": settings})
 
 
 def selection_range_params(view: sublime.View) -> Dict[str, Any]:

--- a/plugin/tooling.py
+++ b/plugin/tooling.py
@@ -285,7 +285,8 @@ class ServerTestRunner(TransportCallbacks):
         try:
             cwd = window.folders()[0] if window.folders() else None
             variables = extract_variables(window)
-            self._transport = create_transport(config, cwd, window, self, variables)
+            resolved = config.resolve(variables)
+            self._transport = create_transport(config.name, resolved, cwd, self)
             sublime.set_timeout_async(self.force_close_transport, self.CLOSE_TIMEOUT_SEC * 1000)
         except Exception as ex:
             self.on_transport_close(-1, ex)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,9 +1,7 @@
-from LSP.plugin.core.collections import DottedDict
 from LSP.plugin.core.protocol import Point
 from LSP.plugin.core.protocol import Range
 from LSP.plugin.core.url import filename_to_uri
 from LSP.plugin.core.views import did_change
-from LSP.plugin.core.views import did_change_configuration
 from LSP.plugin.core.views import did_open
 from LSP.plugin.core.views import did_save
 from LSP.plugin.core.views import document_color_params
@@ -121,28 +119,6 @@ class ViewsTest(DeferrableTestCase):
                 "trimFinalNewlines": False
             },
             "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 2}}
-        })
-
-    def test_did_change_configuration(self) -> None:
-        settings = DottedDict()
-        settings.set("a.b.x", 1)
-        settings.set("a.b.y", True)
-        settings.set("a.c.a", 1234)
-        settings.set("a.c.b", "${foo} bar ${baz}")
-        notification = did_change_configuration(settings, {"foo": "X", "baz": "Y"})
-        self.assertEqual(notification.params, {
-            "settings": {
-                "a": {
-                    "b": {
-                        "x": 1,
-                        "y": True
-                    },
-                    "c": {
-                        "a": 1234,
-                        "b": "X bar Y"
-                    }
-                }
-            }
         })
 
     def test_point_to_offset(self) -> None:


### PR DESCRIPTION
- on_pre_start: do just-in-time adjustments for the startup info here
- on_post_start: extra callback just in case :)
- ~~on_pre_window_settings~~ on_pre_workspace_configuration: do just-in-time adjustments for the server settings
  here

As a bonus there's much better separation between construction of the
jsonrpc transport and resolvement of settings.

Resolves #1373 