### PR TITLE
Add support for running source actions

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -29,7 +29,12 @@
             },
             {
                 "command": "lsp_code_actions",
-                "caption": "Apply Code Action…"
+                "caption": "Code Action…"
+            },
+            {
+                "command": "lsp_code_actions",
+                "args": {"only_kinds": ["source"]},
+                "caption": "Source Action…"
             },
             {
                 "command": "lsp_format_document",

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -36,6 +36,25 @@
     //         }
     //     ]
     // },
+    // Show Source Actions
+    // {
+    //     "command": "lsp_code_actions",
+    //     "args": {
+    //         "only_kinds": [
+    //             "source"
+    //         ]
+    //     },
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp.session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "codeActionProvider.codeActionKinds"
+    //         }
+    //     ]
+    // },
     // Show/Hide Diagnostics Panel
     {
         "command": "lsp_show_diagnostics_panel",


### PR DESCRIPTION
Expose a list of source actions that are provided by the servers.
Servers announce support for those through the
"codeActionProvider.codeActionKinds" capability.