### PR TITLE
Don't handle editor.action.triggerSuggest

### DIFF
--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -15,11 +15,6 @@ class LspExecuteCommand(LspTextCommand):
             command_args: Optional[List[Any]] = None,
             session_name: Optional[str] = None,
             event: Optional[dict] = None) -> None:
-        # Handle VSCode-specific command for triggering suggestions popup.
-        if command_name == "editor.action.triggerSuggest":
-            # Triggered from set_timeout as suggestions popup doesn't trigger otherwise.
-            sublime.set_timeout(lambda: self.view.run_command("auto_complete"))
-            return
         session = self.session_by_name(session_name) if session_name else self.best_session(self.capability)
         if session and command_name:
             if command_args:


### PR DESCRIPTION
vscode-json-language-server likes to run this when inserting a snippet like `[$1]`, but it doesn't flow very well for ST. Every plugin should decide for themselves whether they want to handle such a command in their `on_pre_server_command` callback.