### PR TITLE
Don't show ST's internal definitions popup in output panels

### DIFF
--- a/plugin/core/panels.py
+++ b/plugin/core/panels.py
@@ -25,6 +25,7 @@ OUTPUT_PANEL_SETTINGS = {
     "match_brackets": False,
     "rulers": [],
     "scroll_past_end": False,
+    "show_definitions": False,
     "tab_size": 4,
     "translate_tabs_to_spaces": False,
     "word_wrap": False


### PR DESCRIPTION
I noticed at work that ST is showing its own "definition and references" popup in the find-references output panel. That is not useful.