### PR TITLE
prev/next diagnostic selects affected region

### DIFF
--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -496,6 +496,8 @@ class WindowManager(Manager):
                 phantom_set.update([phantom])
                 self._window.focus_view(view)
                 view.show_at_center(phantom.region)
+                # Must be a tuple. Passing a `sublime.Region` causes a Sublime error.
+                view.run_command("lsp_selection_set", {"regions": [phantom.region.to_tuple()]})
                 self._diagnostic_phantom_set = phantom_set
                 has_phantom = view.settings().get(self.DIAGNOSTIC_PHANTOM_KEY)
                 if not has_phantom:

--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -553,6 +553,9 @@ class Region:
     def intersects(self, rhs: 'Region') -> bool:
         ...
 
+    def to_tuple(self) -> Tuple[int, int]:
+        ...
+
 
 class Selection(Reversible):
     view_id = ...  # type: Any


### PR DESCRIPTION
Ideally this would be configurable via command arguments, for example:

```jsonc
"args": {"select": null}     // suppress
"args": {"select": "region"} // select entire region
"args": {"select": "start"}  // select start of region
```

But for now, for simplicity, the behavior is to select the entire region. Let me know if this needs any changes.