### PR TITLE
fix: renaming input has no placeholder if no "renameProvider.prepareProvider"

### DIFF
--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -52,8 +52,10 @@ class LspSymbolRenameCommand(LspTextCommand):
             placeholder = args.get("placeholder", "")
             if not placeholder:
                 point = args.get("point")
-                if isinstance(point, int):
-                    placeholder = self.view.substr(self.view.word(point))
+                # guess the symbol name
+                if not isinstance(point, int):
+                    point = self.view.sel()[0].b
+                placeholder = self.view.substr(self.view.word(point))
             return RenameSymbolInputHandler(self.view, placeholder)
         else:
             return None


### PR DESCRIPTION
Trigger the "lsp_symbol_rename" command via a keybinding with LSP-pyright. The popup input has no placeholder, which is supposed to be the original symbol name. 

This PR introduced a guessed symbol name for the placeholder which is better than nothing I think.