### PR TITLE
Allow signature help to show when auto-completion is turned off.

### DIFF
--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -353,8 +353,6 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         pos = self._stored_region.a
         if pos == -1:
             return
-        if not self.view.match_selector(pos, self.view.settings().get("auto_complete_selector") or ""):  # ???
-            return
         session = self.session("signatureHelpProvider")
         if not session:
             return


### PR DESCRIPTION
I have removed the following check from `_do_signature_help`:
```python
if not self.view.match_selector(pos, self.view.settings().get("auto_complete_selector") or ""):  # ???	
    return
```
To me, signature help should show regardless of whether or not it is in a current `auto_complete_selector` scope. In my particular case I have auto-complete turned off, but still want signature help. I believe these features should be separate.