### PR TITLE
Add fortran language id

### DIFF
--- a/language-ids.sublime-settings
+++ b/language-ids.sublime-settings
@@ -23,10 +23,10 @@
     "source.c++": "cpp",
     "source.cs": "csharp",
     "source.dosbatch": "bat",
+    "source.fixedform-fortran": "fortran", // https://packagecontrol.io/packages/Fortran
     "source.js": "javascript",
     "source.js.react": "javascriptreact", // https://github.com/Thom1729/Sublime-JS-Custom
     "source.jsx": "javascriptreact",
-    "source.fixedform-fortran": "fortran", // https://packagecontrol.io/packages/Fortran
     "source.modern-fortran": "fortran", // https://packagecontrol.io/packages/Fortran
     "source.objc": "objective-c",
     "source.objc++": "objective-cpp",

--- a/language-ids.sublime-settings
+++ b/language-ids.sublime-settings
@@ -26,6 +26,8 @@
     "source.js": "javascript",
     "source.js.react": "javascriptreact", // https://github.com/Thom1729/Sublime-JS-Custom
     "source.jsx": "javascriptreact",
+    "source.fixedform-fortran": "fortran", // https://packagecontrol.io/packages/Fortran
+    "source.modern-fortran": "fortran", // https://packagecontrol.io/packages/Fortran
     "source.objc": "objective-c",
     "source.objc++": "objective-cpp",
     "source.shader": "shaderlab", // https://github.com/waqiju/unity_shader_st3


### PR DESCRIPTION
Fortran syntax has some selectors that would not convert to the right language id.

See:
https://lsp.readthedocs.io/en/latest/#fortran

This PR should fix it.