### PR TITLE
Avoid double registration of external plugins

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -547,6 +547,8 @@ _plugins = {}  # type: Dict[str, Tuple[Type[AbstractPlugin], SettingsRegistratio
 def _register_plugin_impl(plugin: Type[AbstractPlugin], notify_listener: bool) -> None:
     global _plugins
     name = plugin.name()
+    if name in _plugins:
+        return
     try:
         settings, base_file = plugin.configuration()
         if client_configs.add_external_config(name, settings, base_file, notify_listener):


### PR DESCRIPTION
The _register_all_plugins() call is always made first and then
individual plugins are also supposed to call "register_plugin()" which
causes plugins to be registered twice and in effect, things like
"AbstractPlugin.configuration()" being called twice, resulting in
LSP-pyright extending settings twice.