### PR TITLE
Add an optional ClientConfig argument to filename_to_uri and uri_to_filename

### DIFF
--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -2,9 +2,11 @@ from .collections import DottedDict
 from .logging import debug, set_debug_logging
 from .protocol import TextDocumentSyncKindNone
 from .typing import Any, Optional, List, Dict, Generator, Callable, Iterable, Union, Set, Tuple, TypeVar
-from .url import filename_to_uri
-from .url import uri_to_filename
 from threading import RLock
+from urllib.parse import urljoin
+from urllib.parse import urlparse
+from urllib.request import pathname2url
+from urllib.request import url2pathname
 from wcmatch.glob import BRACE
 from wcmatch.glob import globmatch
 from wcmatch.glob import GLOBSTAR
@@ -683,10 +685,14 @@ class ClientConfig:
                 path, mapped = path_map.map_from_local_to_remote(path)
                 if mapped:
                     break
-        return filename_to_uri(path)
+        return urljoin('file:', pathname2url(path))
 
     def map_server_uri_to_client_path(self, uri: str) -> str:
-        path = uri_to_filename(uri)
+        if os.name == 'nt':
+            # url2pathname does not understand %3A (VS Code's encoding forced on all servers :/)
+            path = url2pathname(urlparse(uri).path).strip('\\')
+        else:
+            path = url2pathname(urlparse(uri).path)
         if self.path_maps:
             for path_map in self.path_maps:
                 path, mapped = path_map.map_from_remote_to_local(path)

--- a/plugin/core/url.py
+++ b/plugin/core/url.py
@@ -1,3 +1,5 @@
+from .types import ClientConfig
+from .typing import Optional
 from urllib.parse import urljoin
 from urllib.parse import urlparse
 from urllib.request import pathname2url
@@ -5,13 +7,21 @@ from urllib.request import url2pathname
 import os
 
 
-def filename_to_uri(path: str) -> str:
-    return urljoin('file:', pathname2url(path))
-
-
-def uri_to_filename(uri: str) -> str:
-    if os.name == 'nt':
-        # url2pathname does not understand %3A (VS Code's encoding forced on all servers :/)
-        return url2pathname(urlparse(uri).path).strip('\\')
+def filename_to_uri(path: str, config: Optional[ClientConfig] = None) -> str:
+    if config:
+        return config.map_client_path_to_server_uri(path)
     else:
-        return url2pathname(urlparse(uri).path)
+        # DEPRECATED
+        return urljoin('file:', pathname2url(path))
+
+
+def uri_to_filename(uri: str, config: Optional[ClientConfig] = None) -> str:
+    if config:
+        return config.map_server_uri_to_client_path(uri)
+    else:
+        # DEPRECATED
+        if os.name == 'nt':
+            # url2pathname does not understand %3A (VS Code's encoding forced on all servers :/)
+            return url2pathname(urlparse(uri).path).strip('\\')
+        else:
+            return url2pathname(urlparse(uri).path)

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1,4 +1,6 @@
-from LSP.plugin.core.url import (filename_to_uri, uri_to_filename)
+from LSP.plugin.core.settings import read_client_config
+from LSP.plugin.core.url import filename_to_uri
+from LSP.plugin.core.url import uri_to_filename
 import sys
 import unittest
 
@@ -28,3 +30,17 @@ class NixTests(unittest.TestCase):
     @unittest.skipIf(sys.platform.startswith("win"), "requires non-Windows")
     def test_converts_uri_to_path(self):
         self.assertEqual("/dir ectory/file.txt", uri_to_filename("file:///dir ectory/file.txt"))
+
+    @unittest.skipIf(sys.platform.startswith("win"), "requires non-Windows")
+    def test_using_config(self):
+        config = read_client_config("asdf", {
+            "selector": "source.asdf",
+            "command": ["hello", "there"],
+            "path_maps": [
+                {
+                    "local": "/foo/bar",
+                    "remote": "/workspace"
+                }
+            ]
+        })
+        self.assertEqual("file:///workspace/foo.txt", filename_to_uri("/foo/bar/foo.txt", config))


### PR DESCRIPTION
This ensures backwards compatibility for the public API, because filename_to_uri
and uri_to_filename are indeed part of the API.