### PR TITLE
Work around sublime.command_url not handling 4-byte encoded UTF-8 characters

### DIFF
--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -12,6 +12,7 @@ from .typing import Optional, Dict, Any, Iterable, List, Union, Callable
 from .url import filename_to_uri
 from .url import uri_to_filename
 import html
+import json
 import linecache
 import mdpopups
 import os
@@ -487,6 +488,21 @@ def make_link(href: str, text: str, class_name: Optional[str] = None) -> str:
         return "<a href='{}'>{}</a>".format(href, text)
 
 
+def _format_command(cmd: str, args: Optional[Dict[str, Any]] = None) -> str:
+    if args is None:
+        return cmd
+    else:
+        return '{} {}'.format(cmd, json.dumps(args, ensure_ascii=False, check_circular=False, separators=(',', ':')))
+
+
+def _html_format_command(cmd: str, args: Optional[Dict[str, Any]] = None) -> str:
+    return html.escape(_format_command(cmd, args), quote=True)
+
+
+def _command_url(cmd: str, args: Optional[Dict[str, Any]] = None) -> str:
+    return 'subl:' + _html_format_command(cmd, args)
+
+
 def make_command_link(command: str, text: str, command_args: Optional[Dict[str, Any]] = None,
                       class_name: Optional[str] = None, view: Optional[sublime.View] = None) -> str:
     if view:
@@ -495,7 +511,7 @@ def make_command_link(command: str, text: str, command_args: Optional[Dict[str, 
     else:
         cmd = command
         args = command_args
-    return make_link(sublime.command_url(cmd, args), text, class_name)
+    return make_link(_command_url(cmd, args), text, class_name)
 
 
 class LspRunTextCommandHelperCommand(sublime_plugin.WindowCommand):
@@ -665,11 +681,11 @@ def format_completion(
         if item.get("command"):
             # If there is a "command", we'll have to run the command on the same session so store the name.
             args["session_name"] = session_name
-        completion = sublime.CompletionItem.command_completion(
+        completion = sublime.CompletionItem(
             trigger=st_trigger,
-            command=command,
-            args=args,
             annotation=st_annotation,
+            completion=_format_command(command, args),
+            completion_format=sublime.COMPLETION_FORMAT_COMMAND,
             kind=kind,
             details=st_details)
         if item.get("textEdit"):

--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -93,6 +93,7 @@ KIND_VARIABLE = ...  # type: Tuple[int, str, str]
 KIND_SNIPPET = ...  # type: Tuple[int, str, str]
 COMPLETION_FORMAT_TEXT = ...  # type: int
 COMPLETION_FORMAT_SNIPPET = ...  # type: int
+COMPLETION_FORMAT_COMMAND = ...  # type: int
 
 
 class Settings:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -9,6 +9,7 @@ from LSP.plugin.core.views import FORMAT_STRING, FORMAT_MARKED_STRING, FORMAT_MA
 from LSP.plugin.core.views import location_to_encoded_filename
 from LSP.plugin.core.views import lsp_color_to_html
 from LSP.plugin.core.views import lsp_color_to_phantom
+from LSP.plugin.core.views import make_command_link
 from LSP.plugin.core.views import MissingFilenameError
 from LSP.plugin.core.views import point_to_offset
 from LSP.plugin.core.views import range_to_region
@@ -313,3 +314,7 @@ class ViewsTest(DeferrableTestCase):
         self.assertEqual(
             document_color_params(self.view),
             {"textDocument": {"uri": filename_to_uri(self.view.file_name())}})
+
+    def test_make_command_link(self) -> None:
+        link = make_command_link("foo", "Run Foo", {"param1": "🦄"})
+        self.assertEqual(link, "<a href='subl:foo {&quot;param1&quot;:&quot;🦄&quot;}'>Run&nbsp;Foo</a>")


### PR DESCRIPTION
Fixes #1473