### PR TITLE
Make ClientConfig.update a class method to avoid confusion

### DIFF
--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -62,7 +62,7 @@ class WindowConfigManager(object):
                 debug("applying .sublime-project override for", name)
             else:
                 overrides = {}
-            self.all[name] = config.update(overrides)
+            self.all[name] = ClientConfig.from_config(config, overrides)
         for name in self._temp_disabled_configs:
             self.all[name].enabled = False
         self._window.run_command("lsp_recheck_sessions")

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -145,4 +145,4 @@ def read_client_config(name: str, d: Dict[str, Any]) -> ClientConfig:
 
 
 def update_client_config(external_config: ClientConfig, user_override_config: Dict[str, Any]) -> ClientConfig:
-    return external_config.update(user_override_config)
+    return ClientConfig.from_config(external_config, user_override_config)

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -612,24 +612,26 @@ class ClientConfig:
             path_maps=PathMap.parse(d.get("path_maps"))
         )
 
-    def update(self, override: Dict[str, Any]) -> "ClientConfig":
+    @classmethod
+    def from_config(cls, src_config: "ClientConfig", override: Dict[str, Any]) -> "ClientConfig":
         path_map_override = PathMap.parse(override.get("path_maps"))
         return ClientConfig(
-            name=self.name,
-            selector=_read_selector(override) or self.selector,
-            priority_selector=_read_priority_selector(override) or self.priority_selector,
-            command=override.get("command", self.command),
-            tcp_port=override.get("tcp_port", self.tcp_port),
-            auto_complete_selector=override.get("auto_complete_selector", self.auto_complete_selector),
+            name=src_config.name,
+            selector=_read_selector(override) or src_config.selector,
+            priority_selector=_read_priority_selector(override) or src_config.priority_selector,
+            command=override.get("command", src_config.command),
+            tcp_port=override.get("tcp_port", src_config.tcp_port),
+            auto_complete_selector=override.get("auto_complete_selector", src_config.auto_complete_selector),
             ignore_server_trigger_chars=bool(
-                override.get("ignore_server_trigger_chars", self.ignore_server_trigger_chars)),
-            enabled=override.get("enabled", self.enabled),
-            init_options=DottedDict.from_base_and_override(self.init_options, override.get("initializationOptions")),
-            settings=DottedDict.from_base_and_override(self.settings, override.get("settings")),
-            env=override.get("env", self.env),
+                override.get("ignore_server_trigger_chars", src_config.ignore_server_trigger_chars)),
+            enabled=override.get("enabled", src_config.enabled),
+            init_options=DottedDict.from_base_and_override(
+                src_config.init_options, override.get("initializationOptions")),
+            settings=DottedDict.from_base_and_override(src_config.settings, override.get("settings")),
+            env=override.get("env", src_config.env),
             experimental_capabilities=override.get(
-                "experimental_capabilities", self.experimental_capabilities),
-            path_maps=path_map_override if path_map_override else self.path_maps
+                "experimental_capabilities", src_config.experimental_capabilities),
+            path_maps=path_map_override if path_map_override else src_config.path_maps
         )
 
     def resolve(self, variables: Dict[str, str]) -> ResolvedStartupConfig:


### PR DESCRIPTION
An instance class called "update" should update something on the
instance, one would think, but it has instead created a new instance
of ClientConfig based on the current one.

To avoid confusion, change it to a class method that takes the source
ClientConfig instance.