### PR TITLE
Remove Sourcegraph's javascript-typescript-langserver

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -487,12 +487,6 @@ My own [tomv564/lsp-tsserver](https://github.com/tomv564/lsp-tsserver):
 npm install -g lsp-tsserver
 ```
 
-Sourcegraph's [javascript-typescript-langserver](https://github.com/sourcegraph/javascript-typescript-langserver):
-
-```sh
-npm install -g javascript-typescript-langserver
-```
-
 ### Julia<a name="julia"></a>
 
 1. Install the [Julia](https://packagecontrol.io/packages/Julia) package from Package Control for syntax highlighting.


### PR DESCRIPTION
Hello!

I hope you are doing well.

[Sourcegraph's javascript-typescript-langserver](https://github.com/sourcegraph/javascript-typescript-langserver) is unmaintained, this PR removes it from the recommended LSP servers for TypeScript. They mention [Theia's TypeScript & JavaScript Language Server](https://github.com/theia-ide/typescript-language-server) (already in the docs) as a relevant alternative.

Cheers!