### PR TITLE
Add Plugin API for overriding requests and notifications

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -544,6 +544,25 @@ class AbstractPlugin(metaclass=ABCMeta):
         """
         return False
 
+    def on_pre_send_request_async(self, request_id: int, request: Request) -> None:
+        """
+        Notifies about a request that is about to be sent to the language server.
+        This API is triggered on async thread.
+
+        :param    request_id:  The request ID.
+        :param    request:     The request object. The request params can be modified by the plugin.
+        """
+        pass
+
+    def on_pre_send_notification_async(self, notification: Notification) -> None:
+        """
+        Notifies about a notification that is about to be sent to the language server.
+        This API is triggered on async thread.
+
+        :param    notification:  The notification object. The notification params can be modified by the plugin.
+        """
+        pass
+
 
 _plugins = {}  # type: Dict[str, Tuple[Type[AbstractPlugin], SettingsRegistration]]
 
@@ -1227,6 +1246,8 @@ class Session(TransportCallbacks):
             # This is a workspace or window request
             for sv in self.session_views_async():
                 sv.on_request_started_async(request_id, request)
+        if self._plugin:
+            self._plugin.on_pre_send_request_async(request_id, request)
         self._logger.outgoing_request(request_id, request.method, request.params)
         self.send_payload(request.to_payload(request_id))
 
@@ -1246,6 +1267,8 @@ class Session(TransportCallbacks):
         return promise
 
     def send_notification(self, notification: Notification) -> None:
+        if self._plugin:
+            self._plugin.on_pre_send_notification_async(notification)
         self._logger.outgoing_notification(notification.method, notification.params)
         self.send_payload(notification.to_payload())
 


### PR DESCRIPTION
I've created this low-level API as it's difficult to otherwise create tailored and yet generic API that is not just to be used for a specific case.

LSP-json would utilize it something like this:

```py
RE_JSONC = re.compile(r'(?:\/package\.json)$')


class LspJSONPlugin(NpmClientHandler, StoreListener):

    def on_pre_send_notification_async(self, notification: Notification) -> None:
        if notification.method == 'textDocument/didOpen':
            text_document = notification.params['textDocument']
            if RE_JSONC.search(text_document['uri']):
                text_document['languageId'] = 'jsonc'
```