### PR TITLE
Fix: document highlights cannot be sent earlier than didChange

### DIFF
--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -14,7 +14,8 @@ import socket
 import sublime
 import time
 
-TCP_CONNECT_TIMEOUT = 5
+TCP_CONNECT_TIMEOUT = 5  # seconds
+FEATURES_TIMEOUT = 300  # milliseconds
 
 
 def basescope2languageid(base_scope: str) -> str:

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -144,7 +144,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
     ACTIVE_DIAGNOSTIC = "lsp_active_diagnostic"
     code_actions_debounce_time = 800
     color_boxes_debounce_time = 500
-    highlights_debounce_time = 300
+    highlights_debounce_time = 500
 
     @classmethod
     def applies_to_primary_view_only(cls) -> bool:

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -16,6 +16,7 @@ from .core.signature_help import create_signature_help
 from .core.signature_help import SignatureHelp
 from .core.types import basescope2languageid
 from .core.types import debounced
+from .core.types import FEATURES_TIMEOUT
 from .core.typing import Any, Callable, Optional, Dict, Generator, Iterable, List, Tuple, Union
 from .core.views import DIAGNOSTIC_SEVERITY
 from .core.views import document_color_params
@@ -142,9 +143,9 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
 
     CODE_ACTIONS_KEY = "lsp_code_action"
     ACTIVE_DIAGNOSTIC = "lsp_active_diagnostic"
-    code_actions_debounce_time = 800
-    color_boxes_debounce_time = 500
-    highlights_debounce_time = 500
+    code_actions_debounce_time = FEATURES_TIMEOUT
+    color_boxes_debounce_time = FEATURES_TIMEOUT
+    highlights_debounce_time = FEATURES_TIMEOUT
 
     @classmethod
     def applies_to_primary_view_only(cls) -> bool:

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -7,6 +7,7 @@ from .core.settings import userprefs
 from .core.types import Capabilities
 from .core.types import debounced
 from .core.types import Debouncer
+from .core.types import FEATURES_TIMEOUT
 from .core.typing import Any, Iterable, Optional, List, Dict, Tuple
 from .core.views import DIAGNOSTIC_SEVERITY
 from .core.views import did_change
@@ -189,7 +190,7 @@ class SessionBuffer:
                 self.pending_changes.update(change_count, changes)
                 purge = True
             if purge:
-                debounced(lambda: self.purge_changes_async(view), 500,
+                debounced(lambda: self.purge_changes_async(view), FEATURES_TIMEOUT,
                           lambda: view.is_valid() and change_count == view.change_count(), async_thread=True)
 
     def on_revert_async(self, view: sublime.View) -> None:


### PR DESCRIPTION
The text changes are buffered and sent after a 500ms timeout, provided that
nothing interesting happens like a trigger character.

The highlights are now sent after a 300ms timeout. This can cause the request
params to contain a document position that doesn't exist from the viewpoint of
the server, because those changes did not yet arrive (they will arrive another
200ms later).

This can be fixed by setting the timeout for highlights to 500ms.

Found in general rust-analyzer debugging.