### PR TITLE
Rework textDocument/signatureHelp

### DIFF
--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -10,7 +10,7 @@ TextDocumentSyncKindFull = 1
 TextDocumentSyncKindIncremental = 2
 
 
-class DiagnosticSeverity(object):
+class DiagnosticSeverity:
     Error = 1
     Warning = 2
     Information = 3
@@ -26,11 +26,17 @@ class InsertTextFormat:
     Snippet = 2
 
 
-class DocumentHighlightKind(object):
+class DocumentHighlightKind:
     Unknown = 0
     Text = 1
     Read = 2
     Write = 3
+
+
+class SignatureHelpTriggerKind:
+    Invoked = 1
+    TriggerCharacter = 2
+    ContentChange = 3
 
 
 ExecuteCommandParams = TypedDict('ExecuteCommandParams', {
@@ -54,6 +60,34 @@ CodeAction = TypedDict('CodeAction', {
     'edit': Optional[dict],
     'command': Optional[Command],
 })
+
+
+ParameterInformation = TypedDict('ParameterInformation', {
+    'label': Union[str, List[int]],
+    'documentation': Union[str, Dict[str, str]]
+}, total=False)
+
+
+SignatureInformation = TypedDict('SignatureInformation', {
+    'label': str,
+    'documentation': Union[str, Dict[str, str]],
+    'parameters': List[ParameterInformation]
+}, total=False)
+
+
+SignatureHelp = TypedDict('SignatureHelp', {
+    'signatures': List[SignatureInformation],
+    'activeSignature': int,
+    'activeParameter': int,
+}, total=False)
+
+
+SignatureHelpContext = TypedDict('SignatureHelpContext', {
+    'triggerKind': int,
+    'triggerCharacter': str,
+    'isRetrigger': bool,
+    'activeSignatureHelp': SignatureHelp
+}, total=False)
 
 
 class Request:

--- a/plugin/core/signature_help.py
+++ b/plugin/core/signature_help.py
@@ -25,7 +25,7 @@ class SigHelp:
     @classmethod
     def from_lsp(cls, sighelp: Optional[SignatureHelp]) -> "Optional[SigHelp]":
         """Create a SigHelp state object from a server's response to textDocument/signatureHelp."""
-        if sighelp is None:
+        if sighelp is None or not sighelp.get("signatures"):
             return None
         return cls(sighelp)
 

--- a/plugin/core/signature_help.py
+++ b/plugin/core/signature_help.py
@@ -122,6 +122,8 @@ class SigHelp:
             formatted.append(docs)
         docs = _signature_documentation(view, signature)
         if docs:
+            if formatted:
+                formatted.append("<hr/>")
             formatted.append('<div style="font-size: 0.9rem">')
             formatted.append(docs)
             formatted.append('</div>')

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -8,12 +8,12 @@ from .core.protocol import Diagnostic
 from .core.protocol import DocumentHighlightKind
 from .core.protocol import Range
 from .core.protocol import Request
+from .core.protocol import SignatureHelp
 from .core.registry import best_session
 from .core.registry import windows
 from .core.sessions import Session
 from .core.settings import userprefs
-from .core.signature_help import create_signature_help
-from .core.signature_help import SignatureHelp
+from .core.signature_help import SigHelp
 from .core.types import basescope2languageid
 from .core.types import debounced
 from .core.types import FEATURES_TIMEOUT
@@ -21,11 +21,8 @@ from .core.typing import Any, Callable, Optional, Dict, Generator, Iterable, Lis
 from .core.views import DIAGNOSTIC_SEVERITY
 from .core.views import document_color_params
 from .core.views import format_completion
-from .core.views import FORMAT_MARKUP_CONTENT
-from .core.views import FORMAT_STRING
 from .core.views import lsp_color_to_phantom
 from .core.views import make_command_link
-from .core.views import minihtml
 from .core.views import range_to_region
 from .core.views import region_to_range
 from .core.views import text_document_position_params
@@ -37,7 +34,6 @@ from .session_buffer import SessionBuffer
 from .session_view import SessionView
 from weakref import WeakSet
 from weakref import WeakValueDictionary
-import html
 import mdpopups
 import sublime
 import sublime_plugin
@@ -65,32 +61,6 @@ def previous_non_whitespace_char(view: sublime.View, pt: int) -> str:
     if prev.isspace():
         return view.substr(view.find_by_class(pt, False, ~0) - 1)
     return prev
-
-
-class ColorSchemeScopeRenderer:
-    def __init__(self, view: sublime.View) -> None:
-        self._scope_styles = {}  # type: dict
-        self._view = view
-        for scope in ["entity.name.function", "variable.parameter", "punctuation"]:
-            self._scope_styles[scope] = mdpopups.scope2style(view, scope)
-
-    def function(self, content: str, escape: bool = True) -> str:
-        return self._wrap_with_scope_style(content, "entity.name.function", escape=escape)
-
-    def punctuation(self, content: str) -> str:
-        return self._wrap_with_scope_style(content, "punctuation")
-
-    def parameter(self, content: str, emphasize: bool = False) -> str:
-        return self._wrap_with_scope_style(content, "variable.parameter", emphasize)
-
-    def markup(self, content: Union[str, Dict[str, str]]) -> str:
-        return minihtml(self._view, content, allowed_formats=FORMAT_STRING | FORMAT_MARKUP_CONTENT)
-
-    def _wrap_with_scope_style(self, content: str, scope: str, emphasize: bool = False, escape: bool = True) -> str:
-        color = self._scope_styles[scope]["color"]
-        additional_styles = 'font-weight: bold; text-decoration: underline;' if emphasize else ''
-        content = html.escape(content, quote=False) if escape else content
-        return '<span style="color: {};{}">{}</span>'.format(color, additional_styles, content)
 
 
 class TextChangeListener(sublime_plugin.TextChangeListener):
@@ -157,8 +127,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         self._session_views = {}  # type: Dict[str, SessionView]
         self._stored_region = sublime.Region(-1, -1)
         self._color_phantoms = sublime.PhantomSet(self.view, "lsp_color")
-        self._sighelp = None  # type: Optional[SignatureHelp]
-        self._sighelp_renderer = ColorSchemeScopeRenderer(self.view)
+        self._sighelp = None  # type: Optional[SigHelp]
         self._language_id = ""
         self._registered = False
 
@@ -318,7 +287,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             elif self._sighelp and self._sighelp.has_multiple_signatures() and not self.view.is_auto_complete_visible():
                 # We use the "operand" for the number -1 or +1. See the keybindings.
                 self._sighelp.select_signature(operand)
-                self._update_sighelp_popup(self._sighelp.build_popup_content(self._sighelp_renderer))
+                self._update_sighelp_popup(self._sighelp.render(self.view))
                 return True  # We handled this keybinding.
         return False
 
@@ -374,10 +343,10 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             self.view.hide_popup()
             self._sighelp = None
 
-    def _on_signature_help(self, response: Optional[Dict], point: int) -> None:
-        self._sighelp = create_signature_help(response)
+    def _on_signature_help(self, response: Optional[SignatureHelp], point: int) -> None:
+        self._sighelp = SigHelp.from_lsp(response)
         if self._sighelp:
-            content = self._sighelp.build_popup_content(self._sighelp_renderer)
+            content = self._sighelp.render(self.view)
 
             def render_sighelp_on_main_thread() -> None:
                 if self.view.is_popup_visible():
@@ -397,7 +366,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         mdpopups.show_popup(self.view,
                             content,
                             css=css().popups,
-                            md=True,
+                            md=False,
                             flags=flags,
                             location=point,
                             wrapper_class=css().popups_classname,
@@ -410,7 +379,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         mdpopups.update_popup(self.view,
                               content,
                               css=css().popups,
-                              md=True,
+                              md=False,
                               wrapper_class=css().popups_classname)
 
     def _on_sighelp_hide(self) -> None:

--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -958,6 +958,9 @@ class View:
     def transform_region_from(self, region: Region, change_id: Any) -> Region:
         ...
 
+    def style_for_scope(self, scope: str) -> Dict[str, str]:
+        ...
+
 
 class Buffer:
     buffer_id = ...  # type: int

--- a/tests/test_signature_help.py
+++ b/tests/test_signature_help.py
@@ -13,6 +13,10 @@ class SignatureHelpTest(unittest.TestCase):
         help = SigHelp.from_lsp(None)
         self.assertIsNone(help)
 
+    def test_empty_signature_list(self) -> None:
+        help = SigHelp.from_lsp({"signatures": [], "activeSignature": None, "activeParameter": None})
+        self.assertIsNone(help)
+
     def assert_render(self, input: SignatureHelp, regex: str) -> None:
         help = SigHelp(input)
         self.assertRegex(help.render(self.view), regex.replace("\n", "").replace("            ", ""))

--- a/tests/test_signature_help.py
+++ b/tests/test_signature_help.py
@@ -1,307 +1,246 @@
-from LSP.plugin.core.signature_help import create_signature_help
-from LSP.plugin.core.signature_help import parse_signature_information
-from LSP.plugin.core.signature_help import render_signature_label
-from LSP.plugin.core.signature_help import ScopeRenderer
-from LSP.plugin.core.signature_help import SignatureHelp
-from LSP.plugin.core.typing import Union, Dict
+from LSP.plugin.core.protocol import SignatureHelp
+from LSP.plugin.core.signature_help import SigHelp
+import sublime
 import unittest
 
-signature = {
-    'label': 'foo_bar(value: int) -> None',
-    'documentation': {'value': 'The default function for foobaring'},
-    'parameters': [{
-        'label': 'value',
-        'documentation': {
-            'value': 'A number to foobar on'
-        }
-    }]
-}  # type: dict
 
-signature_overload = {
-    'label': 'foo_bar(value: int, multiplier: int) -> None',
-    'documentation': {'value': 'Foobaring with a multiplier'},
-    'parameters': [{
-        'label': 'value',
-        'documentation': {
-            'value': 'A number to foobar on'
-        }
-    }, {
-        'label': 'multiplier',
-        'documentation': 'Change foobar to work on larger increments'
-    }]
-}  # type: dict
+class SignatureHelpTest(unittest.TestCase):
 
-signature_missing_label = {
-    'documentation': '',
-    'parameters': [{
-        'documentation': None,
-        'label': 'verbose_name'
-    }, {
-        'documentation': None,
-        'label': 'name'
-    }, {
-        'documentation': None,
-        'label': 'primary_key'
-    }, {
-        'documentation': None,
-        'label': 'max_length'
-    }],
-    'label': ''
-}
+    def setUp(self) -> None:
+        self.view = sublime.active_window().active_view()
 
-signature_information = parse_signature_information(signature)
-signature_overload_information = parse_signature_information(signature_overload)
-signature_missing_label_information = parse_signature_information(signature_missing_label)
+    def test_no_signature(self) -> None:
+        help = SigHelp.from_lsp(None)
+        self.assertIsNone(help)
 
-SINGLE_SIGNATURE = """<div class="highlight"><pre>
+    def assert_render(self, input: SignatureHelp, regex: str) -> None:
+        help = SigHelp(input)
+        self.assertRegex(help.render(self.view), regex.replace("\n", "").replace("            ", ""))
 
-<entity.name.function>foo_bar
-<punctuation>(</punctuation>
-<variable.parameter emphasize>value</variable.parameter>: int
-<punctuation>)</punctuation> -&gt; None</entity.name.function>
-</pre></div>
-<p>{'value': 'The default function for foobaring'}</p>
-<p><b>value</b>: {'value': 'A number to foobar on'}</p>"""
+    def test_signature(self) -> None:
+        self.assert_render(
+            {
+                "signatures":
+                [
+                    {
+                        "label": "f(x)",
+                        "documentation": "f does interesting things",
+                        "parameters":
+                        [
+                            {
+                                "label": "x",
+                                "documentation": "must be in the frobnicate range"
+                            }
+                        ]
+                    }
+                ],
+                "activeSignature": 0,
+                "activeParameter": 0
+            },
+            r'''
+            <div class="highlight"><pre>
+            <span style="color: #\w{6}">f\(</span>
+            <span style="color: #\w{6}; font-weight: bold; text-decoration: underline">x</span>
+            <span style="color: #\w{6}">\)</span>
+            </pre></div>
+            <p>must be in the frobnicate range</p>
+            <div style="font-size: 0\.9rem"><p>f does interesting things</p></div>
+            '''
+        )
 
-MISSING_LABEL_SIGNATURE = """<div class="highlight"><pre>
+    def test_markdown(self) -> None:
+        self.assert_render(
+            {
+                "signatures":
+                [
+                    {
+                        "label": "f(x)",
+                        "documentation":
+                        {
+                            "value": "f does _interesting_ things",
+                            "kind": "markdown"
+                        },
+                        "parameters":
+                        [
+                            {
+                                "label": "x",
+                                "documentation":
+                                {
+                                    "value": "must be in the **frobnicate** range",
+                                    "kind": "markdown"
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "activeSignature": 0,
+                "activeParameter": 0
+            },
+            r'''
+            <div class="highlight"><pre>
+            <span style="color: #\w{6}">f\(</span>
+            <span style="color: #\w{6}; font-weight: bold; text-decoration: underline">x</span>
+            <span style="color: #\w{6}">\)</span>
+            </pre></div>
+            <p>must be in the <strong>frobnicate</strong> range</p>
+            <div style="font-size: 0\.9rem"><p>f does <em>interesting</em> things</p></div>
+            '''
+        )
 
-<entity.name.function></entity.name.function>
-</pre></div>"""
+    def test_second_parameter(self) -> None:
+        self.assert_render(
+            {
+                "signatures":
+                [
+                    {
+                        "label": "f(x, y)",
+                        "parameters":
+                        [
+                            {
+                                "label": "x"
+                            },
+                            {
+                                "label": "y",
+                                "documentation": "hello there"
+                            }
+                        ]
+                    }
+                ],
+                "activeSignature": 0,
+                "activeParameter": 1
+            },
+            r'''
+            <div class="highlight"><pre>
+            <span style="color: #\w{6}">f\(</span>
+            <span style="color: #\w{6}">x</span>
+            <span style="color: #\w{6}">, </span>
+            <span style="color: #\w{6}; font-weight: bold; text-decoration: underline">y</span>
+            <span style="color: #\w{6}">\)</span>
+            </pre></div>
+            <p>hello there</p>
+            '''
+        )
 
-OVERLOADS_FIRST = """**1** of **2** overloads (use the ↑ ↓ keys to navigate, press ESC to hide):
+    def test_parameter_ranges(self) -> None:
+        self.assert_render(
+            {
+                "signatures":
+                [
+                    {
+                        "label": "f(x, y)",
+                        "parameters":
+                        [
+                            {
+                                "label": [2, 3],
+                            },
+                            {
+                                "label": [5, 6],
+                                "documentation": "hello there"
+                            }
+                        ]
+                    }
+                ],
+                "activeSignature": 0,
+                "activeParameter": 1
+            },
+            r'''
+            <div class="highlight"><pre>
+            <span style="color: #\w{6}">f\(</span>
+            <span style="color: #\w{6}">x</span>
+            <span style="color: #\w{6}">, </span>
+            <span style="color: #\w{6}; font-weight: bold; text-decoration: underline">y</span>
+            <span style="color: #\w{6}">\)</span>
+            </pre></div>
+            <p>hello there</p>
+            '''
+        )
 
-<div class="highlight"><pre>
+    def test_overloads(self) -> None:
+        self.assert_render(
+            {
+                "signatures":
+                [
+                    {
+                        "label": "f(x, y)",
+                        "parameters":
+                        [
+                            {
+                                "label": [2, 3]
+                            },
+                            {
+                                "label": [5, 6],
+                                "documentation": "hello there"
+                            }
+                        ]
+                    },
+                    {
+                        "label": "f(x, a, b)",
+                        "parameters":
+                        [
+                            {
+                                "label": [2, 3]
+                            },
+                            {
+                                "label": [5, 6]
+                            },
+                            {
+                                "label": [8, 9]
+                            }
+                        ]
+                    }
+                ],
+                "activeSignature": 1,
+                "activeParameter": 0
+            },
+            r'''
+            <p>
+            <div style="font-size: 0\.9rem">
+            <b>2</b> of <b>2</b> overloads \(use ↑ ↓ to navigate, press Esc to hide\):
+            </div>
+            </p>
+            <div class="highlight"><pre><span style="color: #52fa7c">f\(</span>
+            <span style="color: #\w{6}; font-weight: bold; text-decoration: underline">x</span>
+            <span style="color: #\w{6}">, </span>
+            <span style="color: #\w{6}">a</span>
+            <span style="color: #\w{6}">, </span>
+            <span style="color: #\w{6}">b</span>
+            <span style="color: #\w{6}">\)</span>
+            </pre></div>
+            '''
+        )
 
-<entity.name.function>foo_bar
-<punctuation>(</punctuation>
-<variable.parameter emphasize>value</variable.parameter>: int
-<punctuation>)</punctuation> -&gt; None</entity.name.function>
-</pre></div>
-<p>{'value': 'The default function for foobaring'}</p>
-<p><b>value</b>: {'value': 'A number to foobar on'}</p>"""
-
-
-OVERLOADS_SECOND = """**2** of **2** overloads (use the ↑ ↓ keys to navigate, press ESC to hide):
-
-<div class="highlight"><pre>
-
-<entity.name.function>foo_bar
-<punctuation>(</punctuation>
-<variable.parameter emphasize>value</variable.parameter>: int,\
- \n<variable.parameter>multiplier</variable.parameter>: int
-<punctuation>)</punctuation> -&gt; None</entity.name.function>
-</pre></div>
-<p>{'value': 'Foobaring with a multiplier'}</p>
-<p><b>value</b>: {'value': 'A number to foobar on'}</p>"""
-
-OVERLOADS_SECOND_SECOND_PARAMETER = """**2** of **2** overloads (use the ↑ ↓ keys to navigate, press ESC to hide):
-
-<div class="highlight"><pre>
-
-<entity.name.function>foo_bar
-<punctuation>(</punctuation>
-<variable.parameter>value</variable.parameter>: int,\
- \n<variable.parameter emphasize>multiplier</variable.parameter>: int
-<punctuation>)</punctuation> -&gt; None</entity.name.function>
-</pre></div>
-<p>{'value': 'Foobaring with a multiplier'}</p>
-<p><b>multiplier</b>: Change foobar to work on larger increments</p>"""
-
-
-JSON_STRINGIFY = """"""
-
-
-def create_signature(label: str, *param_labels, **kwargs) -> dict:
-    raw = dict(label=label, parameters=list(dict(label=param_label) for param_label in param_labels))
-    raw.update(kwargs)
-    return raw
-
-
-class MockRenderer(ScopeRenderer):
-
-    def function(self, content: str, escape: bool = True) -> str:
-        return self._wrap_with_scope_style(content, "entity.name.function")
-
-    def punctuation(self, content: str) -> str:
-        return self._wrap_with_scope_style(content, "punctuation")
-
-    def parameter(self, content: str, emphasize: bool = False) -> str:
-        return self._wrap_with_scope_style(content, "variable.parameter", emphasize)
-
-    def _wrap_with_scope_style(self, content: str, scope: str, emphasize: bool = False) -> str:
-        return '\n<{}{}>{}</{}>'.format(scope, " emphasize" if emphasize else "", content, scope)
-
-    def markup(self, content: Union[str, Dict[str, str]]) -> str:
-        return content
-
-
-renderer = MockRenderer()
-
-
-class CreateSignatureHelpTests(unittest.TestCase):
-
-    def test_none(self):
-        self.assertIsNone(create_signature_help(None))
-
-    def test_empty(self):
-        self.assertIsNone(create_signature_help({}))
-
-    def test_default_indices(self):
-
-        help = create_signature_help({"signatures": [signature]})
-
-        self.assertIsNotNone(help)
-        if help:
-            self.assertEqual(help._active_signature_index, 0)
-            self.assertEqual(help._active_parameter_index, -1)
-
-    def test_dockerfile_signature_help(self):
-        info = parse_signature_information({
-            'label': 'RUN [ "command" "parameters", ... ]',
-            'parameters': [
-                {'label': '['},
-                {'label': '"command"'},
-                {'label': '"parameters"'},
-                {'label': '...'},
-                {'label': ']'}
-            ]})
-        self.assertEqual(info.label, 'RUN [ "command" "parameters", ... ]')
-        self.assertEqual(len(info.parameters), 5)
-        self.assertEqual(info.parameters[0].label, '[')
-        self.assertEqual(info.parameters[1].label, '"command"')
-        self.assertEqual(info.parameters[2].label, '"parameters"')
-        self.assertEqual(info.parameters[3].label, '...')
-        self.assertEqual(info.parameters[4].label, ']')
-        # There are no open and close parentheses.
-        self.assertEqual(info.open_paren_index, -1)
-        self.assertEqual(info.close_paren_index, -1)
-
-
-class RenderSignatureLabelTests(unittest.TestCase):
-
-    def test_no_parameters(self):
-        sig = create_signature("foobar()")
-        help = create_signature_help(dict(signatures=[sig]))
-        if help:
-            label = render_signature_label(renderer, help.active_signature(), 0)
-            self.assertEqual(label, "\n<entity.name.function>foobar()</entity.name.function>")
-
-    def test_params(self):
-        sig = create_signature("foobar(foo, foo)", "foo", "foo", activeParameter=1)
-        help = create_signature_help(dict(signatures=[sig]))
-        if help:
-            label = render_signature_label(renderer, help.active_signature(), 1)
-            self.assertEqual(label, """
-<entity.name.function>foobar
-<punctuation>(</punctuation>
-<variable.parameter>foo</variable.parameter>,\
- \n<variable.parameter emphasize>foo</variable.parameter>
-<punctuation>)</punctuation></entity.name.function>""")
-
-    def test_params_are_substrings(self):
-        sig = create_signature("foobar(self, foo: str, foo: i32)", "foo", "foo", activeParameter=1)
-        help = create_signature_help(dict(signatures=[sig]))
-        if help:
-            label = render_signature_label(renderer, help.active_signature(), 1)
-            self.assertEqual(label, """
-<entity.name.function>foobar
-<punctuation>(</punctuation>self,\
- \n<variable.parameter>foo</variable.parameter>: str,\
- \n<variable.parameter emphasize>foo</variable.parameter>: i32
-<punctuation>)</punctuation></entity.name.function>""")
-
-    def test_params_are_substrings_before_comma(self):
-        sig = create_signature("f(x: str, t)", "x", "t")
-        help = create_signature_help(dict(signatures=[sig]))
-        if help:
-            label = render_signature_label(renderer, help.active_signature(), 0)
-            self.assertEqual(label, """
-<entity.name.function>f
-<punctuation>(</punctuation>\
-\n<variable.parameter emphasize>x</variable.parameter>: str,\
- \n<variable.parameter>t</variable.parameter>
-<punctuation>)</punctuation></entity.name.function>""")
-
-    def test_params_with_range(self):
-        sig = create_signature("foobar(foo, foo)", [7, 10], [12, 15], activeParameter=1)
-        help = create_signature_help(dict(signatures=[sig]))
-        if help:
-            label = render_signature_label(renderer, help.active_signature(), 1)
-            self.assertEqual(label, """
-<entity.name.function>foobar
-<punctuation>(</punctuation>
-<variable.parameter>foo</variable.parameter>,\
- \n<variable.parameter emphasize>foo</variable.parameter>
-<punctuation>)</punctuation></entity.name.function>""")
-
-    def test_params_no_parens(self):
-        # note: will not work without ranges: first "foo" param will match "foobar"
-        sig = create_signature("foobar foo foo", [7, 10], [11, 14], activeParameter=1)
-        help = create_signature_help(dict(signatures=[sig]))
-        if help:
-            label = render_signature_label(renderer, help.active_signature(), 1)
-            self.assertEqual(label, """
-<entity.name.function>foobar\
- \n<variable.parameter>foo</variable.parameter>\
- \n<variable.parameter emphasize>foo</variable.parameter></entity.name.function>""")
-
-    def test_long_signature(self):
-        # self.maxDiff = None
-        sig = create_signature(
-            """do_the_foo_bar_if_correct_with_optional_bar_and_uppercase_option(takes_a_mandatory_foo: int, \
-bar_if_needed: Optional[str], in_uppercase: Optional[bool]) -> Optional[str]""",
-            "takes_a_mandatory_foo",
-            "bar_if_needed",
-            "in_uppercase",
-            activeParameter=1)
-        help = create_signature_help(dict(signatures=[sig]))
-        if help:
-            label = render_signature_label(renderer, help.active_signature(), 1)
-            self.assertEqual(label, """
-<entity.name.function>do_the_foo_bar_if_correct_with_optional_bar_and_uppercase_option
-<punctuation>(</punctuation>
-<variable.parameter>takes_a_mandatory_foo</variable.parameter>: int,\
- <br>&nbsp;&nbsp;&nbsp;&nbsp;\n<variable.parameter emphasize>bar_if_needed</variable.parameter>: Optional[str],\
- <br>&nbsp;&nbsp;&nbsp;&nbsp;\n<variable.parameter>in_uppercase</variable.parameter>: Optional[bool]
-<punctuation>)</punctuation> -&gt; Optional[str]</entity.name.function>""")
-
-
-class SignatureHelpTests(unittest.TestCase):
-
-    def test_single_signature(self):
-        help = SignatureHelp([signature_information])
-        self.assertIsNotNone(help)
-        if help:
-            content = help.build_popup_content(renderer)
-            self.assertFalse(help.has_multiple_signatures())
-            self.assertEqual(content, SINGLE_SIGNATURE)
-
-    def test_signature_missing_label(self):
-        help = SignatureHelp([signature_missing_label_information])
-        self.assertIsNotNone(help)
-        if help:
-            content = help.build_popup_content(renderer)
-            self.assertFalse(help.has_multiple_signatures())
-            self.assertEqual(content, MISSING_LABEL_SIGNATURE)
-
-    def test_overload(self):
-        help = SignatureHelp([signature_information, signature_overload_information])
-        self.assertIsNotNone(help)
-        if help:
-            content = help.build_popup_content(renderer)
-            self.assertTrue(help.has_multiple_signatures())
-            self.assertEqual(content, OVERLOADS_FIRST)
-
-            help.select_signature(1)
-            help.select_signature(1)  # verify we don't go out of bounds,
-            content = help.build_popup_content(renderer)
-            self.assertEqual(content, OVERLOADS_SECOND)
-
-    def test_active_parameter(self):
-        help = SignatureHelp([signature_information, signature_overload_information], active_signature=1,
-                             active_parameter=1)
-        self.assertIsNotNone(help)
-        if help:
-            content = help.build_popup_content(renderer)
-            self.assertTrue(help.has_multiple_signatures())
-            self.assertEqual(content, OVERLOADS_SECOND_SECOND_PARAMETER)
+    def test_dockerfile_signature(self) -> None:
+        self.assert_render(
+            {
+                "signatures":
+                [
+                    {
+                        "label": 'RUN [ "command" "parameters", ... ]',
+                        "parameters":
+                        [
+                            {'label': '['},
+                            {'label': '"command"'},
+                            {'label': '"parameters"'},
+                            {'label': '...'},
+                            {'label': ']'}
+                        ]
+                    }
+                ],
+                "activeSignature": 0,
+                "activeParameter": 2
+            },
+            r'''
+            <div class="highlight"><pre>
+            <span style="color: #\w{6}">RUN </span>
+            <span style="color: #\w{6}">\[</span>
+            <span style="color: #\w{6}"> </span>
+            <span style="color: #\w{6}">"command"</span>
+            <span style="color: #\w{6}"> </span>
+            <span style="color: #\w{6}; font-weight: bold; text-decoration: underline">"parameters"</span>
+            <span style="color: #\w{6}">, </span>
+            <span style="color: #\w{6}">\.\.\.</span>
+            <span style="color: #\w{6}"> </span>
+            <span style="color: #\w{6}">\]</span>
+            </pre></div>
+            '''
+        )

--- a/tests/test_signature_help.py
+++ b/tests/test_signature_help.py
@@ -14,11 +14,12 @@ class SignatureHelpTest(unittest.TestCase):
         self.assertIsNone(help)
 
     def test_empty_signature_list(self) -> None:
-        help = SigHelp.from_lsp({"signatures": [], "activeSignature": None, "activeParameter": None})
+        help = SigHelp.from_lsp({"signatures": []})
         self.assertIsNone(help)
 
     def assert_render(self, input: SignatureHelp, regex: str) -> None:
         help = SigHelp(input)
+        assert self.view
         self.assertRegex(help.render(self.view), regex.replace("\n", "").replace("            ", ""))
 
     def test_signature(self) -> None:
@@ -48,6 +49,7 @@ class SignatureHelpTest(unittest.TestCase):
             <span style="color: #\w{6}">\)</span>
             </pre></div>
             <p>must be in the frobnicate range</p>
+            <hr/>
             <div style="font-size: 0\.9rem"><p>f does interesting things</p></div>
             '''
         )
@@ -87,6 +89,7 @@ class SignatureHelpTest(unittest.TestCase):
             <span style="color: #\w{6}">\)</span>
             </pre></div>
             <p>must be in the <strong>frobnicate</strong> range</p>
+            <hr/>
             <div style="font-size: 0\.9rem"><p>f does <em>interesting</em> things</p></div>
             '''
         )


### PR DESCRIPTION
- Proper handling of markdown parameter docs.
- Don't assume that function signatures have an `(` and `)`.
- Put the *active parameter docs* at the top, font-size 1rem.
- Put the *signature docs* under that, font-size 0.9rem.
- Use 0.9rem font-size for the intro message.
- KISS.

close #1001 