### PR TITLE
Display the diagnostic code

### DIFF
--- a/Syntaxes/Diagnostics.sublime-syntax
+++ b/Syntaxes/Diagnostics.sublime-syntax
@@ -21,8 +21,8 @@ contexts:
     - match: ^\s+(?=\d)
       push:
         - ensure-diag-meta-scope
-        - expect-message
         - expect-source-and-code
+        - expect-message
         - expect-severity
         - expect-row-col
 
@@ -34,6 +34,8 @@ contexts:
   expect-message:
     # Various server-specific tokens may get special treatment here in the diag message.
     - include: pop-at-end
+    - match: \x{200b}  # Zero-width space
+      pop: true
 
   expect-severity:
     # Implements RFC1036: https://github.com/sublimehq/Packages/issues/1036
@@ -52,13 +54,11 @@ contexts:
 
   expect-source-and-code:
     - include: pop-at-end
-    - match: (\[)([^:\]]+)((:)(\S+))?(\])
+    - match: ([^:\]]+)((:)(\S+))?
       captures:
-        1: punctuation.section.brackets.begin.lsp
-        2: comment.line.lsp
-        4: punctuation.separator.lsp
-        5: constant.numeric.code.lsp
-        6: punctuation.section.brackets.end.lsp
+        1: comment.line.source.lsp
+        3: punctuation.separator.lsp
+        4: comment.line.code.lsp
       pop: true
 
   expect-row-col:

--- a/Syntaxes/Diagnostics.sublime-syntax
+++ b/Syntaxes/Diagnostics.sublime-syntax
@@ -5,44 +5,38 @@
 hidden: true
 scope: output.lsp.diagnostics
 
-variables:
-  start_of_diag_body: ^\s+(?=\d)
-  filename_and_colon: ^\s*(\S)\s+(.*)(:)$
-
 contexts:
   main:
-    - include: diagnostic-preamble
-    - include: diagnostic-body
+    - include: file
+    - include: line
 
-  diagnostic-preamble:
-    - match: '{{filename_and_colon}}'
+  file:
+    - match: ^(.*)(:)$
       captures:
         0: meta.diagnostic.preamble.lsp
-        1: punctuation.section.diagnostics.preample.lsp
-        2: string.unquoted.lsp
-        3: punctuation.separator.lsp
+        1: string.unquoted.lsp
+        2: punctuation.separator.lsp
 
-  diagnostic-body:
-    - match: '{{start_of_diag_body}}'
+  line:
+    - match: ^\s+(?=\d)
       push:
         - ensure-diag-meta-scope
-        - expect-diag-message
-        - expect-diag-type
-        - expect-linter-type
-        - expect-line-maybe-column
+        - expect-message
+        - expect-source-and-code
+        - expect-severity
+        - expect-row-col
 
   ensure-diag-meta-scope:
     - meta_scope: meta.diagnostic.body.lsp
     - match: ""  # match the empty string
       pop: true
 
-  expect-diag-message:
+  expect-message:
     # Various server-specific tokens may get special treatment here in the diag message.
     - include: pop-at-end
 
-  expect-diag-type:
-    # See: https://github.com/sublimehq/Packages/issues/1036
-    # We use sublimelinter markup scopes too so that old color schemes can catch up.
+  expect-severity:
+    # Implements RFC1036: https://github.com/sublimehq/Packages/issues/1036
     - include: pop-at-end
     - match: \berror\b
       scope: markup.deleted.lsp sublimelinter.mark.error markup.error.lsp
@@ -53,16 +47,23 @@ contexts:
     - match: \binfo\b
       scope: markup.inserted.lsp sublimelinter.gutter-mark markup.info.lsp
       pop: true
+    - match: \bhint\b
+      scope: markup.inserted.lsp sublimelinter.gutter-mark markup.info.hint.lsp
 
-  expect-linter-type:
+  expect-source-and-code:
     - include: pop-at-end
-    - match: \S+
-      scope: comment.line.lsp
+    - match: (\[)([^:\]]+)((:)(\S+))?(\])
+      captures:
+        1: punctuation.section.brackets.begin.lsp
+        2: comment.line.lsp
+        4: punctuation.separator.lsp
+        5: constant.numeric.code.lsp
+        6: punctuation.section.brackets.end.lsp
       pop: true
 
-  expect-line-maybe-column:
+  expect-row-col:
     - include: pop-at-end
-    - match: (\d+)(?:(:)(\d+))?
+    - match: (\d+)(:)(\d+)
       captures:
         1: constant.numeric.integer.decimal.lsp
         2: punctuation.separator.lsp

--- a/plugin/core/diagnostics.py
+++ b/plugin/core/diagnostics.py
@@ -7,7 +7,7 @@ import sublime
 
 
 def ensure_diagnostics_panel(window: sublime.Window) -> Optional[sublime.View]:
-    return ensure_panel(window, "diagnostics", r"^\s*\S\s+(\S.*):$", r"^\s+([0-9]+):?([0-9]+).*$",
+    return ensure_panel(window, "diagnostics", r"^(.*):$", r"^\s+(\d+):(\d+)",
                         "Packages/LSP/Syntaxes/Diagnostics.sublime-syntax")
 
 

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -39,6 +39,11 @@ class SignatureHelpTriggerKind:
     ContentChange = 3
 
 
+CodeDescription = TypedDict('CodeDescription', {
+    'href': str
+}, total=True)
+
+
 ExecuteCommandParams = TypedDict('ExecuteCommandParams', {
     'command': str,
     'arguments': Optional[List[Any]],
@@ -383,7 +388,7 @@ class Location(object):
         )
 
 
-class DiagnosticRelatedInformation(object):
+class DiagnosticRelatedInformation:
 
     def __init__(self, location: Location, message: str) -> None:
         self.location = location
@@ -396,15 +401,27 @@ class DiagnosticRelatedInformation(object):
             lsp_related_information["message"])
 
 
-class Diagnostic(object):
-    def __init__(self, message: str, range: Range, severity: int, source: Optional[str], lsp_diagnostic: dict,
-                 related_info: List[DiagnosticRelatedInformation]) -> None:
+class Diagnostic:
+    def __init__(
+        self,
+        message: str,
+        range: Range,
+        severity: int,
+        code: Union[None, int, str],
+        code_description: Optional[CodeDescription],
+        source: Optional[str],
+        lsp_diagnostic: dict,
+        related_info: List[DiagnosticRelatedInformation]
+    ) -> None:
         self.message = message
         self.range = range
         self.severity = severity
+        self.code = code
+        self.code_description = code_description
         self.source = source
         self._lsp_diagnostic = lsp_diagnostic
         self.related_info = related_info
+        self.code
 
     @classmethod
     def from_lsp(cls, lsp_diagnostic: dict) -> 'Diagnostic':
@@ -414,6 +431,8 @@ class Diagnostic(object):
             Range.from_lsp(lsp_diagnostic['range']),
             # optional keys
             lsp_diagnostic.get('severity', DiagnosticSeverity.Error),
+            lsp_diagnostic.get('code'),
+            lsp_diagnostic.get('codeDescription'),
             lsp_diagnostic.get('source'),
             lsp_diagnostic,
             [DiagnosticRelatedInformation.from_lsp(info) for info in lsp_diagnostic.get('relatedInformation') or []]

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -221,7 +221,10 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
                 "dynamicRegistration": True  # exceptional
             },
             "publishDiagnostics": {
-                "relatedInformation": True
+                "relatedInformation": True,
+                "versionSupport": True,
+                "codeDescriptionSupport": True,
+                "dataSupport": True
             },
             "selectionRange": {
                 "dynamicRegistration": True

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -546,7 +546,7 @@ def format_diagnostic_for_panel(diagnostic: Diagnostic) -> str:
     formatted = [diagnostic.source if diagnostic.source else "unknown-source"]
     if diagnostic.code:
         formatted.extend((":", str(diagnostic.code)))
-    lines = (diagnostic.message.splitlines() or [""])
+    lines = diagnostic.message.splitlines() or [""]
     # \u200B is the zero-width space
     result = "{:>4}:{:<4}{:<8}{} \u200B{}".format(
         diagnostic.range.start.row + 1,

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -542,13 +542,9 @@ def format_severity(severity: int) -> str:
 
 
 def format_diagnostic_for_panel(diagnostic: Diagnostic) -> str:
-    if diagnostic.code_description:
-        code = make_link(diagnostic.code_description["href"], diagnostic.code)  # type: Optional[str]
-    else:
-        code = str(diagnostic.code) if diagnostic.code else None
     formatted = [diagnostic.source if diagnostic.source else "unknown-source"]
-    if code:
-        formatted.extend((":", code))
+    if diagnostic.code:
+        formatted.extend((":", str(diagnostic.code)))
     # \u200B is the zero-width space
     return "{:>4}:{:<4}{:<8}{} \u200B{}".format(
         diagnostic.range.start.row + 1,

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -19,6 +19,7 @@ import re
 import sublime
 import sublime_plugin
 import tempfile
+import itertools
 
 DIAGNOSTIC_SEVERITY = [
     # Kind       CSS class   Scope for color     Icon resource
@@ -545,14 +546,18 @@ def format_diagnostic_for_panel(diagnostic: Diagnostic) -> str:
     formatted = [diagnostic.source if diagnostic.source else "unknown-source"]
     if diagnostic.code:
         formatted.extend((":", str(diagnostic.code)))
+    lines = (diagnostic.message.splitlines() or [""])
     # \u200B is the zero-width space
-    return "{:>4}:{:<4}{:<8}{} \u200B{}".format(
+    result = "{:>4}:{:<4}{:<8}{} \u200B{}".format(
         diagnostic.range.start.row + 1,
         diagnostic.range.start.col + 1,
         format_severity(diagnostic.severity),
-        (diagnostic.message.splitlines() or [""])[0],
+        lines[0],
         "".join(formatted)
     )
+    for line in itertools.islice(lines, 1, None):
+        result += "\n" + 17 * " " + line
+    return result
 
 
 def _format_diagnostic_related_info(info: DiagnosticRelatedInformation, base_dir: Optional[str] = None) -> str:

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -566,21 +566,24 @@ def _format_diagnostic_related_info(info: DiagnosticRelatedInformation, base_dir
     return '<a href="location:{}">{}</a>: {}'.format(encoded_filename, text2html(file_path), text2html(info.message))
 
 
+def _with_color(text: Any, hexcolor: str) -> str:
+    return '<span style="color: {};">{}</span>'.format(hexcolor, text)
+
+
 def _with_scope_color(view: sublime.View, text: Any, scope: str) -> str:
-    return '<span style="color: {};">{}</span>'.format(view.style_for_scope(scope)["foreground"], text)
+    return _with_color(text, view.style_for_scope(scope)["foreground"])
 
 
 def format_diagnostic_for_html(view: sublime.View, diagnostic: Diagnostic, base_dir: Optional[str] = None) -> str:
     formatted = ['<pre class="', DIAGNOSTIC_SEVERITY[diagnostic.severity - 1][1], '">', text2html(diagnostic.message)]
     if diagnostic.code_description:
         code = make_link(diagnostic.code_description["href"], diagnostic.code)  # type: Optional[str]
+    elif diagnostic.code:
+        code = _with_color(diagnostic.code, "color(var(--foreground) alpha(0.6))")
     else:
-        code = _with_scope_color(view, diagnostic.code, "comment.line.code.lsp") if diagnostic.code else None
+        code = None
     source = diagnostic.source if diagnostic.source else "unknown-source"
-    formatted.extend((
-        " ",
-        _with_scope_color(view, source, "comment.line.source.lsp")
-    ))
+    formatted.extend((" ", _with_color(source, "color(var(--foreground) alpha(0.6))")))
     if code:
         formatted.extend((_with_scope_color(view, ":", "punctuation.separator.lsp"), code))
     if diagnostic.related_info:

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -425,7 +425,7 @@ class WindowManager(Manager):
             file_path = listener.view.file_name() or ""
             base_dir = self.get_project_path(file_path)  # What about different base dirs for multiple folders?
             file_path = os.path.relpath(file_path, base_dir) if base_dir else file_path
-            to_render.append(" ◌ {}:".format(file_path))
+            to_render.append("{}:".format(file_path))
             to_render.extend(contribution)
         if isinstance(base_dir, str):
             panel.settings().set("result_base_dir", base_dir)

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -119,7 +119,7 @@ class LspHoverCommand(LspTextCommand):
             formatted.append('<div class="diagnostics">')
             for diagnostic in self._diagnostics_by_config[config_name]:
                 by_severity.setdefault(diagnostic.severity, []).append(
-                    format_diagnostic_for_html(diagnostic, self._base_dir))
+                    format_diagnostic_for_html(self.view, diagnostic, self._base_dir))
             for items in by_severity.values():
                 formatted.extend(items)
             if config_name in self._actions_by_config:
@@ -127,7 +127,7 @@ class LspHoverCommand(LspTextCommand):
                 if action_count > 0:
                     href = "{}:{}".format('code-actions', config_name)
                     text = "choose code action ({} available)".format(action_count)
-                    formatted.append('<div class="actions">{}</div>'.format(make_link(href, text)))
+                    formatted.append('<div class="actions">[{}] {}</div>'.format(config_name, make_link(href, text)))
             formatted.append("</div>")
         return "".join(formatted)
 


### PR DESCRIPTION
Both in the hover popup, as well as in the diagnostic panel.
The hover popup additionally creates a clickable link if there exists a
codeDescription field with a URL.

I have also freshened up the diagnostics panel. It looks more like
SublimeLinter's panel now.

Resolves #1173
Resolves #1367

Impressions:

<img width="943" alt="Schermafbeelding 2020-12-09 om 21 40 58" src="https://user-images.githubusercontent.com/2431823/101687766-434d8e80-3a6b-11eb-8e73-93765882b78f.png">

<img width="1106" alt="Schermafbeelding 2020-12-09 om 22 02 31" src="https://user-images.githubusercontent.com/2431823/101687780-48124280-3a6b-11eb-82a1-dd3eb376e795.png">
