### PR TITLE
Sort diagnostics in the diagnostics panel

### DIFF
--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -180,7 +180,8 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
                 data = sb.data_per_severity.get(severity)
                 if data:
                     result.extend(data.panel_contribution)
-        return result
+        # sort the result by asc line number
+        return sorted(result)
 
     def diagnostics_async(self) -> Generator[Tuple[SessionBuffer, List[Diagnostic]], None, None]:
         for sb in self.session_buffers_async():


### PR DESCRIPTION
Sort the diagnostics by ascending line number.

Before:
```
plugin/configuration.py:
  10:32  error   Expected ":" ​Pyright
  11:13  error   Expected expression ​Pyright
  12:14  error   Expected expression ​Pyright
  13:13  error   Unexpected indentation ​Pyright
  15:5   error   Unindent not expected ​Pyright
  21:1   error   Unindent not expected ​Pyright
  13:13  error   "self" is not defined ​Pyright (reportUndefinedVariable)
```

After:
```
plugin/configuration.py:
  10:32  error   Expected ":" ​Pyright
  11:13  error   Expected expression ​Pyright
  12:14  error   Expected expression ​Pyright
  13:13  error   "self" is not defined ​Pyright (reportUndefinedVariable)
  13:13  error   Unexpected indentation ​Pyright
  15:5   error   Unindent not expected ​Pyright
  21:1   error   Unindent not expected ​Pyright
```