### PR TITLE
fix: diagnostics line regex

### DIFF
--- a/Syntaxes/Diagnostics.sublime-syntax
+++ b/Syntaxes/Diagnostics.sublime-syntax
@@ -18,7 +18,7 @@ contexts:
         2: punctuation.separator.lsp
 
   line:
-    - match: ^\s+(?=\d)
+    - match: ^\s*(?=\d)
       push:
         - ensure-diag-meta-scope
         - expect-source-and-code

--- a/plugin/core/diagnostics.py
+++ b/plugin/core/diagnostics.py
@@ -7,7 +7,7 @@ import sublime
 
 
 def ensure_diagnostics_panel(window: sublime.Window) -> Optional[sublime.View]:
-    return ensure_panel(window, "diagnostics", r"^(.*):$", r"^\s+(\d+):(\d+)",
+    return ensure_panel(window, "diagnostics", r"^(.*):$", r"^\s*(\d+):(\d+)",
                         "Packages/LSP/Syntaxes/Diagnostics.sublime-syntax")
 
 


### PR DESCRIPTION
This PR will make sure the last line `1018:1   error   Invalid type "sublime.TextChange.str" mypy`
is also matched with the line regex. (so the f4 and shift+f4 will work for those lines).

```
plugin/documents.py:
   3:2   error   Cannot find module named '.completion' mypy
   4:2   error   Cannot find module named '.core.css' mypy
   ...
1018:1   error   Invalid type "sublime.TextChange.str" mypy
```

![image](https://user-images.githubusercontent.com/22029477/101963399-e25ebb80-3c0e-11eb-9ce4-4bb7a62e2b49.png)
