### PR TITLE
Never close the diags panel automatically, and more

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -2,12 +2,7 @@
   // Show permanent language server status in the status bar.
   "show_view_status": true,
 
-  // Open and close the diagnostics panel automatically,
-  // depending on available diagnostics.
-  // Valid values are "never", "always" and "saved"
-  "auto_show_diagnostics_panel": "saved",
-
-  // Run the server's formatProvider (if supported) on a document before saving.
+  // Run the server's formatProvider (if supported) on a file before saving.
   // This option is also supported in syntax-specific settings and/or in the
   // "settings" section of project files.
   "lsp_format_on_save": false,
@@ -32,8 +27,9 @@
   // The amount of time the code actions on save are allowed to run for.
   "code_action_on_save_timeout_ms": 2000,
 
-  // Open the diagnostics panel automatically
-  // when diagnostics level is equal to or less than:
+  // Open the diagnostics panel automatically on save when diagnostics level is
+  // equal to or less than:
+  // none: 0 (never open the panel automatically)
   // error: 1
   // warning: 2
   // info: 3
@@ -49,7 +45,7 @@
 
   // Show highlights and gutter markers in the file views for diagnostics
   // with level equal to or less than:
-  // none: 0
+  // none: 0 (never show)
   // error: 1
   // warning: 2
   // info: 3

--- a/Syntaxes/Diagnostics.sublime-syntax
+++ b/Syntaxes/Diagnostics.sublime-syntax
@@ -7,6 +7,8 @@ scope: output.lsp.diagnostics
 
 contexts:
   main:
+    - match: ^  No diagnostics. Well done!$
+      scope: comment.line.placeholder.lsp
     - include: file
     - include: line
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -97,10 +97,6 @@ class Manager(metaclass=ABCMeta):
     def show_diagnostics_panel_async(self) -> None:
         pass
 
-    @abstractmethod
-    def hide_diagnostics_panel_async(self) -> None:
-        pass
-
     # Event callbacks
 
     @abstractmethod

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -144,7 +144,6 @@ def read_list_setting(settings_obj: sublime.Settings, key: str, default: list) -
 class Settings:
 
     # This is only for mypy
-    auto_show_diagnostics_panel = None  # type: str
     auto_show_diagnostics_panel_level = None  # type: int
     code_action_on_save_timeout_ms = None  # type: int
     diagnostics_additional_delay_auto_complete_ms = None  # type: int
@@ -181,7 +180,6 @@ class Settings:
             val = s.get(name)
             setattr(self, name, val if isinstance(val, default.__class__) else default)
 
-        # r("auto_show_diagnostics_panel", "always")
         r("auto_show_diagnostics_panel_level", 2)
         r("code_action_on_save_timeout_ms", 2000)
         r("diagnostics_additional_delay_auto_complete_ms", 0)
@@ -219,11 +217,11 @@ class Settings:
         # Backwards-compatible with the bool setting
         auto_show_diagnostics_panel = s.get("auto_show_diagnostics_panel")
         if isinstance(auto_show_diagnostics_panel, bool):
-            self.auto_show_diagnostics_panel = "always" if auto_show_diagnostics_panel else "never"
+            if not auto_show_diagnostics_panel:
+                self.auto_show_diagnostics_panel_level = 0
         elif isinstance(auto_show_diagnostics_panel, str):
-            self.auto_show_diagnostics_panel = auto_show_diagnostics_panel
-        else:
-            self.auto_show_diagnostics_panel = "always"
+            if auto_show_diagnostics_panel == "never":
+                self.auto_show_diagnostics_panel_level = 0
 
         # Backwards-compatible with "only_show_lsp_completions"
         only_show_lsp_completions = s.get("only_show_lsp_completions")
@@ -235,12 +233,6 @@ class Settings:
             r("inhibit_word_completions", True)
 
         set_debug_logging(self.log_debug)
-
-    def show_diagnostics_panel_always(self) -> bool:
-        return self.auto_show_diagnostics_panel == "always"
-
-    def show_diagnostics_panel_on_save(self) -> bool:
-        return self.auto_show_diagnostics_panel == "saved"
 
     def document_highlight_style_to_add_regions_flags(self) -> int:
         return _settings_style_to_add_regions_flag(self.document_highlight_style)

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -1,4 +1,3 @@
-import functools
 from ...third_party import WebsocketServer  # type: ignore
 from .configurations import ConfigManager
 from .configurations import WindowConfigManager
@@ -12,11 +11,11 @@ from .panels import update_server_panel
 from .protocol import Diagnostic
 from .protocol import Error
 from .protocol import Point
+from .sessions import get_plugin
 from .sessions import Logger
 from .sessions import Manager
 from .sessions import Session
 from .sessions import SessionBufferProtocol
-from .sessions import get_plugin
 from .sessions import SessionViewProtocol
 from .settings import userprefs
 from .transports import create_transport
@@ -36,6 +35,7 @@ from subprocess import CalledProcessError
 from time import time
 from weakref import ref
 from weakref import WeakSet
+import functools
 import json
 import os
 import sublime

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -229,11 +229,10 @@ class SessionBuffer:
                 self.purge_changes_async(view)
                 # mypy: expected sublime.View, got ViewLike
                 self.session.send_notification(did_save(view, include_text, self.file_name))
-        if userprefs().show_diagnostics_panel_on_save():
-            if self.should_show_diagnostics_panel:
-                mgr = self.session.manager()
-                if mgr:
-                    mgr.show_diagnostics_panel_async()
+        if self.should_show_diagnostics_panel:
+            mgr = self.session.manager()
+            if mgr:
+                mgr.show_diagnostics_panel_async()
 
     def some_view(self) -> Optional[sublime.View]:
         for sv in self.session_views:
@@ -346,10 +345,6 @@ class SessionBuffer:
         mgr = self.session.manager()
         if mgr:
             mgr.update_diagnostics_panel_async()
-            if not self.should_show_diagnostics_panel:
-                mgr.hide_diagnostics_panel_async()
-            elif userprefs().show_diagnostics_panel_always():
-                mgr.show_diagnostics_panel_async()
 
     def __str__(self) -> str:
         return '{}:{}:{}'.format(self.session.config.name, self.id, self.file_name)

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -173,7 +173,7 @@
                 }
               ],
               "default": "saved",
-              "markdownDescription": "Open and close the diagnostics panel automatically, depending on available diagnostics. For backward-compatibility, this can also be a boolean. In that case, if set to `false`, don't show the diagnostics panel, and when set to `true`, always show the diagnostics panel."
+              "deprecationMessage": "Use the \"auto_show_diagnostics_panel_level\" setting instead."
             },
             "code_action_on_save_timeout_ms": {
               "type": "integer",
@@ -182,10 +182,10 @@
             },
             "auto_show_diagnostics_panel_level": {
               "type": "integer",
-              "minimum": 1,
+              "minimum": 0,
               "maximum": 4,
               "default": 2,
-              "markdownDescription": "Open the diagnostics panel automatically when diagnostics level is equal to or less than:\n\n- _error_: `1`,\n- _warning_: `2`,\n- _info_: `3`,\n- _hint_: `4`"
+              "markdownDescription": "Open the diagnostics panel automatically **on save** when diagnostics level is equal to or less than:\n\n- _none_: `0` (this means never show the panel automatically),\n- _error_: `1`,\n- _warning_: `2`,\n- _info_: `3`,\n- _hint_: `4`\n\nThe panel is not shown when there is already another panel open. The panel is never _closed_ automatically. To close the panel, press the <kbd>Esc</kbd> key."
             },
             "show_diagnostics_count_in_view_status": {
               "type": "boolean",

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -40,9 +40,6 @@ class MockManager(Manager):
     def show_diagnostics_panel_async(self) -> None:
         pass
 
-    def hide_diagnostics_panel_async(self) -> None:
-        pass
-
 
 class MockLogger(Logger):
 


### PR DESCRIPTION
Because the diags panel is never closed automatically, it makes little sense
to have it automatically open whenever there's an error/warning. So the
setting

    auto_show_diagnostics_panel

is removed. Instead

    auto_show_diagnostics_panel_level

is used to determine when to automatically open the panel *on save*. Put the
value `0` here to never open the panel.

I've also added a neutral "idle" message for when there are no diagnostics.