### PR TITLE
Add A File Icon alias scopes to language-ids

### DIFF
--- a/language-ids.sublime-settings
+++ b/language-ids.sublime-settings
@@ -21,12 +21,32 @@
 // request at github.com/sublimelsp/LSP if you believe an entry is missing.
 {
     "source.c++": "cpp",
+    "source.coffee.gulpfile": "coffeescript", // https://github.com/SublimeText/AFileIcon
     "source.cs": "csharp",
     "source.dosbatch": "bat",
     "source.fixedform-fortran": "fortran", // https://packagecontrol.io/packages/Fortran
+    "source.groovy.gradle": "groovy", // https://github.com/SublimeText/AFileIcon
+    "source.groovy.jenkins": "groovy", // https://github.com/SublimeText/AFileIcon
     "source.js": "javascript",
+    "source.js.eslint": "javascript", // https://github.com/SublimeText/AFileIcon
+    "source.js.gruntfile": "javascript", // https://github.com/SublimeText/AFileIcon
+    "source.js.gulpfile": "javascript", // https://github.com/SublimeText/AFileIcon
+    "source.js.postcss": "javascript", // https://github.com/SublimeText/AFileIcon
+    "source.js.puglint": "javascript", // https://github.com/SublimeText/AFileIcon
     "source.js.react": "javascriptreact", // https://github.com/Thom1729/Sublime-JS-Custom
+    "source.js.stylelint": "javascript", // https://github.com/SublimeText/AFileIcon
+    "source.js.unittest": "javascript", // https://github.com/SublimeText/AFileIcon
+    "source.js.webpack": "javascript", // https://github.com/SublimeText/AFileIcon
     "source.json-tmlanguage": "jsonc", // https://github.com/SublimeText/PackageDev
+    "source.json.babel": "json", // https://github.com/SublimeText/AFileIcon
+    "source.json.bower": "json", // https://github.com/SublimeText/AFileIcon
+    "source.json.composer": "json", // https://github.com/SublimeText/AFileIcon
+    "source.json.eslint": "json", // https://github.com/SublimeText/AFileIcon
+    "source.json.npm": "json", // https://github.com/SublimeText/AFileIcon
+    "source.json.postcss": "json", // https://github.com/SublimeText/AFileIcon
+    "source.json.puglint": "json", // https://github.com/SublimeText/AFileIcon
+    "source.json.settings": "json", // https://github.com/SublimeText/AFileIcon
+    "source.json.stylelint": "json", // https://github.com/SublimeText/AFileIcon
     "source.json.sublime": "jsonc", // https://github.com/SublimeText/PackageDev
     "source.json.sublime.build": "jsonc", // https://github.com/SublimeText/PackageDev
     "source.json.sublime.color-scheme": "jsonc", // https://github.com/SublimeText/PackageDev
@@ -39,23 +59,58 @@
     "source.json.sublime.project": "jsonc", // https://github.com/SublimeText/PackageDev
     "source.json.sublime.settings": "jsonc", // https://github.com/SublimeText/PackageDev
     "source.json.sublime.theme": "jsonc", // https://github.com/SublimeText/PackageDev
+    "source.json.tern": "json", // https://github.com/SublimeText/AFileIcon
     "source.jsx": "javascriptreact",
+    "source.jsx.unittest": "javascriptreact", // https://github.com/SublimeText/AFileIcon
     "source.modern-fortran": "fortran", // https://packagecontrol.io/packages/Fortran
     "source.objc": "objective-c",
     "source.objc++": "objective-cpp",
     "source.shader": "shaderlab", // https://github.com/waqiju/unity_shader_st3
     "source.shell.bash": "shellscript",
+    "source.shell.docker": "shellscript", // https://github.com/SublimeText/AFileIcon
+    "source.shell.eslint": "shellscript", // https://github.com/SublimeText/AFileIcon
+    "source.shell.npm": "shellscript", // https://github.com/SublimeText/AFileIcon
+    "source.shell.ruby": "shellscript", // https://github.com/SublimeText/AFileIcon
+    "source.shell.stylelint": "shellscript", // https://github.com/SublimeText/AFileIcon
     "source.ts": "typescript",
     "source.ts.react": "typescriptreact", // https://github.com/Thom1729/Sublime-JS-Custom
+    "source.ts.unittest": "typescript", // https://github.com/SublimeText/AFileIcon
     "source.tsx": "typescriptreact",
+    "source.tsx.unittest": "typescriptreact", // https://github.com/SublimeText/AFileIcon
     "source.unity.unity_shader": "shaderlab", // https://github.com/petereichinger/Unity3D-Shader
+    "source.viml.vimrc": "viml", // https://github.com/SublimeText/AFileIcon
     "source.yaml-tmlanguage": "yaml", // https://github.com/SublimeText/PackageDev
+    "source.yaml.circleci": "yaml", // https://github.com/SublimeText/AFileIcon
+    "source.yaml.docker": "yaml", // https://github.com/SublimeText/AFileIcon
+    "source.yaml.eslint": "yaml", // https://github.com/SublimeText/AFileIcon
+    "source.yaml.lock": "yaml", // https://github.com/SublimeText/AFileIcon
+    "source.yaml.procfile": "yaml", // https://github.com/SublimeText/AFileIcon
+    "source.yaml.stylelint": "yaml", // https://github.com/SublimeText/AFileIcon
     "source.yaml.sublime.syntax": "yaml", // https://github.com/SublimeText/PackageDev
+    "source.yaml.yarn": "yaml", // https://github.com/SublimeText/AFileIcon
+    "text.advanced_csv": "csv", // https://github.com/SublimeText/AFileIcon
     "text.html.basic": "html",
+    "text.html.markdown.license": "markdown", // https://github.com/SublimeText/AFileIcon
     "text.html.markdown.rmarkdown": "r", // https://github.com/REditorSupport/sublime-ide-r
     "text.html.ngx": "html", // https://github.com/princemaple/ngx-html-syntax
     "text.plain": "txt",
+    "text.plain.buildpacks": "txt", // https://github.com/SublimeText/AFileIcon
+    "text.plain.eslint": "txt", // https://github.com/SublimeText/AFileIcon
+    "text.plain.fastq": "txt", // https://github.com/SublimeText/AFileIcon
+    "text.plain.license": "txt", // https://github.com/SublimeText/AFileIcon
+    "text.plain.lnk": "txt", // https://github.com/SublimeText/AFileIcon
+    "text.plain.log": "txt", // https://github.com/SublimeText/AFileIcon
+    "text.plain.nodejs": "txt", // https://github.com/SublimeText/AFileIcon
+    "text.plain.pcb": "txt", // https://github.com/SublimeText/AFileIcon
+    "text.plain.ps": "txt", // https://github.com/SublimeText/AFileIcon
+    "text.plain.python": "txt", // https://github.com/SublimeText/AFileIcon
+    "text.plain.readme": "txt", // https://github.com/SublimeText/AFileIcon
+    "text.plain.ruby": "txt", // https://github.com/SublimeText/AFileIcon
+    "text.plain.sketch": "txt", // https://github.com/SublimeText/AFileIcon
+    "text.plain.visualstudio": "txt", // https://github.com/SublimeText/AFileIcon
     "text.xml.plist": "xml", // https://github.com/SublimeText/PackageDev
     "text.xml.plist.textmate.preferences": "xml", // https://github.com/SublimeText/PackageDev
     "text.xml.sublime.snippet": "xml", // https://github.com/SublimeText/PackageDev
+    "text.xml.svg": "xml", // https://github.com/SublimeText/AFileIcon
+    "text.xml.visualstudio": "xml", // https://github.com/SublimeText/AFileIcon
 }


### PR DESCRIPTION
This PR adds all alias scopes of A File Icon, which point to source or text files.

Those aliases are created to attach unique icons to special named files, such as unittests or makefiles. All those alias files either use
text.plain or another scope of a syntax, shipped with Sublime Text.

As all those aliases add a sub-scope to the used base scope, they need to be added to this list here.

**Example:**

 All files ending with `.test.js` are scoped `source.js.unittest`.
 This commit makes sure to send the correct language id `javascript` to
 language-servers.