### PR TITLE
Make <hr> less noticeable in popups

### DIFF
--- a/popups.css
+++ b/popups.css
@@ -2,6 +2,9 @@
     margin: 0.5rem;
     font-family: system;
 }
+.lsp_popup hr {
+  border-color: color(var(--foreground) alpha(0.10));
+}
 .highlight {
     border-width: 0;
     border-radius: 0;


### PR DESCRIPTION
Before:
the hr was a solid foreground color.
![Screenshot from 2021-01-05 23-09-32](https://user-images.githubusercontent.com/22029477/103705342-28f3cb80-4fab-11eb-95c8-f7d15b6ddb0f.png)

After:
the hr is an slightly opaque line.
![Screenshot from 2021-01-05 23-09-58](https://user-images.githubusercontent.com/22029477/103705359-301ad980-4fab-11eb-8e09-559c70b2b726.png)
![Screenshot from 2021-01-05 23-09-48](https://user-images.githubusercontent.com/22029477/103705357-2ee9ac80-4fab-11eb-9661-7da3f11d149f.png)