### PR TITLE
Symbol Tag support

### DIFF
--- a/plugin/core/open.py
+++ b/plugin/core/open.py
@@ -1,8 +1,8 @@
 from .logging import exception_log
 from .promise import Promise
 from .promise import ResolveFunc
-from .protocol import Range
-from .typing import Any, Dict, Tuple, Optional
+from .protocol import Range, Range_T
+from .typing import Dict, Tuple, Optional
 from .url import uri_to_filename
 from .views import range_to_region
 import os
@@ -42,7 +42,7 @@ def open_file(
     return promise
 
 
-def open_file_and_center(window: sublime.Window, file_path: str, r: Optional[Dict[str, Any]], flag: int = 0,
+def open_file_and_center(window: sublime.Window, file_path: str, r: Optional[Range_T], flag: int = 0,
                          group: int = -1) -> Promise:
     """Open a file asynchronously and center the range. It is only safe to call this function from the UI thread."""
 
@@ -57,7 +57,7 @@ def open_file_and_center(window: sublime.Window, file_path: str, r: Optional[Dic
     return open_file(window, file_path).then(center_selection)
 
 
-def open_file_and_center_async(window: sublime.Window, file_path: str, r: Optional[Dict[str, Any]], flag: int = 0,
+def open_file_and_center_async(window: sublime.Window, file_path: str, r: Optional[Range_T], flag: int = 0,
                                group: int = -1) -> Promise:
     """Open a file asynchronously and center the range, worker thread version."""
     return Promise.on_main_thread() \

--- a/plugin/core/open.py
+++ b/plugin/core/open.py
@@ -1,7 +1,7 @@
 from .logging import exception_log
 from .promise import Promise
 from .promise import ResolveFunc
-from .protocol import Range, Range_T
+from .protocol import Range, RangeLsp
 from .typing import Dict, Tuple, Optional
 from .url import uri_to_filename
 from .views import range_to_region
@@ -42,7 +42,7 @@ def open_file(
     return promise
 
 
-def open_file_and_center(window: sublime.Window, file_path: str, r: Optional[Range_T], flag: int = 0,
+def open_file_and_center(window: sublime.Window, file_path: str, r: Optional[RangeLsp], flag: int = 0,
                          group: int = -1) -> Promise:
     """Open a file asynchronously and center the range. It is only safe to call this function from the UI thread."""
 
@@ -57,7 +57,7 @@ def open_file_and_center(window: sublime.Window, file_path: str, r: Optional[Ran
     return open_file(window, file_path).then(center_selection)
 
 
-def open_file_and_center_async(window: sublime.Window, file_path: str, r: Optional[Range_T], flag: int = 0,
+def open_file_and_center_async(window: sublime.Window, file_path: str, r: Optional[RangeLsp], flag: int = 0,
                                group: int = -1) -> Promise:
     """Open a file asynchronously and center the range, worker thread version."""
     return Promise.on_main_thread() \

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -132,7 +132,7 @@ DocumentSymbol = TypedDict('DocumentSymbol', {
     'deprecated': Optional[bool],
     'range': Range_T,
     'selectionRange': Range_T,
-    'children': Optional[List[Any]]  # mypy doesn't support recurive types, Optional[List[DocumentSymbol]]
+    'children': Optional[List[Any]]  # mypy doesn't support recurive types like Optional[List[DocumentSymbol]]
 }, total=True)
 
 SymbolInformation = TypedDict('SymbolInformation', {

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -40,6 +40,15 @@ class SignatureHelpTriggerKind:
 
 DocumentUri = str
 
+Position = TypedDict('Position', {
+    'line': int,
+    'character': int
+})
+
+Range_T = TypedDict('Range_T', {
+    'start': Position,
+    'end': Position
+})
 
 CodeDescription = TypedDict('CodeDescription', {
     'href': str
@@ -70,7 +79,7 @@ CodeAction = TypedDict('CodeAction', {
 
 
 CodeLens = TypedDict('CodeLens', {
-    'range': Dict[str, Any],
+    'range': Range_T,
     'command': Optional[Command],
     'data': Any,
     # Custom property to bring along the name of the session
@@ -108,12 +117,31 @@ SignatureHelpContext = TypedDict('SignatureHelpContext', {
 
 Location = TypedDict('Location', {
     'uri': DocumentUri,
-    'range': Dict[str, Any]
+    'range': Range_T
 }, total=True)
 
+DocumentSymbol = TypedDict('DocumentSymbol', {
+    'name': str,
+    'detail': Optional[str],
+    'kind': int,
+    'tags': Optional[List[int]],
+    'deprecated': Optional[bool],
+    'range': Range_T,
+    'selectionRange': Range_T,
+    'children': Optional[List[Any]]  # mypy doesn't support recurive types, Optional[List[DocumentSymbol]]
+}, total=True)
+
+SymbolInformation = TypedDict('SymbolInformation', {
+    'name': str,
+    'kind': int,
+    'tags': Optional[List[int]],
+    'deprecated': Optional[bool],
+    'location': Location,
+    'containerName': Optional[str]
+}, total=True)
 
 LocationLink = TypedDict('LocationLink', {
-    'originSelectionRange': Dict[str, Any],
+    'originSelectionRange': Optional[Range_T],
     'targetUri': DocumentUri,
     'targetRange': Dict[str, Any],
     'targetSelectionRange': Dict[str, Any]
@@ -127,7 +155,7 @@ DiagnosticRelatedInformation = TypedDict('DiagnosticRelatedInformation', {
 
 
 Diagnostic = TypedDict('Diagnostic', {
-    'range': Dict[str, Any],
+    'range': Range_T,
     'severity': int,
     'code': Union[int, str],
     'codeDescription': CodeDescription,
@@ -360,7 +388,7 @@ class Point(object):
         return self.row == other.row and self.col == other.col
 
     @classmethod
-    def from_lsp(cls, point: dict) -> 'Point':
+    def from_lsp(cls, point: Position) -> 'Point':
         return Point(point['line'], point['character'])
 
     def to_lsp(self) -> Dict[str, Any]:
@@ -385,7 +413,7 @@ class Range(object):
         return self.start == other.start and self.end == other.end
 
     @classmethod
-    def from_lsp(cls, range: dict) -> 'Range':
+    def from_lsp(cls, range: Range_T) -> 'Range':
         return Range(Point.from_lsp(range['start']), Point.from_lsp(range['end']))
 
     def to_lsp(self) -> Dict[str, Any]:

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -20,6 +20,10 @@ class CompletionItemTag:
     Deprecated = 1
 
 
+class SymbolTag:
+    Deprecated = 1
+
+
 class InsertTextFormat:
     PlainText = 1
     Snippet = 2

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -49,7 +49,7 @@ Position = TypedDict('Position', {
     'character': int
 })
 
-Range_T = TypedDict('Range_T', {
+RangeLsp = TypedDict('RangeLsp', {
     'start': Position,
     'end': Position
 })
@@ -83,7 +83,7 @@ CodeAction = TypedDict('CodeAction', {
 
 
 CodeLens = TypedDict('CodeLens', {
-    'range': Range_T,
+    'range': RangeLsp,
     'command': Optional[Command],
     'data': Any,
     # Custom property to bring along the name of the session
@@ -121,7 +121,7 @@ SignatureHelpContext = TypedDict('SignatureHelpContext', {
 
 Location = TypedDict('Location', {
     'uri': DocumentUri,
-    'range': Range_T
+    'range': RangeLsp
 }, total=True)
 
 DocumentSymbol = TypedDict('DocumentSymbol', {
@@ -130,8 +130,8 @@ DocumentSymbol = TypedDict('DocumentSymbol', {
     'kind': int,
     'tags': Optional[List[int]],
     'deprecated': Optional[bool],
-    'range': Range_T,
-    'selectionRange': Range_T,
+    'range': RangeLsp,
+    'selectionRange': RangeLsp,
     'children': Optional[List[Any]]  # mypy doesn't support recurive types like Optional[List[DocumentSymbol]]
 }, total=True)
 
@@ -145,7 +145,7 @@ SymbolInformation = TypedDict('SymbolInformation', {
 }, total=True)
 
 LocationLink = TypedDict('LocationLink', {
-    'originSelectionRange': Optional[Range_T],
+    'originSelectionRange': Optional[RangeLsp],
     'targetUri': DocumentUri,
     'targetRange': Dict[str, Any],
     'targetSelectionRange': Dict[str, Any]
@@ -159,7 +159,7 @@ DiagnosticRelatedInformation = TypedDict('DiagnosticRelatedInformation', {
 
 
 Diagnostic = TypedDict('Diagnostic', {
-    'range': Range_T,
+    'range': RangeLsp,
     'severity': int,
     'code': Union[int, str],
     'codeDescription': CodeDescription,
@@ -417,7 +417,7 @@ class Range(object):
         return self.start == other.start and self.end == other.end
 
     @classmethod
-    def from_lsp(cls, range: Range_T) -> 'Range':
+    def from_lsp(cls, range: RangeLsp) -> 'Range':
         return Range(Point.from_lsp(range['start']), Point.from_lsp(range['end']))
 
     def to_lsp(self) -> Dict[str, Any]:

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -132,7 +132,7 @@ DocumentSymbol = TypedDict('DocumentSymbol', {
     'deprecated': Optional[bool],
     'range': RangeLsp,
     'selectionRange': RangeLsp,
-    'children': Optional[List[Any]]  # mypy doesn't support recurive types like Optional[List[DocumentSymbol]]
+    'children': Optional[List[Any]]  # mypy doesn't support recurive types like Optional[List['DocumentSymbol']]
 }, total=True)
 
 SymbolInformation = TypedDict('SymbolInformation', {

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -165,6 +165,9 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
                 "hierarchicalDocumentSymbolSupport": True,
                 "symbolKind": {
                     "valueSet": symbol_kinds
+                },
+                "tagSupport": {
+                    "valueSet": [1]
                 }
             },
             "formatting": {
@@ -221,7 +224,10 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
                 "relatedInformation": True,
                 "versionSupport": True,
                 "codeDescriptionSupport": True,
-                "dataSupport": True
+                "dataSupport": True,
+                "tagSupport": {
+                    "valueSet": [1]
+                }
             },
             "selectionRange": {
                 "dynamicRegistration": True
@@ -245,6 +251,9 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
                 "dynamicRegistration": True,  # exceptional
                 "symbolKind": {
                     "valueSet": symbol_kinds
+                },
+                "tagSupport": {
+                    "valueSet": [1]
                 }
             },
             "configuration": True

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -10,6 +10,7 @@ from .promise import Promise
 from .protocol import CodeAction
 from .protocol import Command
 from .protocol import CompletionItemTag
+from .protocol import SymbolTag
 from .protocol import Diagnostic
 from .protocol import Error
 from .protocol import ErrorCode
@@ -113,6 +114,7 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
     completion_kinds = list(range(1, len(COMPLETION_KINDS) + 1))
     symbol_kinds = list(range(1, len(SYMBOL_KINDS) + 1))
     completion_tag_value_set = [v for k, v in CompletionItemTag.__dict__.items() if not k.startswith('_')]
+    symbol_tag_value_set = [v for k, v in SymbolTag.__dict__.items() if not k.startswith('_')]
     first_folder = workspace_folders[0] if workspace_folders else None
     capabilities = {
         "general": {
@@ -167,7 +169,7 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
                     "valueSet": symbol_kinds
                 },
                 "tagSupport": {
-                    "valueSet": [1]
+                    "valueSet": symbol_tag_value_set
                 }
             },
             "formatting": {
@@ -224,10 +226,7 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
                 "relatedInformation": True,
                 "versionSupport": True,
                 "codeDescriptionSupport": True,
-                "dataSupport": True,
-                "tagSupport": {
-                    "valueSet": [1]
-                }
+                "dataSupport": True
             },
             "selectionRange": {
                 "dynamicRegistration": True
@@ -253,7 +252,7 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
                     "valueSet": symbol_kinds
                 },
                 "tagSupport": {
-                    "valueSet": [1]
+                    "valueSet": symbol_tag_value_set
                 }
             },
             "configuration": True

--- a/plugin/symbols.py
+++ b/plugin/symbols.py
@@ -33,9 +33,13 @@ def get_symbol_scope_from_lsp_kind(kind: int) -> str:
     return 'comment'
 
 
-def symbol_information_to_quick_panel_item(item: SymbolInformation, show_file_name: bool = True) -> sublime.QuickPanelItem:
+def symbol_information_to_quick_panel_item(
+    item: SymbolInformation,
+    show_file_name: bool = True
+) -> sublime.QuickPanelItem:
     st_kind, st_icon, st_display_type, _ = unpack_lsp_kind(item['kind'])
-    if SymbolTag.Deprecated in item.get("tags", []):
+    tags = item.get("tags") or []
+    if SymbolTag.Deprecated in tags:
         st_display_type = "⚠ {} - Deprecated".format(st_display_type)
     container = item.get("containerName") or ""
     details = []  # List[str]
@@ -193,7 +197,8 @@ class LspDocumentSymbolsCommand(LspTextCommand):
                 st_details = "{} | {}".format(st_details, formatted_names)
             else:
                 st_details = formatted_names
-            if SymbolTag.Deprecated in item.get("tags", []):
+            tags = item.get("tags") or []
+            if SymbolTag.Deprecated in tags:
                 st_display_type = "⚠ {} - Deprecated".format(st_display_type)
             quick_panel_items.append(
                 sublime.QuickPanelItem(
@@ -252,7 +257,9 @@ class LspWorkspaceSymbolsCommand(LspTextCommand):
             matches = response
             window = self.view.window()
             if window:
-                window.show_quick_panel(list(map(symbol_information_to_quick_panel_item, matches)), lambda i: self._open_file(matches, i))
+                window.show_quick_panel(
+                    list(map(symbol_information_to_quick_panel_item, matches)),
+                    lambda i: self._open_file(matches, i))
         else:
             sublime.message_dialog("No matches found for query string: '{}'".format(query))
 

--- a/plugin/symbols.py
+++ b/plugin/symbols.py
@@ -206,8 +206,7 @@ class LspDocumentSymbolsCommand(LspTextCommand):
                     details=st_details,
                     annotation=st_display_type,
                     kind=(st_kind, st_icon, st_display_type)))
-            children = item.get('children') or []
-            children = cast(List[DocumentSymbol], children)
+            children = item.get('children') or []  # type: List[DocumentSymbol]
             for child in children:
                 self.process_document_symbol_recursive(quick_panel_items, child, names)
 

--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -1024,7 +1024,7 @@ class QuickPanelItem:
     def __init__(
         self,
         trigger: str,
-        details: str = "",
+        details: Union[str, List[str]] = "",
         annotation: str = "",
         kind: Tuple[int, str, str] = KIND_AMBIGUOUS
     ) -> None:

--- a/tests/test_document_symbols.py
+++ b/tests/test_document_symbols.py
@@ -3,6 +3,7 @@ from LSP.plugin.core.typing import Generator
 from LSP.plugin.symbols import symbol_information_to_quick_panel_item
 from LSP.plugin.core.protocol import SymbolTag
 
+
 class QueryCompletionsTests(TextDocumentTestCase):
     def test_show_deprecated_flag_for_symbol_information(self) -> 'Generator':
         symbol_information = {

--- a/tests/test_document_symbols.py
+++ b/tests/test_document_symbols.py
@@ -1,0 +1,23 @@
+from setup import TextDocumentTestCase
+from LSP.plugin.core.typing import Generator
+from LSP.plugin.symbols import symbol_information_to_quick_panel_item
+from LSP.plugin.core.protocol import SymbolTag
+
+class QueryCompletionsTests(TextDocumentTestCase):
+    def test_show_deprecated_flag_for_symbol_information(self) -> 'Generator':
+        symbol_information = {
+            "name": 'Name',
+            "kind": 6,  # Method
+            "tags": [SymbolTag.Deprecated],
+        }
+        formatted_symbol_information = symbol_information_to_quick_panel_item(symbol_information, show_file_name=False)
+        self.assertEqual('⚠ Method - Deprecated', formatted_symbol_information.annotation)
+
+    def test_dont_show_deprecated_flag_for_symbol_information(self) -> 'Generator':
+        symbol_information = {
+            "name": 'Name',
+            "kind": 6,  # Method
+            # to deprecated tags
+        }
+        formatted_symbol_information = symbol_information_to_quick_panel_item(symbol_information, show_file_name=False)
+        self.assertEqual('Method', formatted_symbol_information.annotation)

--- a/tests/test_document_symbols.py
+++ b/tests/test_document_symbols.py
@@ -4,7 +4,7 @@ from LSP.plugin.symbols import symbol_information_to_quick_panel_item
 from LSP.plugin.core.protocol import SymbolTag
 
 
-class QueryCompletionsTests(TextDocumentTestCase):
+class DocumentSymbolTests(TextDocumentTestCase):
     def test_show_deprecated_flag_for_symbol_information(self) -> 'Generator':
         symbol_information = {
             "name": 'Name',


### PR DESCRIPTION
In this PR:

NEW:
- added deprecated tags to document symbols popup and  symbols in project popup
- symbols in project now looks consistent with the document symbol popup
- added new typed dicts

FIXES:
- This PR also fixes the invocation of the `LspWorkspaceSymbolsCommand` by removing the [fallback value](https://github.com/sublimelsp/LSP/compare/tags-support?expand=1#diff-514c816d75b08e41f44833deaf8e7281295700ce87fdfff07adbd5aabab403c3R240). - The problem is that I trigger the keybinding for `lsp_workspace_symbols` and I expect to see the popup, but no popup is shown. Some people don't experience this problem, but I do experience it on Linux and Mac. A discussion is held on Discord so I will update this PR if we conclude more about that.

Document symbol popup
![document-symbol](https://user-images.githubusercontent.com/22029477/104133276-d9cee180-5382-11eb-9e20-ebcd4c6a3b6d.png)

Symbols in project popup - before
![workspace-symbols-before](https://user-images.githubusercontent.com/22029477/104133278-dd626880-5382-11eb-964c-e3d4df41fbcc.png)

 Symbols in project popup - after
![workspace-symbols-after](https://user-images.githubusercontent.com/22029477/104133280-e05d5900-5382-11eb-9cbb-96122d4369be.png)
