### PR TITLE
Be explicit where new line are added

### DIFF
--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -449,18 +449,18 @@ class WindowManager(Manager):
             file_path = listener.view.file_name() or ""
             base_dir = self.get_project_path(file_path)  # What about different base dirs for multiple folders?
             file_path = os.path.relpath(file_path, base_dir) if base_dir else file_path
-            to_render.append("{}:".format(file_path))
+            to_render.append("{}:\n".format(file_path))
             row += 1
             for content, offset, code, href in contribution:
-                to_render.append(content)
+                to_render.append(content + "\n")
                 if offset is not None and code is not None and href is not None:
                     prephantoms.append((row, offset, code, href))
                 row += content.count("\n") + 1
-            to_render.append("")  # add spacing between filenames
+            to_render.append("\n")  # add spacing between filenames
             row += 1
         for listener in listeners:
             set_diagnostics_count(listener.view, self.total_error_count, self.total_warning_count)
-        characters = "\n".join(to_render)
+        characters = "".join(to_render)
         if not characters:
             characters = _NO_DIAGNOSTICS_PLACEHOLDER
         sublime.set_timeout(functools.partial(self._update_panel_main_thread, base_dir, characters, prephantoms))

--- a/plugin/references.py
+++ b/plugin/references.py
@@ -124,13 +124,13 @@ class LspSymbolReferencesCommand(LspTextCommand):
             to_render = []  # type: List[str]
             references_count = 0
             for file, references in references_by_file.items():
-                to_render.append('{}:'.format(self.get_relative_path(file)))
+                to_render.append('{}:\n'.format(self.get_relative_path(file)))
                 for reference in references:
                     references_count += 1
                     point, line = reference
-                    to_render.append('{:>5}:{:<4} {}'.format(point.row + 1, point.col + 1, line))
-                to_render.append("")  # add spacing between filenames
-            characters = "\n".join(to_render)
+                    to_render.append('{:>5}:{:<4} {}\n'.format(point.row + 1, point.col + 1, line))
+                to_render.append("\n")  # add spacing between filenames
+            characters = "".join(to_render)
             base_dir = windows.lookup(window).get_project_path(self.view.file_name() or "")
             panel.settings().set("result_base_dir", base_dir)
 

--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -163,13 +163,13 @@ class LspSymbolRenameCommand(LspTextCommand):
             return
         to_render = []  # type: List[str]
         for file, file_changes in changes.items():
-            to_render.append('{}:'.format(self._get_relative_path(file)))
+            to_render.append('{}:\n'.format(self._get_relative_path(file)))
             for edit in file_changes:
                 start = edit[0]
                 line_content = get_line(self.view.window(), file, start[0])
-                to_render.append('{:>5}:{:<4} {}'.format(start[0] + 1, start[1] + 1, line_content))
-            to_render.append("")  # this adds a spacing between filenames
-        characters = "\n".join(to_render)
+                to_render.append('{:>5}:{:<4} {}\n'.format(start[0] + 1, start[1] + 1, line_content))
+            to_render.append("\n")  # this adds a spacing between filenames
+        characters = "".join(to_render)
         base_dir = windows.lookup(window).get_project_path(self.view.file_name() or "")
         panel.settings().set("result_base_dir", base_dir)
         panel.run_command("lsp_clear_panel")


### PR DESCRIPTION
I think this is easier to grasp and resolves this question: https://github.com/sublimelsp/LSP/commit/a9406f55e775a0be50c9d3d252787c8ba3be0a7e#r45265031

I checked multiline diagnostics, seems to work fine:
![image](https://user-images.githubusercontent.com/22029477/104137385-8073ac00-539c-11eb-9fb4-fcc0dc201c0e.png)
