### PR TITLE
Handle basic editor commands

### DIFF
--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -110,6 +110,10 @@ class AbstractViewListener(metaclass=ABCMeta):
     def get_language_id(self) -> str:
         raise NotImplementedError()
 
+    @abstractmethod
+    def do_signature_help_async(self, manual: bool) -> None:
+        raise NotImplementedError()
+
 
 def extract_message(params: Any) -> str:
     return params.get("message", "???") if isinstance(params, dict) else "???"

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -272,7 +272,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             self._when_selection_remains_stable_async(self._do_color_boxes_async, current_region,
                                                       after_ms=self.color_boxes_debounce_time)
         if "signatureHelp" not in userprefs().disabled_capabilities:
-            self._do_signature_help(manual=False)
+            self.do_signature_help_async(manual=False)
         if "codeLensProvider" not in userprefs().disabled_capabilities:
             self._when_selection_remains_stable_async(self._do_code_lenses_async, current_region,
                                                       after_ms=self.code_lenses_debounce_time)
@@ -330,7 +330,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         elif key == "lsp.signature_help":
             if not self.view.is_popup_visible():
                 if operand == 0:
-                    sublime.set_timeout_async(lambda: self._do_signature_help(manual=True))
+                    sublime.set_timeout_async(lambda: self.do_signature_help_async(manual=True))
                     return True
             elif self._sighelp and self._sighelp.has_multiple_signatures() and not self.view.is_auto_complete_visible():
                 # We use the "operand" for the number -1 or +1. See the keybindings.
@@ -349,7 +349,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
     def on_post_text_command(self, command_name: str, args: Optional[Dict[str, Any]]) -> None:
         if command_name in ("next_field", "prev_field") and args is None:
             if "signatureHelp" not in userprefs().disabled_capabilities:
-                sublime.set_timeout_async(lambda: self._do_signature_help(manual=True))
+                sublime.set_timeout_async(lambda: self.do_signature_help_async(manual=True))
         if not self.view.is_popup_visible():
             return
         if command_name in ["hide_auto_complete", "move", "commit_completion"] or 'delete' in command_name:
@@ -370,7 +370,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
 
     # --- textDocument/signatureHelp -----------------------------------------------------------------------------------
 
-    def _do_signature_help(self, manual: bool) -> None:
+    def do_signature_help_async(self, manual: bool) -> None:
         # NOTE: We take the beginning of the region to check the previous char (see last_char variable). This is for
         # when a language server inserts a snippet completion.
         pos = self._stored_region.a

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -14,6 +14,11 @@ class LspExecuteCommand(LspTextCommand):
             command_args: Optional[List[Any]] = None,
             session_name: Optional[str] = None,
             event: Optional[dict] = None) -> None:
+        # Handle VSCode-specific command for triggering suggestions popup.
+        if command_name == "editor.action.triggerSuggest":
+            # Triggered from set_timeout as suggestions popup doesn't trigger otherwise.
+            sublime.set_timeout(lambda: self.view.run_command("auto_complete"))
+            return
         session = self.session_by_name(session_name) if session_name else self.best_session(self.capability)
         if session and command_name:
             if command_args:

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -2,6 +2,7 @@ import sublime
 from .core.protocol import Error
 from .core.protocol import ExecuteCommandParams
 from .core.registry import LspTextCommand
+from .core.registry import windows
 from .core.typing import List, Optional, Any
 from .core.views import uri_from_view, offset_to_point, region_to_range, text_document_identifier
 
@@ -14,11 +15,18 @@ class LspExecuteCommand(LspTextCommand):
             command_args: Optional[List[Any]] = None,
             session_name: Optional[str] = None,
             event: Optional[dict] = None) -> None:
-        # Handle VSCode-specific command for triggering suggestions popup.
+        # Handle VSCode-specific command for triggering AC/sighelp
         if command_name == "editor.action.triggerSuggest":
             # Triggered from set_timeout as suggestions popup doesn't trigger otherwise.
-            sublime.set_timeout(lambda: self.view.run_command("auto_complete"))
-            return
+            return sublime.set_timeout(lambda: self.view.run_command("auto_complete"))
+        if command_name == "editor.action.triggerParameterHints":
+
+            def run_async() -> None:
+                listener = windows.listener_for_view(self.view)
+                if listener:
+                    listener.do_signature_help_async(manual=False)
+
+            return sublime.set_timeout_async(run_async)
         session = self.session_by_name(session_name) if session_name else self.best_session(self.capability)
         if session and command_name:
             if command_args:


### PR DESCRIPTION
After some discussion on Discord it seems it's safer to handle vscode-specific commands.

Most notably, now that we don't check if the server is a commandProvider due to handling client-side code lens commands, rust-analyzer will sometimes complain about not understanding workspace/executeCommand. Because it puts the command `editor.action.triggerParameterHints` in one of its completion items.

See: https://github.com/microsoft/language-server-protocol/issues/1148