### PR TITLE
Fix #1548: when the region is empty, query touching points

### DIFF
--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -283,10 +283,7 @@ class LspCodeActionsCommand(LspTextCommand):
         listener = windows.listener_for_view(view)
         if not listener:
             return
-        if region.a == region.b:
-            session_buffer_diagnostics, covering = listener.diagnostics_touching_point_async(region.b)
-        else:
-            session_buffer_diagnostics, covering = listener.diagnostics_intersecting_region_async(region)
+        session_buffer_diagnostics, covering = listener.diagnostics_intersecting_async(region)
         dict_kinds = {kind: True for kind in only_kinds} if only_kinds else None
         actions_manager.request_for_region_async(
             view, covering, session_buffer_diagnostics, self.handle_responses_async, dict_kinds)

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -283,7 +283,10 @@ class LspCodeActionsCommand(LspTextCommand):
         listener = windows.listener_for_view(view)
         if not listener:
             return
-        session_buffer_diagnostics, covering = listener.diagnostics_intersecting_region_async(region)
+        if region.a == region.b:
+            session_buffer_diagnostics, covering = listener.diagnostics_touching_point_async(region.b)
+        else:
+            session_buffer_diagnostics, covering = listener.diagnostics_intersecting_region_async(region)
         dict_kinds = {kind: True for kind in only_kinds} if only_kinds else None
         actions_manager.request_for_region_async(
             view, covering, session_buffer_diagnostics, self.handle_responses_async, dict_kinds)

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -76,7 +76,7 @@ class AbstractViewListener(metaclass=ABCMeta):
         raise NotImplementedError()
 
     @abstractmethod
-    def diagnostics_intersecting_point_async(
+    def diagnostics_touching_point_async(
         self,
         pt: int
     ) -> Tuple[Sequence[Tuple[SessionBufferProtocol, Sequence[Diagnostic]]], sublime.Region]:

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -17,7 +17,7 @@ from .sessions import SessionViewProtocol
 from .settings import userprefs
 from .transports import create_transport
 from .types import ClientConfig
-from .typing import Optional, Any, Dict, Deque, List, Generator, Tuple, Iterable, Sequence
+from .typing import Optional, Any, Dict, Deque, List, Generator, Tuple, Iterable, Sequence, Union
 from .views import extract_variables
 from .views import make_link
 from .workspace import disable_in_project
@@ -81,6 +81,17 @@ class AbstractViewListener(metaclass=ABCMeta):
         pt: int
     ) -> Tuple[Sequence[Tuple[SessionBufferProtocol, Sequence[Diagnostic]]], sublime.Region]:
         raise NotImplementedError()
+
+    def diagnostics_intersecting_async(
+        self,
+        region_or_point: Union[sublime.Region, int]
+    ) -> Tuple[Sequence[Tuple[SessionBufferProtocol, Sequence[Diagnostic]]], sublime.Region]:
+        if isinstance(region_or_point, int):
+            return self.diagnostics_touching_point_async(region_or_point)
+        elif region_or_point.empty():
+            return self.diagnostics_touching_point_async(region_or_point.a)
+        else:
+            return self.diagnostics_intersecting_region_async(region_or_point)
 
     @abstractmethod
     def diagnostics_panel_contribution_async(self) -> Sequence[Tuple[str, Optional[int], Optional[str], Optional[str]]]:

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -444,10 +444,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
     # --- textDocument/codeAction --------------------------------------------------------------------------------------
 
     def _do_code_actions(self) -> None:
-        if self._stored_region.empty():
-            diagnostics_by_config, covering = self.diagnostics_touching_point_async(self._stored_region.b)
-        else:
-            diagnostics_by_config, covering = self.diagnostics_intersecting_region_async(self._stored_region)
+        diagnostics_by_config, covering = self.diagnostics_intersecting_async(self._stored_region)
         actions_manager.request_for_region_async(self.view, covering, diagnostics_by_config, self._on_code_actions)
 
     def _on_code_actions(self, responses: CodeActionsByConfigName) -> None:

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -216,7 +216,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
                 result.append((sb, intersections))
         return result, covering
 
-    def diagnostics_intersecting_point_async(
+    def diagnostics_touching_point_async(
         self,
         pt: int
     ) -> Tuple[List[Tuple[SessionBuffer, List[Diagnostic]]], sublime.Region]:
@@ -241,7 +241,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         if userprefs().show_diagnostics_in_view_status:
             r = self._stored_region
             if r is not None:
-                session_buffer_diagnostics, _ = self.diagnostics_intersecting_point_async(r.b)
+                session_buffer_diagnostics, _ = self.diagnostics_touching_point_async(r.b)
                 if session_buffer_diagnostics:
                     for _, diagnostics in session_buffer_diagnostics:
                         diag = next(iter(diagnostics), None)
@@ -445,7 +445,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
 
     def _do_code_actions(self) -> None:
         if self._stored_region.empty():
-            diagnostics_by_config, covering = self.diagnostics_intersecting_point_async(self._stored_region.b)
+            diagnostics_by_config, covering = self.diagnostics_touching_point_async(self._stored_region.b)
         else:
             diagnostics_by_config, covering = self.diagnostics_intersecting_region_async(self._stored_region)
         actions_manager.request_for_region_async(self.view, covering, diagnostics_by_config, self._on_code_actions)

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -86,7 +86,7 @@ class LspHoverCommand(LspTextCommand):
             listener = wm.listener_for_view(self.view)
             if not listener:
                 return
-            self._diagnostics_by_config, covering = listener.diagnostics_intersecting_point_async(hover_point)
+            self._diagnostics_by_config, covering = listener.diagnostics_touching_point_async(hover_point)
             if self._diagnostics_by_config:
                 if not only_diagnostics:
                     actions_manager.request_with_diagnostics_async(


### PR DESCRIPTION
Text points are the positions inbetween the characters in the buffer. A region
is a tuple of two text positions. So a region where r.a == r.b never intersects
with another region unless they are the same. Querying for touching points
behaves differently in this regard.

I also renamed `diagnostics_intersecting_point_async` to `diagnostics_touching_point_async`.