### PR TITLE
Always look up the session name for lsp_execute

### DIFF
--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -51,11 +51,11 @@ class LspTextCommand(sublime_plugin.TextCommand):
 
     # When this is defined in a derived class, the command is enabled only if there exists a session attached to the
     # view that has the given capability.
-    capability = ''
+    capability = None  # type: Optional[str]
 
     # When this is defined in a derived class, the command is enabled only if there exists a session attached to the
     # view that has the given name.
-    session_name = ''
+    session_name = None  # type: Optional[str]
 
     def is_enabled(self, event: Optional[dict] = None, point: Optional[int] = None) -> bool:
         if self.capability:

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -51,11 +51,11 @@ class LspTextCommand(sublime_plugin.TextCommand):
 
     # When this is defined in a derived class, the command is enabled only if there exists a session attached to the
     # view that has the given capability.
-    capability = None  # type: Optional[str]
+    capability = ''
 
     # When this is defined in a derived class, the command is enabled only if there exists a session attached to the
     # view that has the given name.
-    session_name = None  # type: Optional[str]
+    session_name = ''
 
     def is_enabled(self, event: Optional[dict] = None, point: Optional[int] = None) -> bool:
         if self.capability:

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -27,7 +27,7 @@ class LspExecuteCommand(LspTextCommand):
                     listener.do_signature_help_async(manual=False)
 
             return sublime.set_timeout_async(run_async)
-        session = self.session_by_name(session_name) if session_name else self.best_session(self.capability)
+        session = self.session_by_name(session_name if session_name else self.session_name)
         if session and command_name:
             if command_args:
                 self._expand_variables(command_args)


### PR DESCRIPTION
The `self.capability` used to be an empty string, which meant that
the check for `capability is None` was always false when looking up
suitable sessions.

Resolves #1556