### PR TITLE
Fix: '*InputHandler' object has no attribute 'want_event'

### DIFF
--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -18,6 +18,9 @@ import sublime_plugin
 
 
 class RenameSymbolInputHandler(sublime_plugin.TextInputHandler):
+    def want_event(self) -> bool:
+        return False
+
     def __init__(self, view: sublime.View, placeholder: str) -> None:
         self.view = view
         self._placeholder = placeholder

--- a/plugin/symbols.py
+++ b/plugin/symbols.py
@@ -222,6 +222,8 @@ class LspDocumentSymbolsCommand(LspTextCommand):
 
 
 class SymbolQueryInput(sublime_plugin.TextInputHandler):
+    def want_event(self) -> bool:
+        return False
 
     def validate(self, txt: str) -> bool:
         return txt != ""


### PR DESCRIPTION
I don't know if we should wait for the next ST release that will fix this, 
but here is a fix for the `'*InputHandler' object has no attribute 'want_event'` error.
