### PR TITLE
Fix issue with diagnostics regions sometimes not being removed on undo

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -957,11 +957,6 @@ class Session(TransportCallbacks):
         if mgr:
             getattr(mgr, method)(*args)
 
-    def clear_diagnostics_async(self) -> None:
-        # XXX: Remove this functionality?
-        for sb in self.session_buffers_async():
-            sb.on_diagnostics_async([], None)
-
     def on_stderr_message(self, message: str) -> None:
         self.call_manager('handle_stderr_log', self, message)
         self._logger.stderr_message(message)

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -302,10 +302,7 @@ class SessionBuffer:
 
         self.diagnostics_debouncer.cancel_pending()
 
-        if not bool(diagnostics) and not self.diagnostics_are_visible:
-            # Nothing was previously visible, and nothing will become visible. So do nothing.
-            pass
-        elif self.diagnostics_are_visible:
+        if self.diagnostics_are_visible:
             # Old diagnostics are visible. Update immediately.
             present()
         else:


### PR DESCRIPTION
The problem stems from the fact that ST restores regions on Undo so in
a situation when there is a diagnostic shown:

```
let a
     ^ missing semicolon
```

then semicolon is added:

```
let a;
```

and immediately (before the diagnostic is removed) the document is
changed again by for example adding something before semicolon:

```
let aa;
```

then LSP will remove the diagnostic (region) but pressing undo will
add it back (after the semicolon):

```
let a;
      ^ missing semi
```

At this point, our logic decides that there are no diagnostics visible and
we've just received empty diagnostics message so we don't need to do
anything while in fact, we do have to remove the region.

Fixes #1218