### PR TITLE
Change popup style

### DIFF
--- a/popups.css
+++ b/popups.css
@@ -6,6 +6,8 @@
     margin-top: 0.5rem;
 }
 .lsp_popup hr {
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
     border-color: color(var(--foreground) alpha(0.10));
 }
 .highlight {

--- a/popups.css
+++ b/popups.css
@@ -10,12 +10,14 @@
     margin-bottom: 0.5rem;
     border-color: color(var(--foreground) alpha(0.10));
 }
-.lsp_popup h1 { font-size: 1rem; }
-.lsp_popup h2 { font-size: 1rem; }
-.lsp_popup h3 { font-size: 1rem; }
-.lsp_popup h4 { font-size: 1rem; }
-.lsp_popup h5 { font-size: 1rem; }
-.lsp_popup h6 { font-size: 1rem; }
+.lsp_popup h1,
+.lsp_popup h2,
+.lsp_popup h3,
+.lsp_popup h4,
+.lsp_popup h5,
+.lsp_popup h6 {
+    font-size: 1rem;
+}
 .highlight {
     border-width: 0;
     border-radius: 0;

--- a/popups.css
+++ b/popups.css
@@ -10,6 +10,12 @@
     margin-bottom: 0.5rem;
     border-color: color(var(--foreground) alpha(0.10));
 }
+.lsp_popup h1 { font-size: 1rem; }
+.lsp_popup h2 { font-size: 1rem; }
+.lsp_popup h3 { font-size: 1rem; }
+.lsp_popup h4 { font-size: 1rem; }
+.lsp_popup h5 { font-size: 1rem; }
+.lsp_popup h6 { font-size: 1rem; }
 .highlight {
     border-width: 0;
     border-radius: 0;


### PR DESCRIPTION
closes #1566 

This PR makes all the font-size of header elements the same as the other text(1rem).
But header elements are bold, which makes them standout just enough from the rest of the text.
 
Header font size before:
![headers](https://user-images.githubusercontent.com/22029477/107695087-6afde480-6cb0-11eb-9c7b-836bfde4eea8.png)

Header font size after:
![the smallest](https://user-images.githubusercontent.com/22029477/107695118-718c5c00-6cb0-11eb-8fb7-f122be7a1609.png)

----

I also reduced the `hr` margin to be consistent with the popup margin spacing (0.5)

Before:
![big](https://user-images.githubusercontent.com/22029477/107694980-4bff5280-6cb0-11eb-953a-be41d34ee44c.png)

After
![smaller](https://user-images.githubusercontent.com/22029477/107695007-515c9d00-6cb0-11eb-8f1d-70e3bc8900be.png)
