### PR TITLE
Replace document_highlight_scopes setting with better default scopes

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -86,13 +86,6 @@
   // When set to the empty string (""), no document highlighting is requested.
   "document_highlight_style": "underline",
 
-  "document_highlight_scopes": {
-    "unknown": "text",
-    "text": "text",
-    "read": "markup.inserted",
-    "write": "markup.changed"
-  },
-
   // Gutter marker for code diagnostics.
   // Valid values are "dot", "circle", "bookmark", "sign" or ""
   "diagnostics_gutter_marker": "dot",

--- a/docs/src/features.md
+++ b/docs/src/features.md
@@ -213,21 +213,15 @@ The following tables give an overview about the scope names used by LSP.
 
 #### Diagnostics
 
-=== "Sublime Text 4"
-| scope | DiagnosticSeverity | description |
-| ----- | ------------------ | ----------- |
-| `region.redish` | Error | Reports an error |
-| `region.yellowish` | Warning | Reports a warning |
-| `region.bluish` | Information | Reports an information |
-| `region.bluish` | Hint | Reports a hint |
-
-=== "Sublime Text 3"
 | scope | DiagnosticSeverity | description |
 | ----- | ------------------ | ----------- |
 | `markup.error.lsp` | Error | Reports an error |
 | `markup.warning.lsp` | Warning | Reports a warning |
 | `markup.info.lsp` | Information | Reports an information |
 | `markup.info.suggestion.lsp` | Hint | Reports a hint |
+
+!!! note
+    If `diagnostics_highlight_style` is set to "fill" in the LSP settings, the highlighting color can be controlled via the "background" color from a color scheme rule for the listed scopes.
 
 #### Signature Help
 

--- a/docs/src/features.md
+++ b/docs/src/features.md
@@ -182,7 +182,6 @@ Add these settings to LSP settings, your Sublime settings, Syntax-specific setti
 * `diagnostics_highlight_style` `"underline"` *highlight style of code diagnostics: "box", "underline", "stippled", "squiggly" or ""*
 * `highlight_active_signature_parameter`: *highlight the active parameter of the currently active signature*
 * `document_highlight_style`: *document highlight style: "box", "underline", "stippled", "squiggly" or ""*
-* `document_highlight_scopes`: *customize your sublime text scopes for document highlighting*
 * `diagnostics_gutter_marker` `"dot"` *gutter marker for code diagnostics: "dot", "circle", "bookmark", "sign" or ""*
 * `show_symbol_action_links` `false` *show links to symbol actions like go to, references and rename in the hover popup*
 * `disabled_capabilities`, `[]` *Turn off client capabilities (features): "hover", "completion", "documentHighlight", "colorProvider", "signatureHelp", "codeLensProvider", "codeActionProvider"*
@@ -190,3 +189,54 @@ Add these settings to LSP settings, your Sublime settings, Syntax-specific setti
 * `log_server` `[]` *log communication from and to language servers*
 * `log_stderr` `false` *show language server stderr output in the console*
 * `log_max_size` `8192` *max  number of characters of payloads to print*
+
+### Color configurations
+
+Some features use TextMate scopes to control the colors (underline, background or text color) of styled regions in a document or popup.
+Colors can be customized by adding a rule for these scopes into your color scheme, see https://www.sublimetext.com/docs/3/color_schemes.html#customization.
+
+The following tables give an overview about the scope names used by LSP.
+
+#### Document Highlights
+
+!!! info "This feature is only available if the server has the *documentHighlightProvider* capability."
+    Highlights other occurrences of the symbol at a given cursor position.
+
+| scope | DocumentHighlightKind | description |
+| ----- | --------------------- | ----------- |
+| `markup.highlight.text.lsp` | Text | A textual occurrence |
+| `markup.highlight.read.lsp` | Read | Read-access of a symbol, like reading a variable |
+| `markup.highlight.write.lsp` | Write | Write-access of a symbol, like writing to a variable |
+
+If `document_highlight_style` is set to "fill" in the LSP settings, additionally `meta.fill.lsp` gets prepended to the listed scopes.
+
+#### Diagnostics
+
+=== "Sublime Text 4"
+| scope | DiagnosticSeverity | description |
+| ----- | ------------------ | ----------- |
+| `region.redish` | Error | Reports an error |
+| `region.yellowish` | Warning | Reports a warning |
+| `region.bluish` | Information | Reports an information |
+| `region.bluish` | Hint | Reports a hint |
+
+=== "Sublime Text 3"
+| scope | DiagnosticSeverity | description |
+| ----- | ------------------ | ----------- |
+| `markup.error.lsp` | Error | Reports an error |
+| `markup.warning.lsp` | Warning | Reports a warning |
+| `markup.info.lsp` | Information | Reports an information |
+| `markup.info.suggestion.lsp` | Hint | Reports a hint |
+
+#### Signature Help
+
+| scope | description |
+| ----- | ----------- |
+| `entity.name.function.sighelp.lsp` | Function name in the signature help popup |
+| `variable.parameter.sighelp.lsp` | Function argument in the signature help popup |
+
+#### Code Lens
+
+| scope | description |
+| ----- | ----------- |
+| `markup.codelens.accent` | Accent color for code lens annotations |

--- a/docs/src/features.md
+++ b/docs/src/features.md
@@ -208,7 +208,8 @@ The following tables give an overview about the scope names used by LSP.
 | `markup.highlight.read.lsp` | Read | Read-access of a symbol, like reading a variable |
 | `markup.highlight.write.lsp` | Write | Write-access of a symbol, like writing to a variable |
 
-If `document_highlight_style` is set to "fill" in the LSP settings, additionally `meta.fill.lsp` gets prepended to the listed scopes.
+!!! note
+    If `document_highlight_style` is set to "fill" in the LSP settings, the highlighting color can be controlled via the "background" color from a color scheme rule for the listed scopes.
 
 #### Diagnostics
 

--- a/docs/src/features.md
+++ b/docs/src/features.md
@@ -218,7 +218,7 @@ The following tables give an overview about the scope names used by LSP.
 | `markup.error.lsp` | Error | Reports an error |
 | `markup.warning.lsp` | Warning | Reports a warning |
 | `markup.info.lsp` | Information | Reports an information |
-| `markup.info.suggestion.lsp` | Hint | Reports a hint |
+| `markup.info.hint.lsp` | Hint | Reports a hint |
 
 !!! note
     If `diagnostics_highlight_style` is set to "fill" in the LSP settings, the highlighting color can be controlled via the "background" color from a color scheme rule for the listed scopes.

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -30,7 +30,6 @@ class InsertTextFormat:
 
 
 class DocumentHighlightKind:
-    Unknown = 0
     Text = 1
     Read = 2
     Write = 3

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -155,7 +155,6 @@ class Settings:
     diagnostics_highlight_style = None  # type: str
     diagnostics_panel_include_severity_level = None  # type: int
     disabled_capabilities = None  # type: List[str]
-    document_highlight_scopes = None  # type: Dict[str, str]
     document_highlight_style = None  # type: str
     inhibit_snippet_completions = None  # type: bool
     inhibit_word_completions = None  # type: bool
@@ -191,7 +190,6 @@ class Settings:
         r("diagnostics_highlight_style", "underline")
         r("diagnostics_panel_include_severity_level", 4)
         r("disabled_capabilities", [])
-        r("document_highlight_scopes", {"unknown": "text", "text": "text", "read": "markup.inserted", "write": "markup.changed"})  # noqa
         r("document_highlight_style", "stippled")
         r("log_debug", False)
         r("log_max_size", 8 * 1024)

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -72,7 +72,7 @@ def debounced(f: Callable[[], Any], timeout_ms: int = 0, condition: Callable[[],
 def _settings_style_to_add_regions_flag(style: str) -> int:
     flags = 0
     if style == "fill":
-        pass
+        flags = sublime.DRAW_NO_OUTLINE
     elif style == "box":
         flags = sublime.DRAW_NO_FILL
     else:

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -24,11 +24,11 @@ import sublime_plugin
 import tempfile
 
 DIAGNOSTIC_SEVERITY = [
-    # Kind       CSS class   Scope for color                             Icon resource
-    ("error",   "errors",   "region.redish markup.error.lsp",           "Packages/LSP/icons/error.png"),
-    ("warning", "warnings", "region.yellowish markup.warning.lsp",      "Packages/LSP/icons/warning.png"),
-    ("info",    "info",     "region.bluish markup.info.lsp",            "Packages/LSP/icons/info.png"),
-    ("hint",    "hints",    "region.bluish markup.info.suggestion.lsp", "Packages/LSP/icons/info.png"),
+    # Kind       CSS class   Scope for color                        Icon resource
+    ("error",   "errors",   "region.redish markup.error.lsp",      "Packages/LSP/icons/error.png"),
+    ("warning", "warnings", "region.yellowish markup.warning.lsp", "Packages/LSP/icons/warning.png"),
+    ("info",    "info",     "region.bluish markup.info.lsp",       "Packages/LSP/icons/info.png"),
+    ("hint",    "hints",    "region.bluish markup.info.hint.lsp",  "Packages/LSP/icons/info.png"),
 ]
 
 # The scope names mainly come from http://www.sublimetext.com/docs/3/scope_naming.html

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -24,11 +24,11 @@ import sublime_plugin
 import tempfile
 
 DIAGNOSTIC_SEVERITY = [
-    # Kind       CSS class   Scope for color     Icon resource
-    ("error",   "errors",   "region.redish",    "Packages/LSP/icons/error.png"),
-    ("warning", "warnings", "region.yellowish", "Packages/LSP/icons/warning.png"),
-    ("info",    "info",     "region.bluish",    "Packages/LSP/icons/info.png"),
-    ("hint",    "hints",    "region.bluish",    "Packages/LSP/icons/info.png"),
+    # Kind       CSS class   Scope for color                             Icon resource
+    ("error",   "errors",   "region.redish markup.error.lsp",           "Packages/LSP/icons/error.png"),
+    ("warning", "warnings", "region.yellowish markup.warning.lsp",      "Packages/LSP/icons/warning.png"),
+    ("info",    "info",     "region.bluish markup.info.lsp",            "Packages/LSP/icons/info.png"),
+    ("hint",    "hints",    "region.bluish markup.info.suggestion.lsp", "Packages/LSP/icons/info.png"),
 ]
 
 # The scope names mainly come from http://www.sublimetext.com/docs/3/scope_naming.html

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -46,10 +46,15 @@ import webbrowser
 SUBLIME_WORD_MASK = 515
 
 _kind2name = {
-    DocumentHighlightKind.Unknown: "unknown",
     DocumentHighlightKind.Text: "text",
     DocumentHighlightKind.Read: "read",
     DocumentHighlightKind.Write: "write"
+}
+
+_kind2scope = {
+    DocumentHighlightKind.Text: "text markup.highlight.text.lsp",
+    DocumentHighlightKind.Read: "markup.inserted markup.highlight.read.lsp",
+    DocumentHighlightKind.Write: "markup.changed markup.highlight.write.lsp"
 }
 
 ResolveCompletionsFn = Callable[[List[sublime.CompletionItem], int], None]
@@ -559,12 +564,12 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
     # --- textDocument/documentHighlight -------------------------------------------------------------------------------
 
     def _clear_highlight_regions(self) -> None:
-        for kind in userprefs().document_highlight_scopes.keys():
-            self.view.erase_regions("lsp_highlight_{}".format(kind))
+        for kind in range(1, 4):
+            self.view.erase_regions("lsp_highlight_{}".format(_kind2name[kind]))
 
     def _is_in_higlighted_region(self, point: int) -> bool:
-        for kind in userprefs().document_highlight_scopes.keys():
-            regions = self.view.get_regions("lsp_highlight_{}".format(kind))
+        for kind in range(1, 4):
+            regions = self.view.get_regions("lsp_highlight_{}".format(_kind2name[kind]))
             for r in regions:
                 if r.contains(point):
                     return True
@@ -584,23 +589,30 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         if not response:
             self._clear_highlight_regions()
             return
-        kind2regions = {}  # type: Dict[str, List[sublime.Region]]
-        for kind in range(0, 4):
-            kind2regions[_kind2name[kind]] = []
+        kind2regions = {}  # type: Dict[int, List[sublime.Region]]
+        for kind in range(1, 4):
+            kind2regions[kind] = []
         for highlight in response:
             r = range_to_region(Range.from_lsp(highlight["range"]), self.view)
-            kind = highlight.get("kind", DocumentHighlightKind.Unknown)
-            if kind is not None:
-                kind2regions[_kind2name[kind]].append(r)
+            kind = highlight.get("kind", DocumentHighlightKind.Text)
+            if kind in kind2regions:
+                kind2regions[kind].append(r)
+            else:
+                debug("unknown DocumentHighlightKind", kind)
 
         def render_highlights_on_main_thread() -> None:
             self._clear_highlight_regions()
             flags = userprefs().document_highlight_style_to_add_regions_flags()
-            for kind_str, regions in kind2regions.items():
+            for kind, regions in kind2regions.items():
                 if regions:
-                    scope = userprefs().document_highlight_scopes.get(kind_str, None)
-                    if scope:
-                        self.view.add_regions("lsp_highlight_{}".format(kind_str), regions, scope=scope, flags=flags)
+                    scope = _kind2scope[kind]
+                    if not flags & sublime.DRAW_NO_FILL:
+                        scope = "meta.fill.lsp " + scope
+                    self.view.add_regions(
+                        "lsp_highlight_{}".format(_kind2name[kind]),
+                        regions,
+                        scope=scope,
+                        flags=flags)
 
         sublime.set_timeout(render_highlights_on_main_thread)
 

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -52,9 +52,9 @@ _kind2name = {
 }
 
 _kind2scope = {
-    DocumentHighlightKind.Text: "text markup.highlight.text.lsp",
-    DocumentHighlightKind.Read: "markup.inserted markup.highlight.read.lsp",
-    DocumentHighlightKind.Write: "markup.changed markup.highlight.write.lsp"
+    DocumentHighlightKind.Text: "region.bluish markup.highlight.text.lsp",
+    DocumentHighlightKind.Read: "region.greenish markup.highlight.read.lsp",
+    DocumentHighlightKind.Write: "region.yellowish markup.highlight.write.lsp"
 }
 
 ResolveCompletionsFn = Callable[[List[sublime.CompletionItem], int], None]
@@ -606,8 +606,6 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             for kind, regions in kind2regions.items():
                 if regions:
                     scope = _kind2scope[kind]
-                    if not flags & sublime.DRAW_NO_FILL:
-                        scope = "meta.fill.lsp " + scope
                     self.view.add_regions(
                         "lsp_highlight_{}".format(_kind2name[kind]),
                         regions,

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -253,39 +253,6 @@
               "default": "underline",
               "markdownDescription": "Highlighting style of `\"highlights\"`: accentuating nearby text entities that are related to the one under your cursor. When set to the empty string (`\"\"`), no diagnostics are shown in-line."
             },
-            "document_highlight_scopes": {
-              "type": "object",
-              "properties": {
-                "unknown": {
-                  "type": "string",
-                  "default": "text",
-                  "markdownDescription": "What Sublime Text scope should receive the LSP `\"unknown\"` scope?"
-                },
-                "text": {
-                  "type": "string",
-                  "default": "text",
-                  "markdownDescription": "What Sublime Text scope should receive the LSP `\"text\"` scope?"
-                },
-                "read": {
-                  "type": "string",
-                  "default": "markup.inserted",
-                  "markdownDescription": "What Sublime Text scope should receive the LSP `\"read\"` scope?"
-                },
-                "write": {
-                  "type": "string",
-                  "default": "markup.changed",
-                  "markdownDescription": "What Sublime Text scope should receive the LSP `\"write\"` scope?"
-                },
-                "additionalProperties": false
-              },
-              "default": {
-                "unknown": "text",
-                "text": "text",
-                "read": "markup.inserted",
-                "write": "markup.changed"
-              },
-              "markdownDescription": "Map the LSP scopes `\"unknown\"`, `\"text\"`, `\"read\"` and `\"write\"` to the given Sublime Text scopes. You can use those scopes in your .sublime-color-scheme to color the document highlight scopes."
-            },
             "diagnostics_gutter_marker": {
               "enum": [
                 "dot",


### PR DESCRIPTION
Resolves #1584

I saw that the `markup.error`/`markup.warning`/`markup.info` scopes for diagnostic regions in ST3 got "lost" in #1170 (but they are still used for the diagnostics panel). I would suggest to add them back on top of the `region.*` scopes which are currently used, because the `markup` scopes seemed like a nice semantic description and allow configuration of the styles for diagnostics colors independently of all the other places where `region.*` colors are used in ST.

I could also replace the `text` / `markup.inserted` / `markup.changed` scopes for documentHighlight that are kept for backwards compatibility by one (or separate) `region.*` scopes if desired.

Please checkout my branch and confirm that it actually works before merging this PR, because I haven't.