### PR TITLE
Don't lookup the listener so many times

### DIFF
--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -87,7 +87,7 @@ class LspHoverCommand(LspTextCommand):
             if not listener:
                 return
             if not only_diagnostics:
-                self.request_symbol_hover(listener, hover_point)
+                self.request_symbol_hover_async(listener, hover_point)
             self._diagnostics_by_config, covering = listener.diagnostics_touching_point_async(hover_point)
             if self._diagnostics_by_config:
                 if not only_diagnostics:
@@ -98,11 +98,11 @@ class LspHoverCommand(LspTextCommand):
 
         sublime.set_timeout_async(run_async)
 
-    def request_symbol_hover(self, listener: AbstractViewListener, point: int) -> None:
+    def request_symbol_hover_async(self, listener: AbstractViewListener, point: int) -> None:
         session = listener.session('hoverProvider', point)
         if session:
             document_position = text_document_position_params(self.view, point)
-            session.send_request(
+            session.send_request_async(
                 Request("textDocument/hover", document_position, self.view),
                 lambda response: self.handle_response(listener, response, point))
 

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -91,7 +91,6 @@ class LspHoverCommand(LspTextCommand):
             self._diagnostics_by_config, covering = listener.diagnostics_touching_point_async(hover_point)
             if self._diagnostics_by_config:
                 if not only_diagnostics:
-                    functools.partial(self.handle_code_actions, hover_point)
                     actions_manager.request_with_diagnostics_async(
                         self.view, covering, self._diagnostics_by_config,
                         functools.partial(self.handle_code_actions, listener, hover_point))


### PR DESCRIPTION
A tiny improvement. Found during debugging of #1575. Most notably, the
`provider_exists` is called for a few different providers, and each time
we do the same lookup. This is now avoided by remembering with which
listener we are dealing with.