### PR TITLE
Add disabled capabilities per client config

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -110,10 +110,6 @@
   // Show symbol references in Sublime's quick panel instead of the bottom panel.
   "show_references_in_quick_panel": false,
 
-  // Disable language client capabilities. Supported values:
-  // "hover", "completion", "colorProvider", "documentHighlight", "signatureHelp", "codeLensProvider", "codeActionProvider"
-  "disabled_capabilities": [],
-
   // Show verbose debug messages in the sublime console.
   "log_debug": false,
 
@@ -173,6 +169,9 @@
   //
   //     // Sent once to server in initialize request
   //     "initializationOptions": { },
+  //
+  //     // Disable providers if so desired
+  //     "disabled_capabilities": { },
   //
   //     // Extra variables to override/add to language server's environment.
   //     "env": { },

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -120,10 +120,6 @@ class CodeActionsManager:
         actions_handler: Callable[[CodeActionsByConfigName], None],
         on_save_actions: Optional[Dict[str, bool]] = None
     ) -> None:
-        if 'codeActionProvider' in userprefs().disabled_capabilities:
-            sublime.set_timeout_async(lambda: actions_handler({}))
-            return
-
         use_cache = on_save_actions is None
         if use_cache:
             location_cache_key = "{}#{}:{}:{}".format(

--- a/plugin/core/collections.py
+++ b/plugin/core/collections.py
@@ -1,7 +1,7 @@
 """
 Module with additional collections.
 """
-from .typing import Optional, Dict, Any
+from .typing import Optional, Dict, Any, Generator
 from copy import deepcopy
 import sublime
 
@@ -48,6 +48,17 @@ class DottedDict:
             else:
                 return None
         return current
+
+    def walk(self, path: str) -> Generator[Any, None, None]:
+        current = self._d  # type: Any
+        keys = path.split('.')
+        for key in keys:
+            if isinstance(current, dict):
+                current = current.get(key)
+                yield current
+            else:
+                yield None
+                return
 
     def set(self, path: str, value: Any) -> None:
         """

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -868,6 +868,8 @@ class Session(TransportCallbacks):
         return value is not False and value is not None
 
     def get_capability(self, capability: str) -> Optional[Any]:
+        if self.config.is_disabled_capability(capability):
+            return None
         return self.capabilities.get(capability)
 
     def should_notify_did_open(self) -> bool:

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -170,10 +170,8 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             self.view.settings().set("lsp_active", True)
             added = True
         if added:
-            if "colorProvider" not in userprefs().disabled_capabilities:
-                self._do_color_boxes_async()
-            if "codeLensProvider" not in userprefs().disabled_capabilities:
-                self._do_code_lenses_async()
+            self._do_color_boxes_async()
+            self._do_code_lenses_async()
 
     def on_session_shutdown_async(self, session: Session) -> None:
         removed_session = self._session_views.pop(session.config.name, None)
@@ -269,18 +267,14 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
                 sv.on_text_changed_async(change_count, changes)
         if not different:
             return
-        if "documentHighlight" not in userprefs().disabled_capabilities:
-            self._clear_highlight_regions()
-            self._when_selection_remains_stable_async(self._do_highlights_async, current_region,
-                                                      after_ms=self.highlights_debounce_time)
-        if "colorProvider" not in userprefs().disabled_capabilities:
-            self._when_selection_remains_stable_async(self._do_color_boxes_async, current_region,
-                                                      after_ms=self.color_boxes_debounce_time)
-        if "signatureHelp" not in userprefs().disabled_capabilities:
-            self.do_signature_help_async(manual=False)
-        if "codeLensProvider" not in userprefs().disabled_capabilities:
-            self._when_selection_remains_stable_async(self._do_code_lenses_async, current_region,
-                                                      after_ms=self.code_lenses_debounce_time)
+        self._clear_highlight_regions()
+        self._when_selection_remains_stable_async(self._do_highlights_async, current_region,
+                                                  after_ms=self.highlights_debounce_time)
+        self._when_selection_remains_stable_async(self._do_color_boxes_async, current_region,
+                                                  after_ms=self.color_boxes_debounce_time)
+        self.do_signature_help_async(manual=False)
+        self._when_selection_remains_stable_async(self._do_code_lenses_async, current_region,
+                                                  after_ms=self.code_lenses_debounce_time)
 
     def get_language_id(self) -> str:
         return self._language_id
@@ -304,11 +298,10 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
     def on_selection_modified_async(self) -> None:
         different, current_region = self._update_stored_region_async()
         if different:
-            if "documentHighlight" not in userprefs().disabled_capabilities:
-                if not self._is_in_higlighted_region(current_region.b):
-                    self._clear_highlight_regions()
-                self._when_selection_remains_stable_async(self._do_highlights_async, current_region,
-                                                          after_ms=self.highlights_debounce_time)
+            if not self._is_in_higlighted_region(current_region.b):
+                self._clear_highlight_regions()
+            self._when_selection_remains_stable_async(self._do_highlights_async, current_region,
+                                                      after_ms=self.highlights_debounce_time)
             self._clear_code_actions_annotation()
             self._when_selection_remains_stable_async(self._do_code_actions, current_region,
                                                       after_ms=self.code_actions_debounce_time)
@@ -345,16 +338,13 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         return False
 
     def on_hover(self, point: int, hover_zone: int) -> None:
-        if (hover_zone != sublime.HOVER_TEXT
-                or self.view.is_popup_visible()
-                or "hover" in userprefs().disabled_capabilities):
+        if hover_zone != sublime.HOVER_TEXT or self.view.is_popup_visible():
             return
         self.view.run_command("lsp_hover", {"point": point})
 
     def on_post_text_command(self, command_name: str, args: Optional[Dict[str, Any]]) -> None:
         if command_name in ("next_field", "prev_field") and args is None:
-            if "signatureHelp" not in userprefs().disabled_capabilities:
-                sublime.set_timeout_async(lambda: self.do_signature_help_async(manual=True))
+            sublime.set_timeout_async(lambda: self.do_signature_help_async(manual=True))
         if not self.view.is_popup_visible():
             return
         if command_name in ["hide_auto_complete", "move", "commit_completion"] or 'delete' in command_name:
@@ -362,8 +352,6 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             self.view.hide_popup()
 
     def on_query_completions(self, prefix: str, locations: List[int]) -> Optional[sublime.CompletionList]:
-        if "completion" in userprefs().disabled_capabilities:
-            return None
 
         def resolve(clist: sublime.CompletionList, items: List[sublime.CompletionItem], flags: int = 0) -> None:
             # Resolve on the main thread to prevent any sort of data race for _set_target (see sublime_plugin.py).

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -146,8 +146,10 @@ class SessionBuffer:
             sv.on_capability_removed_async(registration_id, discarded)
 
     def get_capability(self, capability_path: str) -> Optional[Any]:
+        if self.session.config.is_disabled_capability(capability_path):
+            return None
         value = self.capabilities.get(capability_path)
-        return value if value is not None else self.session.get_capability(capability_path)
+        return value if value is not None else self.session.capabilities.get(capability_path)
 
     def has_capability(self, capability: str) -> bool:
         value = self.get_capability(capability)

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -63,6 +63,10 @@
               "type": "object",
               "markdownDescription": "Experimental capabilities that are passed to the language server process during the _initialize_ phase. This is different per language server, so you'll need to look up documentation for your particular language server."
             },
+            "ClientDisabledCapabilities": {
+              "type": "object",
+              "markdownDescription": "A dictionary that \"masks\" (disables) the capabilities registered by this language server. For instance, to disable completions, use `{\"completionProvider\": true}`. To disable hover info, use `{\"hoverProvider\": true}`. Multiple providers can be disabled. To disable a subset of a provider, use a nested dictionary. For intance, to disable only the trigger characters of a language server, but not the completion functionality itself, use `{\"completionProvider\": {\"triggerCharacters\": true}}`.\n\nTo figure out exactly which _provider_ you need to disable here is an advanced topic. You'll have to study the official specification to see what particular providers exist. Here are a few common provider names that might do what you want:\n\n- hoverProvider\n- completionProvider\n- colorProvider\n- documentHighlightProvider\n- signatureHelpProvider\n- codeLensProvider\n- codeActionProvider"
+            },
             "ClientEnv": {
               "type": "object",
               "markdownDescription": "Specify environment variables to pass to the language server process on startup.",
@@ -117,6 +121,9 @@
                 },
                 "experimental_capabilities": {
                   "$ref": "#/definitions/ClientExperimentalCapabilities"
+                },
+                "disabled_capabilities": {
+                  "$ref": "#/definitions/ClientDisabledCapabilities"
                 },
                 "env": {
                   "$ref": "#/definitions/ClientEnv"
@@ -299,21 +306,9 @@
             },
             "disabled_capabilities": {
               "type": "array",
-              "items": {
-                "type": "string",
-                "enum": [
-                  "hover",
-                  "completion",
-                  "colorProvider",
-                  "documentHighlight",
-                  "signatureHelp",
-                  "codeLensProvider",
-                  "codeActionProvider"
-                ]
-              },
               "uniqueItems": true,
               "minItems": 0,
-              "markdownDescription": "Disable language server capabilities."
+              "deprecationMessage": "Instead of a global option, this option is now on a per-client basis. Moreover, this is now an object instead of an array."
             },
             "log_debug": {
               "type": "boolean",
@@ -427,6 +422,9 @@
             },
             "experimental_capabilities": {
               "$ref": "sublime://settings/LSP#/definitions/ClientExperimentalCapabilities"
+            },
+            "disabled_capabilities": {
+              "$ref": "sublime://settings/LSP#/definitions/ClientDisabledCapabilities"
             },
             "env": {
               "$ref": "sublime://settings/LSP#/definitions/ClientEnv"

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -62,6 +62,31 @@ class ConfigParsingTests(DeferrableTestCase):
         config = read_client_config("pyls", settings)
         self.assertEqual(config.experimental_capabilities, experimental_capabilities)
 
+    def test_disabled_capabilities(self):
+        settings = {
+            "command": ["pyls"],
+            "selector": "source.python",
+            "disabled_capabilities": {
+                "colorProvider": True,
+                "completionProvider": {"triggerCharacters": True},
+                "codeActionProvider": True
+            }
+        }
+        config = read_client_config("pyls", settings)
+        self.assertTrue(config.is_disabled_capability("colorProvider"))
+        # If only a sub path is disabled, the entire capability should not be disabled as a whole
+        self.assertFalse(config.is_disabled_capability("completionProvider"))
+        # This sub path should be disabled
+        self.assertTrue(config.is_disabled_capability("completionProvider.triggerCharacters"))
+        # But not this sub path
+        self.assertFalse(config.is_disabled_capability("completionProvider.resolveProvider"))
+        # The entire codeActionProvider is disabld
+        self.assertTrue(config.is_disabled_capability("codeActionProvider"))
+        # If codeActionProvider is disabled, all of its sub paths should be disabled as well
+        self.assertTrue(config.is_disabled_capability("codeActionProvider.codeActionKinds"))
+        # This one should be enabled
+        self.assertFalse(config.is_disabled_capability("definitionProvider"))
+
     def test_path_maps(self):
         config = read_client_config("asdf", {
             "command": ["asdf"],


### PR DESCRIPTION
This adds disabled_capabilities to each client configuration. It is different
from the old disabled_capabilities in that it is now an object instead of an
array. You can disable subsets of functionality.