### PR TITLE
Enable hardbreak in mdpopups to handle escaped newlines

### DIFF
--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -463,7 +463,7 @@ def minihtml(view: sublime.View, content: Union[str, Dict[str, str], list], allo
             "markdown_extensions": [
                 {
                     "pymdownx.escapeall": {
-                        "hardbreak": False,
+                        "hardbreak": True,
                         "nbsp": False
                     }
                 },

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -345,3 +345,9 @@ class ViewsTest(DeferrableTestCase):
             format_diagnostic_for_html(self.view, diagnostic1, "/foo/bar"),
             format_diagnostic_for_html(self.view, diagnostic2, "/foo/bar")
         )
+
+    def test_escaped_newline_in_markdown(self) -> None:
+        self.assertEqual(
+            minihtml(self.view, {"kind": "markdown", "value": "hello\\\nworld"}, FORMAT_MARKUP_CONTENT),
+            "<p>hello<br />\nworld</p>"
+        )


### PR DESCRIPTION
Discussion can be found here: https://github.com/facelessuser/sublime-markdown-popups/issues/119