### PR TITLE
Remove ignore_server_trigger_chars setting

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1095,14 +1095,15 @@ class Session(TransportCallbacks):
         """handles the client/registerCapability request"""
         registrations = params["registrations"]
         for registration in registrations:
-            registration_id = registration["id"]
             capability_path, registration_path = method_to_capability(registration["method"])
+            if self.config.is_disabled_capability(capability_path):
+                continue
             debug("{}: registering capability:".format(self.config.name), capability_path)
             options = registration.get("registerOptions")  # type: Optional[Dict[str, Any]]
             if not isinstance(options, dict):
                 options = {}
-            if self.config.filter_disabled_capabilities(capability_path, options):
-                continue
+            options = self.config.filter_out_disabled_capabilities(capability_path, options)
+            registration_id = registration["id"]
             data = _RegistrationData(registration_id, capability_path, registration_path, options)
             self._registrations[registration_id] = data
             if data.selector:

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -713,16 +713,12 @@ class ClientConfig:
                     return True
         return False
 
-    def filter_disabled_capabilities(self, capability_path: str, options: Dict[str, Any]) -> bool:
-        if self.is_disabled_capability(capability_path):
-            return True
-        to_be_removed = []  # type: List[str]
-        for k in options.keys():
-            if self.is_disabled_capability("{}.{}".format(capability_path, k)):
-                to_be_removed.append(k)
-        for k in to_be_removed:
-            options.pop(k)
-        return False
+    def filter_out_disabled_capabilities(self, capability_path: str, options: Dict[str, Any]) -> Dict[str, Any]:
+        result = {}  # type: Dict[str, Any]
+        for k, v in options.items():
+            if not self.is_disabled_capability("{}.{}".format(capability_path, k)):
+                result[k] = v
+        return result
 
     def __repr__(self) -> str:
         items = []  # type: List[str]

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -77,8 +77,8 @@ class SessionView:
     def _setup_auto_complete_triggers(self, settings: sublime.Settings) -> None:
         """Register trigger characters from static capabilities of the server."""
         trigger_chars = self.session.get_capability(self.TRIGGER_CHARACTERS_KEY)
-        if isinstance(trigger_chars, list):
-            self._apply_auto_complete_triggers(settings, trigger_chars)
+        if isinstance(trigger_chars, list) or self.session.config.auto_complete_selector:
+            self._apply_auto_complete_triggers(settings, trigger_chars or [])
 
     def _register_auto_complete_triggers(self, registration_id: str, trigger_chars: List[str]) -> None:
         """Register trigger characters from a dynamic server registration."""
@@ -115,7 +115,7 @@ class SessionView:
             # from the auto_complete_triggers array once the session is stopped.
             "server": self.session.config.name
         }
-        if not self.session.config.ignore_server_trigger_chars:
+        if trigger_chars:
             trigger["characters"] = "".join(trigger_chars)
         if isinstance(registration_id, str):
             # This key is not used by Sublime, but is used as a "breadcrumb" as well, for dynamic registrations.
@@ -149,8 +149,8 @@ class SessionView:
             self._increment_hover_count()
         elif capability_path.startswith(self.COMPLETION_PROVIDER_KEY):
             trigger_chars = options.get("triggerCharacters")
-            if isinstance(trigger_chars, list):
-                self._register_auto_complete_triggers(registration_id, trigger_chars)
+            if isinstance(trigger_chars, list) or self.session.config.auto_complete_selector:
+                self._register_auto_complete_triggers(registration_id, trigger_chars or [])
         elif capability_path.startswith("codeLensProvider"):
             listener = self.listener()
             if listener:

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -49,7 +49,7 @@
             "ClientIgnoreServerTriggerChars": {
               "type": "boolean",
               "default": false,
-              "markdownDescription": "A language server may register a list of characters that, when typed, trigger the auto-complete. These days, there are Sublime syntaxes that are so good that it is possible to detect via a selector when the auto-complete should be triggered. This can result in a much better editor experience. When this is the case for your syntax, choose an appropriate selector for the `\"auto_complete_selector\"` and set this setting to `\"true\"`.\n\n**Hint.** You may look at `view.settings().get(\"auto_complete_triggers\")` in the Console to verify your settings."
+              "deprecationMessage": "Use disabled_capabilities instead: \"disabled_capabilities\": {\"completionProvider\": {\"triggerCharacters\": true}}"
             },
             "ClientInitializationOptions": {
               "type": "object",

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -68,7 +68,7 @@ def remove_config(config):
     client_configs.remove_for_testing(config)
 
 
-def close_test_view(view: sublime.View):
+def close_test_view(view: Optional[sublime.View]):
     if view:
         view.set_scratch(True)
         view.close()
@@ -81,6 +81,10 @@ def expand(s: str, w: sublime.Window) -> str:
 class TextDocumentTestCase(DeferrableTestCase):
 
     @classmethod
+    def get_stdio_test_config(cls) -> ClientConfig:
+        return make_stdio_test_config()
+
+    @classmethod
     def setUpClass(cls) -> Generator:
         super().setUpClass()
         test_name = cls.get_test_name()
@@ -89,7 +93,7 @@ class TextDocumentTestCase(DeferrableTestCase):
         filename = expand(join("$packages", "LSP", "tests", "{}.txt".format(test_name)), window)
         open_view = window.find_open_file(filename)
         close_test_view(open_view)
-        cls.config = make_stdio_test_config()
+        cls.config = cls.get_stdio_test_config()
         cls.config.init_options.set("serverResponse", server_capabilities)
         add_config(cls.config)
         cls.wm = windows.lookup(window)

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -87,7 +87,7 @@ class ConfigParsingTests(DeferrableTestCase):
         # This one should be enabled
         self.assertFalse(config.is_disabled_capability("definitionProvider"))
 
-    def test_filter_disabled_capabilities_ignore_partially(self):
+    def test_filter_out_disabled_capabilities_ignore_partially(self):
         settings = {
             "command": ["pyls"],
             "selector": "source.python",
@@ -96,20 +96,9 @@ class ConfigParsingTests(DeferrableTestCase):
         config = read_client_config("pyls", settings)
         capability_path = "completionProvider"
         options = {"triggerCharacters": ["!"], "resolveProvider": True}
-        self.assertFalse(config.filter_disabled_capabilities(capability_path, options))
+        options = config.filter_out_disabled_capabilities(capability_path, options)
         self.assertNotIn("triggerCharacters", options)
         self.assertIn("resolveProvider", options)
-
-    def test_filter_disabled_capabilities_ignore_fully(self):
-        settings = {
-            "command": ["pyls"],
-            "selector": "source.python",
-            "disabled_capabilities": {"codeActionProvider": True}
-        }
-        config = read_client_config("pyls", settings)
-        capability_path = "codeActionProvider"
-        options = {"codeActionKinds": [], "resolveProvider": True}
-        self.assertTrue(config.filter_disabled_capabilities(capability_path, options))
 
     def test_path_maps(self):
         config = read_client_config("asdf", {

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -87,6 +87,30 @@ class ConfigParsingTests(DeferrableTestCase):
         # This one should be enabled
         self.assertFalse(config.is_disabled_capability("definitionProvider"))
 
+    def test_filter_disabled_capabilities_ignore_partially(self):
+        settings = {
+            "command": ["pyls"],
+            "selector": "source.python",
+            "disabled_capabilities": {"completionProvider": {"triggerCharacters": True}}
+        }
+        config = read_client_config("pyls", settings)
+        capability_path = "completionProvider"
+        options = {"triggerCharacters": ["!"], "resolveProvider": True}
+        self.assertFalse(config.filter_disabled_capabilities(capability_path, options))
+        self.assertNotIn("triggerCharacters", options)
+        self.assertIn("resolveProvider", options)
+
+    def test_filter_disabled_capabilities_ignore_fully(self):
+        settings = {
+            "command": ["pyls"],
+            "selector": "source.python",
+            "disabled_capabilities": {"codeActionProvider": True}
+        }
+        config = read_client_config("pyls", settings)
+        capability_path = "codeActionProvider"
+        options = {"codeActionKinds": [], "resolveProvider": True}
+        self.assertTrue(config.filter_disabled_capabilities(capability_path, options))
+
     def test_path_maps(self):
         config = read_client_config("asdf", {
             "command": ["asdf"],

--- a/tests/test_server_requests.py
+++ b/tests/test_server_requests.py
@@ -1,7 +1,9 @@
 from LSP.plugin.core.protocol import ErrorCode
 from LSP.plugin.core.protocol import TextDocumentSyncKindFull
 from LSP.plugin.core.protocol import TextDocumentSyncKindIncremental
-from LSP.plugin.core.typing import Any, Dict, Generator, Optional
+from LSP.plugin.core.sessions import SessionBufferProtocol
+from LSP.plugin.core.types import ClientConfig
+from LSP.plugin.core.typing import Any, Dict, Generator, Optional, List
 from LSP.plugin.core.url import filename_to_uri
 from setup import TextDocumentTestCase
 import os
@@ -9,21 +11,31 @@ import sublime
 import tempfile
 
 
+def get_auto_complete_trigger(sb: SessionBufferProtocol) -> Optional[List[Dict[str, str]]]:
+    for sv in sb.session_views:
+        triggers = sv.view.settings().get("auto_complete_triggers")
+        for trigger in triggers:
+            if "server" in trigger and "registration_id" in trigger:
+                return trigger
+    return None
+
+
+def verify(testcase: TextDocumentTestCase, method: str, input_params: Any, expected_output_params: Any) -> Generator:
+    promise = testcase.make_server_do_fake_request(method, input_params)
+    yield from testcase.await_promise(promise)
+    testcase.assertEqual(promise.result(), expected_output_params)
+
+
 class ServerRequests(TextDocumentTestCase):
 
-    def verify(self, method: str, input_params: Any, expected_output_params: Any) -> Generator:
-        promise = self.make_server_do_fake_request(method, input_params)
-        yield from self.await_promise(promise)
-        self.assertEqual(promise.result(), expected_output_params)
-
     def test_unknown_method(self) -> Generator:
-        yield from self.verify("foobar/qux", {}, {"code": ErrorCode.MethodNotFound, "message": "foobar/qux"})
+        yield from verify(self, "foobar/qux", {}, {"code": ErrorCode.MethodNotFound, "message": "foobar/qux"})
 
     def test_m_workspace_workspaceFolders(self) -> Generator:
         expected_output = [{"name": os.path.basename(f), "uri": filename_to_uri(f)}
                            for f in sublime.active_window().folders()]
         self.maxDiff = None
-        yield from self.verify("workspace/workspaceFolders", {}, expected_output)
+        yield from verify(self, "workspace/workspaceFolders", {}, expected_output)
 
     def test_m_workspace_configuration(self) -> Generator:
         self.session.config.settings.set("foo.bar", "$hello")
@@ -42,7 +54,7 @@ class ServerRequests(TextDocumentTestCase):
         method = "workspace/configuration"
         params = {"items": [{"section": "foo"}]}
         expected_output = [{"bar": "X", "baz": "Y", "a": 1, "b": None, "c": ["asdf X Y"]}]
-        yield from self.verify(method, params, expected_output)
+        yield from verify(self, method, params, expected_output)
         self.session.config.settings.clear()
 
     def test_m_workspace_applyEdit(self) -> Generator:
@@ -51,7 +63,7 @@ class ServerRequests(TextDocumentTestCase):
             "newText": "there",
             "range": {"start": {"line": 1, "character": 0}, "end": {"line": 1, "character": 5}}}
         params = {"edit": {"changes": {filename_to_uri(self.view.file_name()): [edit]}}}
-        yield from self.verify("workspace/applyEdit", params, {"applied": True})
+        yield from verify(self, "workspace/applyEdit", params, {"applied": True})
         yield lambda: self.view.change_count() > old_change_count
         self.assertEqual(self.view.substr(sublime.Region(0, self.view.size())), "hello\nthere\n")
 
@@ -63,7 +75,8 @@ class ServerRequests(TextDocumentTestCase):
                 file_paths.append(os.path.join(dirpath, "file{}.txt".format(i)))
                 with open(file_paths[-1], "w") as fp:
                     fp.write(initial_text[i])
-            yield from self.verify(
+            yield from verify(
+                self,
                 "workspace/applyEdit",
                 {
                     "edit": {
@@ -107,7 +120,8 @@ class ServerRequests(TextDocumentTestCase):
                 view.close()
 
     def test_m_client_registerCapability(self) -> Generator:
-        yield from self.verify(
+        yield from verify(
+            self,
             "client/registerCapability",
             {
                 "registrations":
@@ -136,6 +150,8 @@ class ServerRequests(TextDocumentTestCase):
         self.assertEqual(self.session.capabilities.get("workspace.workspaceFolders.changeNotifications"), "asdf")
         self.assertEqual(self.session.capabilities.get("textDocumentSync.didOpen"), {"id": "1"})
         self.assertFalse(self.session.capabilities.get("textDocumentSync.didClose"))
+
+        # willSaveWaitUntil is *only* registered on the buffer
         self.assertFalse(self.session.capabilities.get("textDocumentSync.willSaveWaitUntil"))
         sb = next(self.session.session_buffers_async())
         self.assertEqual(sb.capabilities.text_sync_kind(), TextDocumentSyncKindFull)
@@ -146,24 +162,64 @@ class ServerRequests(TextDocumentTestCase):
         # characters for each view were updated
         self.assertEqual(sb.capabilities.get("completionProvider.id"), "myCompletionRegistrationId")
         self.assertEqual(sb.capabilities.get("completionProvider.triggerCharacters"), ["!", "@", "#"])
-        self.assertTrue(len(sb.session_views) > 0)
-        for sv in sb.session_views:
-            found = False
-            triggers = sv.view.settings().get("auto_complete_triggers")
-            for trigger in triggers:
-                if "server" in trigger and "registration_id" in trigger:
-                    self.assertEqual(trigger.get("characters"), "!@#")
-                    found = True
-            self.assertTrue(found)
+        trigger = get_auto_complete_trigger(sb)
+        self.assertTrue(trigger)
+        self.assertEqual(trigger.get("characters"), "!@#")
 
     def test_m_client_unregisterCapability(self) -> Generator:
-        yield from self.verify(
+        yield from verify(
+            self,
             "client/registerCapability",
             {"registrations": [{"method": "foo/bar", "id": "hello"}]},
             None)
         self.assertIn("barProvider", self.session.capabilities)
-        yield from self.verify(
+        yield from verify(
+            self,
             "client/unregisterCapability",
             {"unregisterations": [{"method": "foo/bar", "id": "hello"}]},
             None)
         self.assertNotIn("barProvider", self.session.capabilities)
+
+
+class ServerRequestsWithAutoCompleteSelector(TextDocumentTestCase):
+
+    @classmethod
+    def get_stdio_test_config(cls) -> ClientConfig:
+        return ClientConfig.from_config(
+            super().get_stdio_test_config(),
+            {
+                "auto_complete_selector": "punctuation.section",
+                "disabled_capabilities": {
+                    "completionProvider": {
+                        "triggerCharacters": True
+                    }
+                }
+            }
+        )
+
+    def test_m_client_registerCapability(self) -> Generator:
+        yield from verify(
+            self,
+            "client/registerCapability",
+            {
+                "registrations":
+                [
+                    # Note that the triggerCharacters are disabled in the configuration.
+                    {"method": "textDocument/completion", "id": "anotherCompletionRegistrationId",
+                     "registerOptions": {"triggerCharacters": ["!", "@", "#"], "documentSelector": [
+                       {"language": "txt"}
+                     ]}}
+                ]
+            },
+            None)
+        sb = next(self.session.session_buffers_async())
+        # Check that textDocument/completion was registered onto the SessionBuffer
+        self.assertEqual(sb.capabilities.get("completionProvider.id"), "anotherCompletionRegistrationId")
+        # Trigger characters should not have been registered
+        self.assertFalse(sb.capabilities.get("completionProvider.triggerCharacters"))
+        trigger = get_auto_complete_trigger(sb)
+        self.assertTrue(trigger)
+        # No triggers should have been assigned
+        self.assertFalse(trigger.get("characters"))
+        # The selector should have been set
+        self.assertEqual(trigger.get("selector"), "punctuation.section")


### PR DESCRIPTION
An alternative is using disabled_capabilities.
I've also added more tests for dynamic registration for this.
Dynamic registration went through for disabled capabilities anyway.
But not anymore :)