### PR TITLE
Remove temp disabled config logic

### DIFF
--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -1,6 +1,6 @@
 from .logging import debug
 from .types import ClientConfig
-from .typing import Any, Generator, List, Dict, Set
+from .typing import Any, Generator, List, Dict
 from .workspace import enable_in_project, disable_in_project
 import sublime
 
@@ -27,7 +27,6 @@ class WindowConfigManager(object):
     def __init__(self, window: sublime.Window, global_configs: Dict[str, ClientConfig]) -> None:
         self._window = window
         self._global_configs = global_configs
-        self._temp_disabled_configs = set()  # type: Set[str]
         self.all = {}  # type: Dict[str, ClientConfig]
         self.update()
 
@@ -63,12 +62,6 @@ class WindowConfigManager(object):
             else:
                 overrides = {}
             self.all[name] = ClientConfig.from_config(config, overrides)
-        for name in self._temp_disabled_configs:
-            try:
-                self.all[name].enabled = False
-            except KeyError:
-                # The plugin is updating
-                self._temp_disabled_configs.discard(name)
         self._window.run_command("lsp_recheck_sessions")
 
     def enable_config(self, config_name: str) -> None:
@@ -77,8 +70,4 @@ class WindowConfigManager(object):
 
     def disable_config(self, config_name: str) -> None:
         disable_in_project(self._window, config_name)
-        self.update()
-
-    def disable_temporarily(self, config_name: str) -> None:
-        self._temp_disabled_configs.add(config_name)
         self.update()

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -339,10 +339,10 @@ class WindowManager(Manager):
             self._new_session = session
         except Exception as e:
             message = "".join((
-                "Failed tot start subprocess for {0}. Reason:\n\n",
+                "Failed to start subprocess for {0}. Reason:\n\n",
                 "{1}\n\n",
                 "{0} will be disabled for this project. Enable {0} again by running ",
-                "LSP: Enable Language Server In Project from the Command Palette."
+                "\"LSP: Enable Language Server In Project\" from the Command Palette."
             )).format(config.name, str(e))
             exception_log("Unable to start subprocess for {}".format(config.name), e)
             if isinstance(e, CalledProcessError):
@@ -428,7 +428,7 @@ class WindowManager(Manager):
                 msg += " and message:\n\n---\n{}\n---".format(str(exception))
             msg += "".join((
                 "\n\nDo you want to restart {0}?\n\nIf you choose Cancel, {0} will be disabled for this project. ",
-                "Enable {0} again by running LSP: Enable Language Server In Project from the Command Palette."
+                "Enable {0} again by running \"LSP: Enable Language Server In Project\" from the Command Palette."
             )).format(config.name)
             if sublime.ok_cancel_dialog(msg, "Restart {}".format(config.name)):
                 for listener in self._listeners:

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -338,15 +338,15 @@ class WindowManager(Manager):
                 lambda session, is_error: self._on_post_session_initialize(initiating_view, session, is_error))
             self._new_session = session
         except Exception as e:
-            message = "\n\n".join([
-                "Could not start {}",
-                "{}",
-                "Server will be disabled for this window"
-            ]).format(config.name, str(e))
-            exception_log("Unable to start {}".format(config.name), e)
+            message = "\n\n".join((
+                "Failed to start subprocess for {0}. Reason:",
+                "{1}",
+                "{0} will be disabled for this project. Enable {0} again using the Command Palette."
+            )).format(config.name, str(e))
+            exception_log("Unable to start subprocess for {}".format(config.name), e)
             if isinstance(e, CalledProcessError):
                 print("Server output:\n{}".format(e.output.decode('utf-8', 'replace')))
-            self._configs.disable_temporarily(config.name)
+            self._configs.disable_config(config.name)
             config.erase_view_status(initiating_view)
             sublime.message_dialog(message)
             # Continue with handling pending listeners
@@ -425,13 +425,13 @@ class WindowManager(Manager):
             msg = "{} exited with status code {}".format(config.name, exit_code)
             if exception:
                 msg += " and message:\n\n---\n{}\n---".format(str(exception))
-            msg += "\n\nDo you want to restart {0}?\n\nIf you choose Cancel, {0} will "\
-                   "be disabled for this window until you restart Sublime Text.".format(config.name)
+            msg += "".join(("\n\nDo you want to restart {0}?\n\nIf you choose Cancel, {0} will be disabled for this ",
+                            "project. You can re-enable {0} manually using the Command Palette.")).format(config.name)
             if sublime.ok_cancel_dialog(msg, "Restart {}".format(config.name)):
                 for listener in self._listeners:
                     self.register_listener_async(listener)
             else:
-                self._configs.disable_temporarily(config.name)
+                self._configs.disable_config(config.name)
 
     def plugin_unloaded(self) -> None:
         """

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -338,10 +338,11 @@ class WindowManager(Manager):
                 lambda session, is_error: self._on_post_session_initialize(initiating_view, session, is_error))
             self._new_session = session
         except Exception as e:
-            message = "\n\n".join((
-                "Failed to start subprocess for {0}. Reason:",
-                "{1}",
-                "{0} will be disabled for this project. Enable {0} again using the Command Palette."
+            message = "".join((
+                "Failed tot start subprocess for {0}. Reason:\n\n",
+                "{1}\n\n",
+                "{0} will be disabled for this project. Enable {0} again by running ",
+                "LSP: Enable Language Server In Project from the Command Palette."
             )).format(config.name, str(e))
             exception_log("Unable to start subprocess for {}".format(config.name), e)
             if isinstance(e, CalledProcessError):
@@ -425,8 +426,10 @@ class WindowManager(Manager):
             msg = "{} exited with status code {}".format(config.name, exit_code)
             if exception:
                 msg += " and message:\n\n---\n{}\n---".format(str(exception))
-            msg += "".join(("\n\nDo you want to restart {0}?\n\nIf you choose Cancel, {0} will be disabled for this ",
-                            "project. You can re-enable {0} manually using the Command Palette.")).format(config.name)
+            msg += "".join((
+                "\n\nDo you want to restart {0}?\n\nIf you choose Cancel, {0} will be disabled for this project. ",
+                "Enable {0} again by running LSP: Enable Language Server In Project from the Command Palette."
+            )).format(config.name)
             if sublime.ok_cancel_dialog(msg, "Restart {}".format(config.name)):
                 for listener in self._listeners:
                     self.register_listener_async(listener)


### PR DESCRIPTION
Putting a configuration into a temporarily disabled state has the major drawback that you can't enable it anymore, unless you close the window and re-open the window.

Instead, disable a failing config via the settings machinery. This way you can enable it again by clicking on Tools > LSP > Enable Language Server In Project.