### PR TITLE
feat(code actions): display code actions within a quick panel 

### DIFF
--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -302,9 +302,14 @@ class LspCodeActionsCommand(LspTextCommand):
 
     def show_popup_menu(self) -> None:
         if len(self.commands) > 0:
-            self.view.window().show_quick_panel([command[1] for command in self.commands], 
-                    self.handle_select, 
-                    placeholder="Code action")
+            items = [command[1] for command in self.commands]
+            win = self.view.window()
+            if win:
+                win.show_quick_panel(items, 
+                        self.handle_select, 
+                        placeholder="Code action")
+            else:
+                self.view.show_popup_menu(items, self.handle_select)
         else:
             self.view.show_popup('No actions available', sublime.HIDE_ON_MOUSE_MOVE_AWAY)
 

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -306,8 +306,6 @@ class LspCodeActionsCommand(LspTextCommand):
             window = self.view.window()
             if window:
                 window.show_quick_panel(items, self.handle_select, placeholder="Code action")
-            else:
-                self.view.show_popup_menu(items, self.handle_select)
         else:
             self.view.show_popup('No actions available', sublime.HIDE_ON_MOUSE_MOVE_AWAY)
 

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -302,7 +302,9 @@ class LspCodeActionsCommand(LspTextCommand):
 
     def show_popup_menu(self) -> None:
         if len(self.commands) > 0:
-            self.view.show_popup_menu([command[1] for command in self.commands], self.handle_select)
+            self.view.window().show_quick_panel([command[1] for command in self.commands], 
+                    self.handle_select, 
+                    placeholder="Code action")
         else:
             self.view.show_popup('No actions available', sublime.HIDE_ON_MOUSE_MOVE_AWAY)
 

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -305,9 +305,7 @@ class LspCodeActionsCommand(LspTextCommand):
             items = [command[1] for command in self.commands]
             win = self.view.window()
             if win:
-                win.show_quick_panel(items, 
-                        self.handle_select, 
-                        placeholder="Code action")
+                win.show_quick_panel(items, self.handle_select, placeholder="Code action")
             else:
                 self.view.show_popup_menu(items, self.handle_select)
         else:

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -291,7 +291,7 @@ class LspCodeActionsCommand(LspTextCommand):
     def handle_responses_async(self, responses: CodeActionsByConfigName) -> None:
         self.commands_by_config = responses
         self.commands = self.combine_commands()
-        self.show_popup_menu()
+        self.show_code_actions()
 
     def combine_commands(self) -> 'List[Tuple[str, str, CodeActionOrCommand]]':
         results = []
@@ -300,12 +300,12 @@ class LspCodeActionsCommand(LspTextCommand):
                 results.append((config, command['title'], command))
         return results
 
-    def show_popup_menu(self) -> None:
+    def show_code_actions(self) -> None:
         if len(self.commands) > 0:
             items = [command[1] for command in self.commands]
-            win = self.view.window()
-            if win:
-                win.show_quick_panel(items, self.handle_select, placeholder="Code action")
+            window = self.view.window()
+            if window:
+                window.show_quick_panel(items, self.handle_select, placeholder="Code action")
             else:
                 self.view.show_popup_menu(items, self.handle_select)
         else:

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -182,7 +182,12 @@ class LspHoverCommand(LspTextCommand):
             _, config_name = href.split(":")
             titles = [command["title"] for command in self._actions_by_config[config_name]]
             self.view.run_command("lsp_selection_set", {"regions": [(point, point)]})
-            self.view.show_popup_menu(titles, lambda i: self.handle_code_action_select(config_name, i))
+            window = self.view.window()
+            if window:
+                window.show_quick_panel(titles, lambda i: self.handle_code_action_select(config_name, i),
+                                        placeholder="Code actions")
+            else:
+                self.view.show_popup_menu(titles, lambda i: self.handle_code_action_select(config_name, i))
         elif href.startswith("location:"):
             window = self.view.window()
             if window:

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -186,8 +186,6 @@ class LspHoverCommand(LspTextCommand):
             if window:
                 window.show_quick_panel(titles, lambda i: self.handle_code_action_select(config_name, i),
                                         placeholder="Code actions")
-            else:
-                self.view.show_popup_menu(titles, lambda i: self.handle_code_action_select(config_name, i))
         elif href.startswith("location:"):
             window = self.view.window()
             if window:


### PR DESCRIPTION
Display the code action in a quick panel instead of the context menu, this makes us able to use more keybindings to control which code action we want to use.
With the context menu you're only able to select an item with `up/down arrows` or the mouse, with a quick panel you can add custom keybindings and also use the search feature of the quick panel.

![](https://i.imgur.com/UZa6C2Y.png)