### PR TITLE
Remove "log_stderr" in favor of always logging errors to the log panel

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -127,11 +127,6 @@
     // "remote",
   ],
 
-  // Show language server stderr output in the Language Servers output panel.
-  // This output panel can be toggled from the command palette with the
-  // command "LSP: Toggle Log Panel".
-  "log_stderr": false,
-
   // When logging to the "panel" (see "log_server"), if the params of the request or
   // response or notification exceed this many characters, then print a <snip> to
   // the panel instead. If you don't want a limit, set this to zero.

--- a/docs/src/features.md
+++ b/docs/src/features.md
@@ -187,7 +187,6 @@ Add these settings to LSP settings, your Sublime settings, Syntax-specific setti
 * `disabled_capabilities`, `[]` *Turn off client capabilities (features): "hover", "completion", "documentHighlight", "colorProvider", "signatureHelp", "codeLensProvider", "codeActionProvider"*
 * `log_debug` `false` *show debug logging in the sublime console*
 * `log_server` `[]` *log communication from and to language servers*
-* `log_stderr` `false` *show language server stderr output in the console*
 * `log_max_size` `8192` *max  number of characters of payloads to print*
 
 ### Color configurations

--- a/docs/src/guides/client_configuration.md
+++ b/docs/src/guides/client_configuration.md
@@ -12,7 +12,7 @@ Here is an example of the `LSP.sublime-settings` file with configurations for th
 ```js
 {
   // General settings
-  "log_debug": true,
+  "show_diagnostics_panel_on_save": 0,
 
   // Language server configurations
   "clients": {
@@ -31,7 +31,7 @@ Some language servers support multiple languages, which can be specified in the 
 ```js
 {
   // General settings
-  "log_debug": true,
+  "show_diagnostics_panel_on_save": 0,
 
   // Language server configurations
   "clients": {

--- a/docs/src/guides/client_configuration.md
+++ b/docs/src/guides/client_configuration.md
@@ -12,7 +12,7 @@ Here is an example of the `LSP.sublime-settings` file with configurations for th
 ```js
 {
   // General settings
-  "log_stderr": true,
+  "log_debug": true,
 
   // Language server configurations
   "clients": {
@@ -31,7 +31,7 @@ Some language servers support multiple languages, which can be specified in the 
 ```js
 {
   // General settings
-  "log_stderr": true,
+  "log_debug": true,
 
   // Language server configurations
   "clients": {

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -1,7 +1,7 @@
 ## Self-help instructions
 
 Enable LSP logging: In LSP Settings enable the `log_debug` setting.
-Enable server logging: set `log_server` to ["panel"] and `log_stderr` to `true`
+Enable server logging: set `log_server` to ["panel"]
 Run "LSP: Toggle Log Panel" from the command palette. No restart is needed.
 If you believe the issue is with this package, please include the output from the Sublime console in your issue report!
 

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -161,7 +161,6 @@ class Settings:
     log_debug = None  # type: bool
     log_max_size = None  # type: int
     log_server = None  # type: List[str]
-    log_stderr = None  # type: bool
     lsp_code_actions_on_save = None  # type: Dict[str, bool]
     lsp_format_on_save = None  # type: bool
     only_show_lsp_completions = None  # type: bool
@@ -194,7 +193,6 @@ class Settings:
         r("log_debug", False)
         r("log_max_size", 8 * 1024)
         # r("log_server", [])
-        r("log_stderr", False)
         r("lsp_code_actions_on_save", {})
         r("lsp_format_on_save", False)
         r("only_show_lsp_completions", False)

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -447,8 +447,7 @@ class WindowManager(Manager):
         self.handle_server_message(session.config.name, extract_message(params))
 
     def handle_stderr_log(self, session: Session, message: str) -> None:
-        if userprefs().log_stderr:
-            self.handle_server_message(session.config.name, message)
+        self.handle_server_message(session.config.name, message)
 
     def handle_show_message(self, session: Session, params: Any) -> None:
         sublime.status_message("{}: {}".format(session.config.name, extract_message(params)))

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -336,11 +336,6 @@
               ],
               "markdownDescription": "Log communication from and to language servers. Possible flags:\n\n- `\"panel\"`: log to the LSP Language Servers output panel\n- `\"remote\"`: start a local websocket server on port 9981. Can be connected to with a websocket client to receive the log messages in real time.\n\nFor backward-compatibility, when set to `true`, enables the `\"panel\"` logger and when set to `false` disables logging. This output panel can be toggled from the command palette with the command **LSP: Toggle Log Panel**."
             },
-            "log_stderr": {
-              "type": "boolean",
-              "default": false,
-              "markdownDescription": "Show language server stderr output in the Language Servers output panel. This output panel can be toggled from the command palette with the command \"LSP: Toggle Log Panel\"."
-            },
             "log_max_size": {
               "type": "integer",
               "default": 8192,


### PR DESCRIPTION
Remove `log_stderr` in favor of always logging errors to the log panel.