### PR TITLE
Make scopes in output panels consistent with Find results panel

### DIFF
--- a/Syntaxes/Diagnostics.sublime-syntax
+++ b/Syntaxes/Diagnostics.sublime-syntax
@@ -16,7 +16,7 @@ contexts:
     - match: ^(?!\s*\d+:\d+)(.*)(:)$
       captures:
         0: meta.diagnostic.preamble.lsp
-        1: string.unquoted.lsp
+        1: entity.name.filename.lsp
         2: punctuation.separator.lsp
 
   line:
@@ -68,9 +68,9 @@ contexts:
     - include: pop-at-end
     - match: (\d+)(:)(\d+)
       captures:
-        1: constant.numeric.integer.decimal.lsp
+        1: constant.numeric.line-number.lsp
         2: punctuation.separator.lsp
-        3: constant.numeric.integer.decimal.lsp
+        3: constant.numeric.col-number.lsp
       pop: true
 
   pop-at-end:

--- a/Syntaxes/Diagnostics.sublime-syntax
+++ b/Syntaxes/Diagnostics.sublime-syntax
@@ -68,9 +68,9 @@ contexts:
     - include: pop-at-end
     - match: (\d+)(:)(\d+)
       captures:
-        1: constant.numeric.line-number.lsp
+        1: meta.number.integer.decimal.lsp constant.numeric.line-number.lsp
         2: punctuation.separator.lsp
-        3: constant.numeric.col-number.lsp
+        3: meta.number.integer.decimal.lsp constant.numeric.col-number.lsp
       pop: true
 
   pop-at-end:

--- a/Syntaxes/References.sublime-syntax
+++ b/Syntaxes/References.sublime-syntax
@@ -43,9 +43,9 @@ contexts:
     - include: pop-at-end
     - match: (\d+)(?:(:)(\d+))?
       captures:
-        1: constant.numeric.line-number.lsp
+        1: meta.number.integer.decimal.lsp constant.numeric.line-number.lsp
         2: punctuation.separator.lsp
-        3: constant.numeric.col-number.lsp
+        3: meta.number.integer.decimal.lsp constant.numeric.col-number.lsp
       pop: true
 
   pop-at-end:

--- a/Syntaxes/References.sublime-syntax
+++ b/Syntaxes/References.sublime-syntax
@@ -18,7 +18,7 @@ contexts:
     - match: '{{filename_and_colon}}'
       captures:
         0: meta.reference.preamble.lsp
-        1: string.unquoted.lsp entity.name.file.references.lsp
+        1: entity.name.filename.lsp
         2: punctuation.separator.lsp
 
   references-body:
@@ -27,7 +27,7 @@ contexts:
         - ensure-reference-meta-scope
         - code
         - expect-line-maybe-column
-      
+
   code:
     - match: '(?=\S)'
       set:
@@ -43,9 +43,9 @@ contexts:
     - include: pop-at-end
     - match: (\d+)(?:(:)(\d+))?
       captures:
-        1: constant.numeric.integer.decimal.lsp
+        1: constant.numeric.line-number.lsp
         2: punctuation.separator.lsp
-        3: constant.numeric.integer.decimal.lsp
+        3: constant.numeric.col-number.lsp
       pop: true
 
   pop-at-end:


### PR DESCRIPTION
Some small tweaks for the scopes used in the diagnostics and references (rename) panels:

* `entity.name.filename` for the filenames (already used in Find in
  Files results panel and by SublimeLinter)
* `constant.numeric.line-number` for line numbers (already used in Find
  in Files results panel and by SublimeLinter)
* `constant.numeric.col-number` for column numbers (already used by
  SublimeLinter and seems to be a suitable scope name)

*Note*: this will change the color in Mariana for filenames in the diagnostics panel form green (string) to orange (entity.name), which may look a little bit worse than before, but I think it's more desirable to have a consistent style over different panels and with the built-in Find Results panel. And the Monokai scheme has a rule for `entity.name.filename`, so we should use that scope here as well. We could maybe keep the `string.unquoted` in front as a fallback, but since `entity.name` is within the minimal scope coverage for color schemes and all default schemes address it, I don't think that scope is of much use and therefore removed it.