### PR TITLE
Fix null session completions

### DIFF
--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -639,9 +639,13 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
     # --- textDocument/complete ----------------------------------------------------------------------------------------
 
     def _on_query_completions_async(self, resolve_completion_list: ResolveCompletionsFn, location: int) -> None:
+        sessions = list(self.sessions('completionProvider'))
+        if not sessions:
+            resolve_completion_list([], 0)
+            return
         self.purge_changes_async()
         completion_promises = []  # type: List[Promise[ResolvedCompletions]]
-        for session in self.sessions('completionProvider'):
+        for session in sessions:
 
             def completion_request() -> Promise[ResolvedCompletions]:
                 return session.send_request_task(
@@ -649,10 +653,6 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
                 ).then(lambda response: (response, session.config.name))
 
             completion_promises.append(completion_request())
-
-        if not completion_promises:
-            resolve_completion_list([], 0)
-            return
 
         Promise.all(completion_promises).then(
             lambda responses: self._on_all_settled(responses, resolve_completion_list))


### PR DESCRIPTION
Fixes #1622

The `sessions()` method returns a generator object, which causes the query for `if not sessions` to always return false. As a result the whole promise machinery is running even if no session is available.

This commit therefore queries `completion_promises` instead, to shorten the route in case of no sessions being available.