### PR TITLE
Add Find References to commands list

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -82,5 +82,9 @@
     {
         "caption": "LSP: Rename",
         "command": "lsp_symbol_rename"
+    },
+    {
+        "caption": "LSP: Find References",
+        "command": "lsp_symbol_references"
     }
 ]


### PR DESCRIPTION
Hello, thank you for your work on LSP.

I noticed "Find references" was in the context menu but not in the commands list so I thought I would add it.

Seems to work on my Mac OS X using ST4 build 4099:

<img width="800" alt="Screenshot 2021-04-02 at 12 54 08" src="https://user-images.githubusercontent.com/6739793/113413400-859c3200-93b2-11eb-9a72-8cb38e459342.png">

