### PR TITLE
Update server log panel only when it's opened

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -21,6 +21,7 @@ from .plugin.core.panels import destroy_output_panels
 from .plugin.core.panels import LspClearPanelCommand
 from .plugin.core.panels import LspUpdatePanelCommand
 from .plugin.core.panels import LspUpdateServerPanelCommand
+from .plugin.core.panels import WindowPanelListener
 from .plugin.core.protocol import Response
 from .plugin.core.protocol import WorkspaceFolder
 from .plugin.core.registry import LspRecheckSessionsCommand

--- a/plugin/core/panels.py
+++ b/plugin/core/panels.py
@@ -1,5 +1,4 @@
 from .typing import Dict, Optional, List, Generator, Tuple
-from .types import debounced
 from contextlib import contextmanager
 import sublime
 import sublime_plugin
@@ -7,9 +6,6 @@ import sublime_plugin
 
 # about 80 chars per line implies maintaining a buffer of about 40kb per window
 SERVER_PANEL_MAX_LINES = 500
-
-# If nothing else shows up after 80ms, actually print the messages to the panel
-SERVER_PANEL_DEBOUNCE_TIME_MS = 80
 
 OUTPUT_PANEL_SETTINGS = {
     "auto_indent": False,
@@ -44,6 +40,31 @@ def mutable(view: sublime.View) -> Generator:
     view.set_read_only(False)
     yield
     view.set_read_only(True)
+
+
+class WindowPanelListener(sublime_plugin.EventListener):
+
+    server_log_map = {}  # type: Dict[int, List[Tuple[str, str]]]
+
+    def on_init(self, views) -> None:
+        for window in sublime.windows():
+            self.server_log_map[window.id()] = []
+
+    def on_new_window(self, window: sublime.Window) -> None:
+        self.server_log_map[window.id()] = []
+
+    def on_pre_close_window(self, window: sublime.Window) -> None:
+        self.server_log_map.pop(window.id())
+
+    def on_window_command(self, window, command_name, args) -> None:
+        if command_name in ('show_panel', 'hide_panel'):
+            sublime.set_timeout(lambda: self.maybe_update_server_panel(window))
+
+    def maybe_update_server_panel(self, window: sublime.Window) -> None:
+        if is_server_panel_open(window):
+            panel = ensure_server_panel(window)
+            if panel:
+                update_server_panel(panel, window.id())
 
 
 def create_output_panel(window: sublime.Window, name: str) -> Optional[sublime.View]:
@@ -118,44 +139,30 @@ def ensure_server_panel(window: sublime.Window) -> Optional[sublime.View]:
     return ensure_panel(window, PanelName.LanguageServers, "", "", "Packages/LSP/Syntaxes/ServerLog.sublime-syntax")
 
 
-def update_server_panel(window: sublime.Window, prefix: str, message: str) -> None:
+def is_server_panel_open(window: sublime.Window) -> bool:
+    return window.is_valid() and window.active_panel() == "output.{}".format(PanelName.LanguageServers)
+
+
+def log_server_message(window: sublime.Window, prefix: str, message: str) -> None:
     if not window.is_valid():
         return
     window_id = window.id()
-    panel = ensure_server_panel(window)
-    if not panel:
-        return
-    LspUpdateServerPanelCommand.to_be_processed.setdefault(window_id, []).append((prefix, message))
-    previous_length = len(LspUpdateServerPanelCommand.to_be_processed[window_id])
+    WindowPanelListener.server_log_map[window_id].append((prefix, message))
+    if is_server_panel_open(window):
+        panel = ensure_server_panel(window)
+        if panel:
+            update_server_panel(panel, window_id)
 
-    def condition() -> bool:
-        if not panel:
-            return False
-        if not panel.is_valid():
-            return False
-        to_process = LspUpdateServerPanelCommand.to_be_processed.get(window_id)
-        if to_process is None:
-            return False
-        current_length = len(to_process)
-        if current_length >= 10:
-            # Do not let the queue grow large.
-            return True
-        # If the queue remains stable, flush the messages.
-        return current_length == previous_length
 
-    debounced(
-        lambda: panel.run_command("lsp_update_server_panel", {"window_id": window_id}) if panel else None,
-        SERVER_PANEL_DEBOUNCE_TIME_MS,
-        condition
-    )
+def update_server_panel(panel: sublime.View, window_id: int) -> None:
+    panel.run_command("lsp_update_server_panel", {"window_id": window_id}),
 
 
 class LspUpdateServerPanelCommand(sublime_plugin.TextCommand):
 
-    to_be_processed = {}  # type: Dict[int, List[Tuple[str, str]]]
-
     def run(self, edit: sublime.Edit, window_id: int) -> None:
-        to_process = self.to_be_processed.pop(window_id)
+        to_process = WindowPanelListener.server_log_map.get(window_id)
+        WindowPanelListener.server_log_map[window_id] = []
         with mutable(self.view):
             for prefix, message in to_process:
                 message = message.replace("\r\n", "\n")  # normalize Windows eol

--- a/plugin/core/panels.py
+++ b/plugin/core/panels.py
@@ -46,7 +46,7 @@ class WindowPanelListener(sublime_plugin.EventListener):
 
     server_log_map = {}  # type: Dict[int, List[Tuple[str, str]]]
 
-    def on_init(self, views) -> None:
+    def on_init(self, views: List[sublime.View]) -> None:
         for window in sublime.windows():
             self.server_log_map[window.id()] = []
 
@@ -56,7 +56,7 @@ class WindowPanelListener(sublime_plugin.EventListener):
     def on_pre_close_window(self, window: sublime.Window) -> None:
         self.server_log_map.pop(window.id())
 
-    def on_window_command(self, window, command_name, args) -> None:
+    def on_window_command(self, window: sublime.Window, command_name: str, args: Dict) -> None:
         if command_name in ('show_panel', 'hide_panel'):
             sublime.set_timeout(lambda: self.maybe_update_server_panel(window))
 
@@ -155,13 +155,13 @@ def log_server_message(window: sublime.Window, prefix: str, message: str) -> Non
 
 
 def update_server_panel(panel: sublime.View, window_id: int) -> None:
-    panel.run_command("lsp_update_server_panel", {"window_id": window_id}),
+    panel.run_command("lsp_update_server_panel", {"window_id": window_id})
 
 
 class LspUpdateServerPanelCommand(sublime_plugin.TextCommand):
 
     def run(self, edit: sublime.Edit, window_id: int) -> None:
-        to_process = WindowPanelListener.server_log_map.get(window_id)
+        to_process = WindowPanelListener.server_log_map.get(window_id) or []
         WindowPanelListener.server_log_map[window_id] = []
         with mutable(self.view):
             for prefix, message in to_process:

--- a/plugin/core/panels.py
+++ b/plugin/core/panels.py
@@ -148,10 +148,9 @@ def log_server_message(window: sublime.Window, prefix: str, message: str) -> Non
         return
     window_id = window.id()
     WindowPanelListener.server_log_map[window_id].append((prefix, message))
-    if is_server_panel_open(window):
-        panel = ensure_server_panel(window)
-        if panel:
-            update_server_panel(panel, window_id)
+    panel = ensure_server_panel(window)
+    if is_server_panel_open(window) and panel:
+        update_server_panel(panel, window_id)
 
 
 def update_server_panel(panel: sublime.View, window_id: int) -> None:

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -5,7 +5,7 @@ from .diagnostics import ensure_diagnostics_panel
 from .logging import debug
 from .logging import exception_log
 from .message_request_handler import MessageRequestHandler
-from .panels import update_server_panel
+from .panels import log_server_message
 from .protocol import CodeLens, Diagnostic
 from .protocol import Error
 from .sessions import get_plugin
@@ -443,7 +443,7 @@ class WindowManager(Manager):
         self._end_sessions_async()
 
     def handle_server_message(self, server_name: str, message: str) -> None:
-        sublime.set_timeout(lambda: update_server_panel(self._window, server_name, message))
+        sublime.set_timeout(lambda: log_server_message(self._window, server_name, message))
 
     def handle_log_message(self, session: Session, params: Any) -> None:
         self.handle_server_message(session.config.name, extract_message(params))

--- a/tests/test_server_panel_circular.py
+++ b/tests/test_server_panel_circular.py
@@ -1,7 +1,6 @@
 from LSP.plugin.core.panels import ensure_server_panel
-from LSP.plugin.core.panels import SERVER_PANEL_DEBOUNCE_TIME_MS
 from LSP.plugin.core.panels import SERVER_PANEL_MAX_LINES
-from LSP.plugin.core.panels import update_server_panel
+from LSP.plugin.core.panels import log_server_message
 from unittesting import DeferrableTestCase
 import sublime
 
@@ -27,7 +26,7 @@ class LspServerPanelTests(DeferrableTestCase):
         self.assertEqual(actual_total_lines, expected_total_lines)
 
     def update_panel(self, msg: str) -> None:
-        update_server_panel(self.window, "test", msg)
+        log_server_message(self.window, "test", msg)
 
     def test_server_panel_circular_behavior(self):
         n = SERVER_PANEL_MAX_LINES
@@ -36,5 +35,4 @@ class LspServerPanelTests(DeferrableTestCase):
         self.update_panel("overflow")
         self.update_panel("overflow")
         self.update_panel("one\ntwo\nthree")
-        yield SERVER_PANEL_DEBOUNCE_TIME_MS
         self.assert_total_lines_equal(n)


### PR DESCRIPTION
Avoid inserting text and parsing the syntax when the panel is closed
which can be expensive if there is a lot of output.

The debouncing logic is removed as there should be no need to delay
anything when the panel is opened.

Fixes #1626