### PR TITLE
Add plugin APIs: "on_*_capability" and "on_session_end"

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -594,14 +594,38 @@ class AbstractPlugin(metaclass=ABCMeta):
         pass
 
     def on_register_capability_async(self, registration_id: str, capability_path: str, options: Dict[str, Any]) -> None:
+        """
+        Notifies about server dynamically registering a capability using the client/registerCapability request.
+        This API is triggered on async thread.
+
+        :param registration_id: The registration identifier
+        :param capability_path: The registration capability path
+        :param options: The registration options
+        """
         pass
 
     def on_unregister_capability_async(
         self, registration_id: str, capability_path: str, options: Dict[str, Any]
     ) -> None:
+        """
+        Notifies about server un-registering a capability using the client/unregisterCapability request.
+        This API is triggered on async thread.
+
+        :param registration_id: The registration identifier
+        :param capability_path: The registration capability path
+        :param options: The registration options
+        """
         pass
 
+
     def on_session_end_async(self) -> None:
+        """
+        Notifies about the session ending (also if the session has crashed). Provides an opportunity to clean up
+        any stored state or delete references to the session or plugin instance that would otherwise prevent the
+        instance from being garbage-collected. If the plugin hasn't crashed, a shutdown message will be send immediately
+        after this method returns.
+        This API is triggered on async thread.
+        """
         pass
 
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -617,7 +617,6 @@ class AbstractPlugin(metaclass=ABCMeta):
         """
         pass
 
-
     def on_session_end_async(self) -> None:
         """
         Notifies about the session ending (also if the session has crashed). Provides an opportunity to clean up

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1161,6 +1161,8 @@ class Session(TransportCallbacks):
             capability_path, registration_path = method_to_capability(unregistration["method"])
             debug("{}: unregistering capability:".format(self.config.name), capability_path)
             data = self._registrations.pop(registration_id, None)
+            if data and self._plugin:
+                self._plugin.on_unregister_capability_async(registration_id, capability_path, data.options)
             if data and not data.selector:
                 discarded = self.capabilities.unregister(registration_id, capability_path, registration_path)
                 # We must inform our SessionViews of the removed capabilities, in case it's for instance a hoverProvider
@@ -1168,10 +1170,6 @@ class Session(TransportCallbacks):
                 if isinstance(discarded, dict):
                     for sv in self.session_views_async():
                         sv.on_capability_removed_async(registration_id, discarded)
-            if self._plugin:
-                inform = functools.partial(
-                    self._plugin.on_unregister_capability_async, registration_id, capability_path, registration_path)
-                sublime.set_timeout_async(inform)
         self.send_response(Response(request_id, None))
 
     def m_window_showDocument(self, params: Any, request_id: Any) -> None:


### PR DESCRIPTION
I have a local implementation of `didChangeWatchedFiles` that I need those APIs for.

 - `on_register_capability_async` to be able to handle `workspace.didChangeWatchedFiles` capability that can specify `watchers` to set up.
 - `on_unregister_capability_async` to unregister them
 - `on_session_end_async` to unregister watchers when session ends.

I have implemented `didChangeWatchedFiles` in `lsp_utils` but not sure if I want to upstream it. It depends on `node` and I'm not sure I have finished it (have done it some time ago and just kept using it as it works ;)). With that in mind, I'm fine with the decision not to integrate this API but if it makes sense in general and doesn't hurt then why not.