### PR TITLE
Check if the process has already stopped

### DIFF
--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -119,7 +119,7 @@ class JsonRpcTransport(Transport):
                 exit_code = self._process.wait(1)
             except (AttributeError, ProcessLookupError, subprocess.TimeoutExpired):
                 pass
-        if self._process:
+        if self._process.poll() is not None:
             try:
                 # The process didn't stop itself. Terminate!
                 self._process.kill()


### PR DESCRIPTION
This avoids a redundant try-except.