### PR TITLE
Improve self-help instructions

### DIFF
--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -1,9 +1,17 @@
 ## Self-help instructions
 
-Enable LSP logging: In LSP Settings enable the `log_debug` setting.
-Enable server logging: set `log_server` to ["panel"]
-Run "LSP: Toggle Log Panel" from the command palette. No restart is needed.
+To get more visibility into the inner-workings of the LSP client and the server and be able to diagnose problems, open `Preferences: LSP Settings` from the Command Palette and set the following options:
+
+| Option                  | Description                                                          |
+| ----------------------- | -------------------------------------------------------------------- |
+| `log_debug: true`       | Show verbose debug messages in the Sublime Text console.             |
+| `log_server: ["panel"]` | Log communication from and to language servers in the output panel.  |
+
+Once enabled (no restart necessary), the communication log can be seen by running `LSP: Toggle Log Panel` from the Command Palette. It might be a good idea to restart the Sublime Text and reproduce the issue again, so that the logs are clean.
+
 If you believe the issue is with this package, please include the output from the Sublime console in your issue report!
+
+If the server is crashing on startup, try running `LSP: Troubleshoot server` from the Command Palette and checking the "Server output" for potential errors or eventually also sharing the output of this command in the report.
 
 ## Updating the PATH used by LSP servers
 

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -7,7 +7,7 @@ To get more visibility into the inner-workings of the LSP client and the server 
 | `log_debug: true`       | Show verbose debug messages in the Sublime Text console.             |
 | `log_server: ["panel"]` | Log communication from and to language servers in the output panel.  |
 
-Once enabled (no restart necessary), the communication log can be seen by running `LSP: Toggle Log Panel` from the Command Palette. It might be a good idea to restart the Sublime Text and reproduce the issue again, so that the logs are clean.
+Once enabled (no restart necessary), the communication log can be seen by running `LSP: Toggle Log Panel` from the Command Palette. It might be a good idea to restart Sublime Text and reproduce the issue again, so that the logs are clean.
 
 If you believe the issue is with this package, please include the output from the Sublime console in your issue report!
 

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -11,7 +11,7 @@ Once enabled (no restart necessary), the communication log can be seen by runnin
 
 If you believe the issue is with this package, please include the output from the Sublime console in your issue report!
 
-If the server is crashing on startup, try running `LSP: Troubleshoot server` from the Command Palette and checking the "Server output" for potential errors or eventually also sharing the output of this command in the report.
+If the server is crashing on startup, try running `LSP: Troubleshoot server` from the Command Palette and check the "Server output" for potential errors. Consider sharing the output of this command in the report.
 
 ## Updating the PATH used by LSP servers
 


### PR DESCRIPTION
 - structure the information better
 - mention where and how the logging information can be seen
 - mention "troubleshooting" command