### PR TITLE
Small tweaks for annotations and lightbulb colors

### DIFF
--- a/docs/src/customization.md
+++ b/docs/src/customization.md
@@ -74,8 +74,9 @@ Diagnostics will also optionally include the following scopes:
 | `entity.name.function.sighelp.lsp` | Function name in the signature help popup |
 | `variable.parameter.sighelp.lsp` | Function argument in the signature help popup |
 
-### Code Lens
+### Annotations
 
 | scope | description |
 | ----- | ----------- |
-| `markup.codelens.accent` | Accent color for code lens annotations |
+| `markup.accent.codelens.lsp` | Accent color for code lens annotations |
+| `markup.accent.codeaction.lsp` | Accent color for code action annotations |

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -480,13 +480,13 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         annotations = []
         annotation_color = ""
         if userprefs().show_code_actions == 'bulb':
-            scope = 'markup.changed'
+            scope = 'region.yellowish lightbulb.lsp'
             icon = 'Packages/LSP/icons/lightbulb.png'
         else:  # 'annotation'
             suffix = 's' if action_count > 1 else ''
             code_actions_link = make_command_link('lsp_code_actions', '{} code action{}'.format(action_count, suffix))
             annotations = ["<div class=\"actions\">{}</div>".format(code_actions_link)]
-            annotation_color = '#2196F3'
+            annotation_color = self.view.style_for_scope("region.bluish markup.accent.codeaction.lsp")["foreground"]
         self.view.add_regions(self.CODE_ACTIONS_KEY, regions, scope, icon, flags, annotations, annotation_color)
 
     def _clear_code_actions_annotation(self) -> None:
@@ -526,7 +526,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         else:
             annotation = "..."
         annotation = '<div class="codelens">{}</div>'.format(annotation)
-        accent = self.view.style_for_scope("region.greenish markup.codelens.accent")["foreground"]
+        accent = self.view.style_for_scope("region.greenish markup.accent.codelens.lsp")["foreground"]
         self.view.add_regions(self._code_lens_key(index), [region], "", "", 0, [annotation], accent)
 
     def _do_code_lenses_async(self) -> None:


### PR DESCRIPTION
This are some of the changes from the closed PR #1663 which make color scheme authors (and possibly users) happier. It affects only the colors, so there shouldn't be any unintended side affects like strange bounding box behavior on hover or so.

Short explanation regarding the scopes:
- The `markup.changed` which was previously used for the lightbulb icon is semantically incorrect and could be any color in theory. The scope `lightbulb` (can be used for potential color adjustments) on top of `region.yellowish` isn't probably used in any scheme, but that scope is comparable to the scopes `bookmarks` and `mark` which are used for the gutter icons by the internal "Goto > Bookmarks" and "Edit > Mark" features.
- If anyone used the former `markup.codelens.accent` scope for a color customization, they will need to update it now, but I think the way I've adjusted it here makes more sense. Maybe this is worth a small mention in the next update notes.