### PR TITLE
didChangeWatchedFiles using watchman

### DIFF
--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -382,6 +382,10 @@ class Notification:
         return Notification("workspace/didChangeWorkspaceFolders", params)
 
     @classmethod
+    def didChangeWatchedFiles(cls, params: dict) -> 'Notification':
+        return Notification("workspace/didChangeWatchedFiles", params)
+
+    @classmethod
     def exit(cls) -> 'Notification':
         return Notification("exit")
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -259,7 +259,7 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
                 "dynamicRegistration": True
             },
             "didChangeWatchedFiles": {
-                "dynamicRegistration": True
+                "dynamicRegistration": Watcher.is_available()
             },
             "executeCommand": {},
             "workspaceEdit": {
@@ -1190,6 +1190,8 @@ class Session(TransportCallbacks):
             capability_path, registration_path = method_to_capability(unregistration["method"])
             debug("{}: unregistering capability:".format(self.config.name), capability_path)
             data = self._registrations.pop(registration_id, None)
+            if capability_path == "didChangeWatchedFilesProvider":
+                Watcher.unregister(registration_id)
             if data and self._plugin:
                 self._plugin.on_unregister_capability_async(registration_id, capability_path, data.options)
             if data and not data.selector:

--- a/plugin/core/watcher.py
+++ b/plugin/core/watcher.py
@@ -1,0 +1,97 @@
+import os
+from subprocess import Popen, PIPE, STDOUT
+import subprocess
+import json
+import threading
+import socket
+import time
+from .protocol import Notification
+
+class Watcher:
+
+    def __init__(self, root_path, options, session):
+        self.process = None
+        self.root_path = root_path
+        self.options = options
+        self.session = session
+
+    @classmethod
+    def register(cls, id, options, session):
+        watchers = options["watchers"]
+        root = ""
+        globs = []
+        for watcher in watchers:
+            uri = watcher["globPattern"]
+            file_path = uri.replace("file://", "")
+            globs.append(file_path)
+            if root:
+                root = os.path.commonprefix([root, file_path])
+            else:
+                root = file_path
+        root_path = os.path.dirname(root)
+        print("registering watch for root:" + root_path)
+
+        root_path_prefix_len = len(root_path)+1
+        globmatches = []
+        for glob in globs:
+            if "{" in glob:
+                rel_glob = glob[root_path_prefix_len:]
+
+                open_pos = rel_glob.index("{")
+                close_pos = rel_glob.index("}")
+                options = rel_glob[open_pos+1:close_pos].split(",")
+                print("found OR values", options)
+                for option in options:
+                    globmatches.append(["match", rel_glob[:open_pos] + option + rel_glob[close_pos+1:], "wholename"])
+
+            else:
+                globmatches.append(["match", glob[root_path_prefix_len:], "wholename"])
+
+        globmatches.insert(0, "anyof")
+        options = {
+            'expression': globmatches,
+            'fields': ["name"]
+        }
+        
+        watcher = Watcher(root_path, options, session)
+        thread = threading.Thread(target=watcher.run)
+        thread.start()
+
+    def run(self):
+        print("thread started")
+
+        command = ["watchman", "get-sockname"]
+
+        output = subprocess.check_output(command)
+        output_obj = json.loads(output.decode())
+        print(output.decode())
+        sockname = output_obj["sockname"]
+        print("connecting to", sockname)
+        self.options["since"] = int(time.time())
+        # {"since": int(time.time()), "expression": ["match", "*.sbt"]}
+
+        args = ["subscribe", self.root_path, "subname_lsp", self.options]
+        request = json.dumps(args) + "\n"
+        print(request)
+
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+            s.connect(sockname)
+            print("connected, sending")
+            s.sendall(request.encode())
+            print("sent, receiving")
+            while True:
+                output = s.recv(1024)
+                if not output:
+                    break
+                else:
+                    print(output.decode())
+                    update_obj = json.loads(output.decode())
+                    if "files" in update_obj:
+                        events = []
+                        for file in update_obj["files"]:
+                            full_path = os.path.join(self.root_path, file)
+                            print(full_path)
+                            # type 1,2,3 = created, changed, deleted
+                            events.append({"uri": "file://" + full_path, "type": 2})
+
+                        self.session.send_notification(Notification.didChangeWatchedFiles({"changes": events}))

--- a/plugin/core/watcher.py
+++ b/plugin/core/watcher.py
@@ -1,97 +1,183 @@
 import os
-from subprocess import Popen, PIPE, STDOUT
 import subprocess
 import json
 import threading
 import socket
 import time
+# import shutils
 from .protocol import Notification
+from .url import filename_to_uri, uri_to_filename
+from .logging import debug
+
+
+def process_watchers(lsp_watchers):
+    root = ""
+    globs = []
+    for watcher in lsp_watchers:
+        uri = watcher["globPattern"]
+        file_path = uri_to_filename(uri)
+        globs.append(file_path)
+        if root:
+            root = os.path.commonprefix([root, file_path])
+        else:
+            root = file_path
+    root_path = os.path.dirname(root)
+    return globs, root_path
+
+def build_glob_matches(root_path, globs):
+    root_path_prefix_len = len(root_path)+1
+    globmatches = []
+    for glob in globs:
+        if "{" in glob:
+            rel_glob = glob[root_path_prefix_len:]
+
+            open_pos = rel_glob.index("{")
+            close_pos = rel_glob.index("}")
+            options = rel_glob[open_pos+1:close_pos].split(",")
+            debug("found OR values", options)
+            for option in options:
+                globmatches.append(["match", rel_glob[:open_pos] + option + rel_glob[close_pos+1:], "wholename"])
+
+        else:
+            globmatches.append(["match", glob[root_path_prefix_len:], "wholename"])
+    return globmatches
+
+
+def make_watch(registration_options):
+    globs, root_path = process_watchers(registration_options["watchers"])   
+    debug("registering watch for root:" + root_path)
+
+    globmatches = build_glob_matches(root_path, globs)
+    globmatches.insert(0, "anyof")
+    subscribe_options = {
+        'expression': globmatches
+        # 'fields': ["name"]
+    }
+
+    subscribe_options["since"] = int(time.time())
+
+    return root_path, subscribe_options
+
+
+class WatchConfig:
+
+    def __init__(self, registration_id, session, root_path, subscribe_options):
+        self.registration_id = registration_id
+        self.subscription_id = session.config.name + "_" + registration_id
+        self.session = session
+        self.root_path = root_path
+        self.subscribe_options = subscribe_options
+
+
+def make_subscription_request(watch_config):
+    return json.dumps(["subscribe", watch_config.root_path, watch_config.subscription_id, watch_config.subscribe_options]) + "\n"
+
+def make_unsubscribe_request(watch_config):
+    return json.dumps(["unsubscribe", watch_config.root_path, watch_config.subscription_id]) + "\n"
+
 
 class Watcher:
 
-    def __init__(self, root_path, options, session):
-        self.process = None
-        self.root_path = root_path
-        self.options = options
-        self.session = session
+    queued_watches = list()
+    running_watches = dict()
+    kill_watches = list()
+    thread = None
+
+    @classmethod
+    def is_available(cls):
+        return True
+        # return shutils.which("watchman")
+
+    @classmethod
+    def unregister(cls, id):
+        cls.kill_watches.append(cls.running_watches.pop(id))
+
+    @classmethod
+    def unregister_all(cls):
+        for id in cls.running_watches:
+            cls.unregister(id)
+
+    @classmethod
+    def start_watchman(cls):
+        thread = threading.Thread(target=cls.run_watchman_session)
+        thread.start()
+
+    @classmethod
+    def queue_watch(cls, watch):
+        pass
 
     @classmethod
     def register(cls, id, options, session):
-        watchers = options["watchers"]
-        root = ""
-        globs = []
-        for watcher in watchers:
-            uri = watcher["globPattern"]
-            file_path = uri.replace("file://", "")
-            globs.append(file_path)
-            if root:
-                root = os.path.commonprefix([root, file_path])
-            else:
-                root = file_path
-        root_path = os.path.dirname(root)
-        print("registering watch for root:" + root_path)
+        if cls.thread is None:
+            cls.start_watchman()
 
-        root_path_prefix_len = len(root_path)+1
-        globmatches = []
-        for glob in globs:
-            if "{" in glob:
-                rel_glob = glob[root_path_prefix_len:]
+        root_path, subscribe_options = make_watch(options)
+        cls.queued_watches.append(WatchConfig(id, session, root_path, subscribe_options))
+       
+        # watcher = Watcher(root_path, options, session)
+        # push to session.
 
-                open_pos = rel_glob.index("{")
-                close_pos = rel_glob.index("}")
-                options = rel_glob[open_pos+1:close_pos].split(",")
-                print("found OR values", options)
-                for option in options:
-                    globmatches.append(["match", rel_glob[:open_pos] + option + rel_glob[close_pos+1:], "wholename"])
+    @classmethod
+    def run_watchman_session(cls):
 
-            else:
-                globmatches.append(["match", glob[root_path_prefix_len:], "wholename"])
+        def handle_files_update(update_obj):
+            subscription = update_obj["subscription"]
+            watch_config = cls.running_watches[subscription]
 
-        globmatches.insert(0, "anyof")
-        options = {
-            'expression': globmatches,
-            'fields': ["name"]
-        }
-        
-        watcher = Watcher(root_path, options, session)
-        thread = threading.Thread(target=watcher.run)
-        thread.start()
+            events = []
+            for file in update_obj["files"]:
+                full_path = os.path.join(watch_config.root_path, file["name"])
+                debug("watchman notification:", full_path)
+                # type 1,2,3 = created, changed, deleted
+                # todo: completely disregards requested WatchKind
+                change_type = 1
+                if not file["new"]:
+                    change_type = 2 if file["exists"] else 4
+                events.append({"uri": filename_to_uri(full_path), "type": change_type})
 
-    def run(self):
-        print("thread started")
+            watch_config.session.send_notification(Notification.didChangeWatchedFiles({"changes": events}))
 
+        debug("watchman thread started")
+
+        # get watchman socket name
         command = ["watchman", "get-sockname"]
-
         output = subprocess.check_output(command)
         output_obj = json.loads(output.decode())
-        print(output.decode())
         sockname = output_obj["sockname"]
-        print("connecting to", sockname)
-        self.options["since"] = int(time.time())
-        # {"since": int(time.time()), "expression": ["match", "*.sbt"]}
 
-        args = ["subscribe", self.root_path, "subname_lsp", self.options]
-        request = json.dumps(args) + "\n"
-        print(request)
-
+        debug("connecting to", sockname)
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
             s.connect(sockname)
-            print("connected, sending")
-            s.sendall(request.encode())
-            print("sent, receiving")
+            debug("connected")
+
             while True:
+                # subscribe
+                if len(cls.queued_watches) > 0:
+                    watch_config = cls.queued_watches.pop()
+                    debug("creating subscription", watch_config.subscription_id, watch_config.root_path)
+                    request = make_subscription_request(watch_config)
+                    debug(request)
+                    s.sendall(request.encode())
+
+                    cls.running_watches[watch_config.subscription_id] = watch_config
+
+                # unsubscribe
+                if len(cls.kill_watches) > 0:
+                    watch_config = cls.kill_watches.pop()
+                    request = make_unsubscribe_request(watch_config)
+                    debug(request)
+                    s.sendall(request.encode())
+
+                # response
+                debug("waiting for response")
                 output = s.recv(1024)
                 if not output:
                     break
                 else:
-                    print(output.decode())
+                    debug("watchman sent ", output.decode())
                     update_obj = json.loads(output.decode())
-                    if "files" in update_obj:
-                        events = []
-                        for file in update_obj["files"]:
-                            full_path = os.path.join(self.root_path, file)
-                            print(full_path)
-                            # type 1,2,3 = created, changed, deleted
-                            events.append({"uri": "file://" + full_path, "type": 2})
 
-                        self.session.send_notification(Notification.didChangeWatchedFiles({"changes": events}))
+                    if "files" in update_obj:
+                        handle_files_update(update_obj)
+
+            debug("watchman thread ended")


### PR DESCRIPTION
This is a proposal for an (interim?) solution for users who want file change notifications to their servers using facebook watchman before a potential API for this arrives in Sublime (so, issue #892)

I know Raoul commented that having a "hard" dependency (or a python package or a binary) would introduce a fair bit of maintenance pain - my thought would be to enable the support if the user opts-in and has watchman on their path for that reason.
It uses a named socket, so it is otherwise similar to TCP communication to language servers.

This was only partially tested using Metals which has a pretty nice set of globs it requests.
It would need quite a bit more testing:
* Windows
* A bunch of servers (javascript/typescript servers are probably important, any other likely heavy users?)
* Ensure watchers and watchman are correctly being removed when sessions, LSP or sublime are shut down.