### PR TITLE
Improve `code action` op

### DIFF
--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -292,11 +292,10 @@ class LspCodeActionsCommand(LspTextCommand):
             actions_manager.request_for_region_async(
                 view, covering, session_buffer_diagnostics, self.handle_responses_async, dict_kinds)
 
-    def handle_responses_async(self, responses: CodeActionsByConfigName,
-                               has_commands_by_config: bool = False) -> None:
+    def handle_responses_async(self, responses: CodeActionsByConfigName, has_actions: bool = False) -> None:
         self.commands_by_config = responses
         self.commands = self.combine_commands()
-        if len(self.commands) == 1 and has_commands_by_config:
+        if len(self.commands) == 1 and has_actions:
             self.handle_select(0)
         else:
             self.show_code_actions()

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -274,7 +274,7 @@ class LspCodeActionsCommand(LspTextCommand):
     capability = 'codeActionProvider'
 
     def run(self, edit: sublime.Edit, event: Optional[dict] = None,
-            only_kinds: Optional[List[str]] = None, commands_by_config: CodeActionsByConfigName = None) -> None:
+            only_kinds: Optional[List[str]] = None, commands_by_config: Optional[CodeActionsByConfigName] = None) -> None:
         self.commands = []  # type: List[Tuple[str, str, CodeActionOrCommand]]
         self.commands_by_config = {}  # type: CodeActionsByConfigName
         if commands_by_config:
@@ -292,10 +292,10 @@ class LspCodeActionsCommand(LspTextCommand):
             actions_manager.request_for_region_async(
                 view, covering, session_buffer_diagnostics, self.handle_responses_async, dict_kinds)
 
-    def handle_responses_async(self, responses: CodeActionsByConfigName, has_actions: bool = False) -> None:
+    def handle_responses_async(self, responses: CodeActionsByConfigName, run_first: bool = False) -> None:
         self.commands_by_config = responses
         self.commands = self.combine_commands()
-        if len(self.commands) == 1 and has_actions:
+        if len(self.commands) == 1 and run_first:
             self.handle_select(0)
         else:
             self.show_code_actions()

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -283,7 +283,7 @@ class LspCodeActionsCommand(LspTextCommand):
         self.commands = []  # type: List[Tuple[str, str, CodeActionOrCommand]]
         self.commands_by_config = {}  # type: CodeActionsByConfigName
         if commands_by_config:
-            self.handle_responses_async(commands_by_config, True)
+            self.handle_responses_async(commands_by_config, run_first=True)
         else:
             view = self.view
             region = first_selection_region(view)

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -278,7 +278,7 @@ class LspCodeActionsCommand(LspTextCommand):
         self.commands = []  # type: List[Tuple[str, str, CodeActionOrCommand]]
         self.commands_by_config = {}  # type: CodeActionsByConfigName
         self.has_commands_by_config = False
-        if commands_by_config not None:
+        if commands_by_config:
             self.has_commands_by_config = True
             self.handle_responses_async(commands_by_config)
         else:

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -278,8 +278,7 @@ class LspCodeActionsCommand(LspTextCommand):
         self.commands = []  # type: List[Tuple[str, str, CodeActionOrCommand]]
         self.commands_by_config = {}  # type: CodeActionsByConfigName
         if commands_by_config:
-            self.commands_by_config = commands_by_config
-            self.handle_responses_async()
+            self.handle_responses_async(commands_by_config, True)
         else:
             view = self.view
             region = first_selection_region(view)
@@ -293,11 +292,11 @@ class LspCodeActionsCommand(LspTextCommand):
             actions_manager.request_for_region_async(
                 view, covering, session_buffer_diagnostics, self.handle_responses_async, dict_kinds)
 
-    def handle_responses_async(self, responses: CodeActionsByConfigName = None) -> None:
-        if responses:
-            self.commands_by_config = responses
+    def handle_responses_async(self, responses: CodeActionsByConfigName,
+                               has_commands_by_config: bool = False) -> None:
+        self.commands_by_config = responses
         self.commands = self.combine_commands()
-        if len(self.commands) == 1 and responses is None:
+        if len(self.commands) == 1 and has_commands_by_config:
             self.handle_select(0)
         else:
             self.show_code_actions()

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -273,8 +273,13 @@ class LspCodeActionsCommand(LspTextCommand):
 
     capability = 'codeActionProvider'
 
-    def run(self, edit: sublime.Edit, event: Optional[dict] = None,
-            only_kinds: Optional[List[str]] = None, commands_by_config: Optional[CodeActionsByConfigName] = None) -> None:
+    def run(
+        self,
+        edit: sublime.Edit,
+        event: Optional[dict] = None,
+        only_kinds: Optional[List[str]] = None,
+        commands_by_config: Optional[CodeActionsByConfigName] = None
+    ) -> None:
         self.commands = []  # type: List[Tuple[str, str, CodeActionOrCommand]]
         self.commands_by_config = {}  # type: CodeActionsByConfigName
         if commands_by_config:

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -277,10 +277,9 @@ class LspCodeActionsCommand(LspTextCommand):
             only_kinds: Optional[List[str]] = None, commands_by_config: CodeActionsByConfigName = None) -> None:
         self.commands = []  # type: List[Tuple[str, str, CodeActionOrCommand]]
         self.commands_by_config = {}  # type: CodeActionsByConfigName
-        self.has_commands_by_config = False
         if commands_by_config:
-            self.has_commands_by_config = True
-            self.handle_responses_async(commands_by_config)
+            self.commands_by_config = commands_by_config
+            self.handle_responses_async()
         else:
             view = self.view
             region = first_selection_region(view)
@@ -294,10 +293,11 @@ class LspCodeActionsCommand(LspTextCommand):
             actions_manager.request_for_region_async(
                 view, covering, session_buffer_diagnostics, self.handle_responses_async, dict_kinds)
 
-    def handle_responses_async(self, responses: CodeActionsByConfigName) -> None:
-        self.commands_by_config = responses
+    def handle_responses_async(self, responses: CodeActionsByConfigName = None) -> None:
+        if responses:
+            self.commands_by_config = responses
         self.commands = self.combine_commands()
-        if len(self.commands) == 1 and self.has_commands_by_config:
+        if len(self.commands) == 1 and responses is None:
             self.handle_select(0)
         else:
             self.show_code_actions()

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -273,25 +273,34 @@ class LspCodeActionsCommand(LspTextCommand):
 
     capability = 'codeActionProvider'
 
-    def run(self, edit: sublime.Edit, event: Optional[dict] = None, only_kinds: Optional[List[str]] = None) -> None:
+    def run(self, edit: sublime.Edit, event: Optional[dict] = None,
+            only_kinds: Optional[List[str]] = None, commands_by_config: CodeActionsByConfigName = None) -> None:
         self.commands = []  # type: List[Tuple[str, str, CodeActionOrCommand]]
         self.commands_by_config = {}  # type: CodeActionsByConfigName
-        view = self.view
-        region = first_selection_region(view)
-        if region is None:
-            return
-        listener = windows.listener_for_view(view)
-        if not listener:
-            return
-        session_buffer_diagnostics, covering = listener.diagnostics_intersecting_async(region)
-        dict_kinds = {kind: True for kind in only_kinds} if only_kinds else None
-        actions_manager.request_for_region_async(
-            view, covering, session_buffer_diagnostics, self.handle_responses_async, dict_kinds)
+        self.has_commands_by_config = False
+        if commands_by_config not None:
+            self.has_commands_by_config = True
+            self.handle_responses_async(commands_by_config)
+        else:
+            view = self.view
+            region = first_selection_region(view)
+            if region is None:
+                return
+            listener = windows.listener_for_view(view)
+            if not listener:
+                return
+            session_buffer_diagnostics, covering = listener.diagnostics_intersecting_async(region)
+            dict_kinds = {kind: True for kind in only_kinds} if only_kinds else None
+            actions_manager.request_for_region_async(
+                view, covering, session_buffer_diagnostics, self.handle_responses_async, dict_kinds)
 
     def handle_responses_async(self, responses: CodeActionsByConfigName) -> None:
         self.commands_by_config = responses
         self.commands = self.combine_commands()
-        self.show_code_actions()
+        if len(self.commands) == 1 and self.has_commands_by_config:
+            self.handle_select(0)
+        else:
+            self.show_code_actions()
 
     def combine_commands(self) -> 'List[Tuple[str, str, CodeActionOrCommand]]':
         results = []

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -486,7 +486,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             if action_count > 1:
                 title = '{} code actions'.format(action_count)
             else:
-                title = next(iter(responses.values()))['title']
+                title = next(iter(responses.values()))[0]['title']
             code_actions_link = make_command_link('lsp_code_actions', title, {
                 "commands_by_config": responses
             })

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -48,6 +48,7 @@ import sublime
 import sublime_plugin
 import webbrowser
 
+
 SUBLIME_WORD_MASK = 515
 
 _kind2name = {

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -486,10 +486,9 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             if action_count > 1:
                 title = '{} code actions'.format(action_count)
             else:
-                command = {}
-                for commands in responses.values():
-                    command = commands[0]
-                title = command.get('title')
+                title = ''
+                for actions in responses.values():
+                    title = actions[0].get('title')
 
             code_actions_link = make_command_link('lsp_code_actions', title, {
                 "commands_by_config": responses

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -488,8 +488,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             else:
                 title = ''
                 for actions in responses.values():
-                    title = actions[0].get('title')
-
+                    title = actions[0].get('title', 'code action')
             code_actions_link = make_command_link('lsp_code_actions', title, {
                 "commands_by_config": responses
             })

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -483,8 +483,17 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             scope = 'region.yellowish lightbulb.lsp'
             icon = 'Packages/LSP/icons/lightbulb.png'
         else:  # 'annotation'
-            suffix = 's' if action_count > 1 else ''
-            code_actions_link = make_command_link('lsp_code_actions', '{} code action{}'.format(action_count, suffix))
+            if action_count > 1:
+                code_actions_link = make_command_link('lsp_code_actions', '{} code actions'.format(action_count))
+            else:
+                for name, commands in responses.items():
+                    command = commands[0].get('command')
+                code_actions_link = make_command_link('lsp_execute', commands[0].get('title'), {
+                    "session_name": name,
+                    "command_name": command.get('command'),
+                    "command_args": command.get('arguments')
+                })
+
             annotations = ["<div class=\"actions\">{}</div>".format(code_actions_link)]
             annotation_color = self.view.style_for_scope("region.bluish markup.accent.codeaction.lsp")["foreground"]
         self.view.add_regions(self.CODE_ACTIONS_KEY, regions, scope, icon, flags, annotations, annotation_color)

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -43,10 +43,10 @@ from functools import partial
 from weakref import WeakSet
 from weakref import WeakValueDictionary
 import functools
+import itertools
 import sublime
 import sublime_plugin
 import webbrowser
-import itertools
 
 SUBLIME_WORD_MASK = 515
 
@@ -487,9 +487,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
                 title = '{} code actions'.format(action_count)
             else:
                 title = next(itertools.chain.from_iterable(responses.values()))['title']
-            code_actions_link = make_command_link('lsp_code_actions', title, {
-                "commands_by_config": responses
-            })
+            code_actions_link = make_command_link('lsp_code_actions', title, {"commands_by_config": responses})
             annotations = ["<div class=\"actions\">{}</div>".format(code_actions_link)]
             annotation_color = self.view.style_for_scope("region.bluish markup.accent.codeaction.lsp")["foreground"]
         self.view.add_regions(self.CODE_ACTIONS_KEY, regions, scope, icon, flags, annotations, annotation_color)

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -486,9 +486,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             if action_count > 1:
                 title = '{} code actions'.format(action_count)
             else:
-                title = ''
-                for actions in responses.values():
-                    title = actions[0].get('title', 'code action')
+                title = next(iter(responses.values()))['title']
             code_actions_link = make_command_link('lsp_code_actions', title, {
                 "commands_by_config": responses
             })

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -484,16 +484,16 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             icon = 'Packages/LSP/icons/lightbulb.png'
         else:  # 'annotation'
             if action_count > 1:
-                code_actions_link = make_command_link('lsp_code_actions', '{} code actions'.format(action_count))
+                title = '{} code actions'.format(action_count)
             else:
-                for name, commands in responses.items():
-                    command = commands[0].get('command')
-                code_actions_link = make_command_link('lsp_execute', commands[0].get('title'), {
-                    "session_name": name,
-                    "command_name": command.get('command'),
-                    "command_args": command.get('arguments')
-                })
+                command = {}
+                for commands in responses.values():
+                    command = commands[0]
+                title = command.get('title')
 
+            code_actions_link = make_command_link('lsp_code_actions', title, {
+                "commands_by_config": responses
+            })
             annotations = ["<div class=\"actions\">{}</div>".format(code_actions_link)]
             annotation_color = self.view.style_for_scope("region.bluish markup.accent.codeaction.lsp")["foreground"]
         self.view.add_regions(self.CODE_ACTIONS_KEY, regions, scope, icon, flags, annotations, annotation_color)

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -46,7 +46,7 @@ import functools
 import sublime
 import sublime_plugin
 import webbrowser
-
+import itertools
 
 SUBLIME_WORD_MASK = 515
 
@@ -486,7 +486,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             if action_count > 1:
                 title = '{} code actions'.format(action_count)
             else:
-                title = next(iter(responses.values()))[0]['title']
+                title = next(itertools.chain.from_iterable(responses.values()))['title']
             code_actions_link = make_command_link('lsp_code_actions', title, {
                 "commands_by_config": responses
             })


### PR DESCRIPTION
If  only one option, display the `code action` method to reduce unnecessary operations