### PR TITLE
Fix: do not ignore return types

### DIFF
--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -45,11 +45,6 @@ class AbstractViewListener(metaclass=ABCMeta):
 
     view = None  # type: sublime.View
 
-    @property
-    @abstractmethod
-    def manager(self) -> "WindowManager":
-        raise NotImplementedError()
-
     @abstractmethod
     def session(self, capability_path: str, point: Optional[int] = None) -> Optional[Session]:
         raise NotImplementedError()

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -702,14 +702,6 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
 
     # --- Public utility methods ---------------------------------------------------------------------------------------
 
-    @property
-    def manager(self) -> WindowManager:  # TODO: Return type is an Optional[WindowManager] !
-        if not self._manager:
-            window = self.view.window()
-            if window:
-                self._manager = windows.lookup(window)
-        return self._manager  # type: ignore
-
     def sessions(self, capability: Optional[str]) -> Generator[Session, None, None]:
         for sb in self.session_buffers_async():
             if capability is None or sb.has_capability(capability):
@@ -782,7 +774,12 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             debug("couldn't find a text change listener for", self)
             return
         self._registered = True
-        self.manager.register_listener_async(self)
+        if not self._manager:
+            window = self.view.window()
+            if not window:
+                return
+            self._manager = windows.lookup(window)
+        self._manager.register_listener_async(self)
         views = buf.views()
         if not isinstance(views, list):
             debug("skipping clone checks for", self)


### PR DESCRIPTION
This fixes an edge case where registering the listener to the window manager could be "too late" because the window/view was already closed on the main thread.

```
Traceback (most recent call last):
  File "C:\Program Files\Sublime Text\Lib\python33\sublime_plugin.py", line 863, in on_load_async
    run_view_callbacks('on_load_async', view_id)
  File "C:\Program Files\Sublime Text\Lib\python33\sublime_plugin.py", line 714, in run_view_callbacks
    callback(*args)
  File "C:\Program Files\Sublime Text\Lib\python33\sublime_plugin.py", line 190, in exception_handler
    return event_handler(*args)
  File "C:\Users\mitranim\AppData\Roaming\Sublime Text\Installed Packages\LSP.sublime-package\plugin/documents.py", line 327, in on_load_async
    self._register_async()
  File "C:\Users\mitranim\AppData\Roaming\Sublime Text\Installed Packages\LSP.sublime-package\plugin/documents.py", line 785, in _register_async
    self.manager.register_listener_async(self)
AttributeError: 'NoneType' object has no attribute 'register_listener_async'
```

I'm assuming the solution is to not ignore type hints.

cc @mitranim 