### PR TITLE
Support list type when parsing contributes.configuration

### DIFF
--- a/plugin/tooling.py
+++ b/plugin/tooling.py
@@ -126,10 +126,15 @@ class LspParseVscodePackageJson(sublime_plugin.ApplicationCommand):
             sublime.error_message('No "contributes" key found!')
             return
         configuration = contributes.get("configuration")
-        if not isinstance(configuration, dict):
+        if not isinstance(configuration, dict) and not isinstance(configuration, list):
             sublime.error_message('No "contributes.configuration" key found!')
             return
-        properties = configuration.get("properties")
+        if isinstance(configuration, dict):
+            properties = configuration.get("properties")
+        else:
+            properties = {}
+            for configuration_item in configuration:
+                properties.update(configuration_item.get("properties"))
         if not isinstance(properties, dict):
             sublime.error_message('No "contributes.configuration.properties" key found!')
             return
@@ -151,7 +156,7 @@ class LspParseVscodePackageJson(sublime_plugin.ApplicationCommand):
                 description = v.get("markdownDescription")
             if isinstance(description, str):
                 for line in description.splitlines():
-                    for wrapped_line in textwrap.wrap(line, width=80 - 8 - 3):
+                    for wrapped_line in textwrap.wrap(line, width=100 - 8 - 3):
                         self.writeline4('// {}'.format(wrapped_line))
             else:
                 self.writeline4('// unknown setting')


### PR DESCRIPTION
The "contributes.configuration" can be a list of objects as defined in
the schema [1] and done in css language server [2].

Also increased wrap width from ~80 to ~100 as the previous value seemed
a little narrow.

[1] https://github.com/microsoft/vscode/blob/c351b396cacdfd5bcbeec6ad89a2890cbdae9263/src/vs/workbench/api/common/configurationExtensionPoint.ts#L133-L146
[2] https://raw.githubusercontent.com/microsoft/vscode/main/extensions/css-language-features/package.json