### PR TITLE
Expose access to LspTextCommand from SaveTasks

### DIFF
--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -254,7 +254,7 @@ class CodeActionOnSaveTask(SaveTask):
         tasks = []  # type: List[Promise]
         for config_name, code_actions in responses.items():
             if code_actions:
-                for session in sessions_for_view(self._task_runner.view, 'codeActionProvider'):
+                for session in self._task_runner.sessions('codeActionProvider'):
                     if session.config.name == config_name:
                         for code_action in code_actions:
                             tasks.append(session.run_code_action_async(code_action, progress=False))

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -244,22 +244,22 @@ class CodeActionOnSaveTask(SaveTask):
 
     def _request_code_actions_async(self) -> None:
         self._purge_changes_async()
-        on_save_actions = self._get_code_actions_on_save(self._view)
-        actions_manager.request_on_save(self._view, self._handle_response_async, on_save_actions)
+        on_save_actions = self._get_code_actions_on_save(self._task_runner.view)
+        actions_manager.request_on_save(self._task_runner.view, self._handle_response_async, on_save_actions)
 
     def _handle_response_async(self, responses: CodeActionsByConfigName) -> None:
         if self._cancelled:
             return
-        document_version = self._view.change_count()
+        document_version = self._task_runner.view.change_count()
         tasks = []  # type: List[Promise]
         for config_name, code_actions in responses.items():
             if code_actions:
-                for session in sessions_for_view(self._view, 'codeActionProvider'):
+                for session in sessions_for_view(self._task_runner.view, 'codeActionProvider'):
                     if session.config.name == config_name:
                         for code_action in code_actions:
                             tasks.append(session.run_code_action_async(code_action, progress=False))
                         break
-        if document_version != self._view.change_count():
+        if document_version != self._task_runner.view.change_count():
             # Give on_text_changed_async a chance to trigger.
             Promise.all(tasks).then(lambda _: sublime.set_timeout_async(self._request_code_actions_async))
         else:

--- a/plugin/formatting.py
+++ b/plugin/formatting.py
@@ -30,7 +30,7 @@ class WillSaveWaitTask(SaveTask):
 
     def run_async(self) -> None:
         super().run_async()
-        self._session_iterator = sessions_for_view(self._task_runner.view, 'textDocumentSync.willSaveWaitUntil')
+        self._session_iterator = self._task_runner.sessions('textDocumentSync.willSaveWaitUntil')
         self._handle_next_session_async()
 
     def _handle_next_session_async(self) -> None:

--- a/plugin/formatting.py
+++ b/plugin/formatting.py
@@ -1,7 +1,6 @@
 from .core.edit import parse_text_edit
 from .core.protocol import TextEdit
 from .core.registry import LspTextCommand
-from .core.registry import sessions_for_view
 from .core.sessions import Session
 from .core.settings import userprefs
 from .core.typing import Any, Callable, List, Optional, Iterator

--- a/plugin/save_command.py
+++ b/plugin/save_command.py
@@ -56,8 +56,6 @@ class SaveTask(metaclass=ABCMeta):
         self._completed = True
         if not self._cancelled:
             self._on_done()
-        self._on_done = None
-        self._task_runner = None
 
     def _purge_changes_async(self) -> None:
         # Supermassive hack that will go away later.

--- a/plugin/save_command.py
+++ b/plugin/save_command.py
@@ -9,8 +9,6 @@ class SaveTask(metaclass=ABCMeta):
     """
     Base class for tasks that run on save.
 
-    Takes care of timing out lask after specified timeout provided that base run() is called.
-
     Note: The whole task runs on the async thread.
     """
 

--- a/plugin/save_command.py
+++ b/plugin/save_command.py
@@ -1,3 +1,4 @@
+from .core.registry import LspTextCommand
 from .core.typing import Callable, List, Type
 from abc import ABCMeta, abstractmethod
 import sublime
@@ -20,8 +21,8 @@ class SaveTask(metaclass=ABCMeta):
     def is_applicable(cls, view: sublime.View) -> bool:
         pass
 
-    def __init__(self, view: sublime.View, on_done: Callable[[], None]):
-        self._view = view
+    def __init__(self, task_runner: LspTextCommand, on_done: Callable[[], None]):
+        self._task_runner = task_runner
         self._on_done = on_done
         self._completed = False
         self._cancelled = False
@@ -44,28 +45,30 @@ class SaveTask(metaclass=ABCMeta):
         self._cancelled = True
 
     def _set_view_status(self, text: str) -> None:
-        self._view.set_status(self._status_key, text)
+        self._task_runner.view.set_status(self._status_key, text)
         sublime.set_timeout_async(self._erase_view_status, 5000)
 
     def _erase_view_status(self) -> None:
-        self._view.erase_status(self._status_key)
+        self._task_runner.view.erase_status(self._status_key)
 
     def _on_complete(self) -> None:
         assert not self._completed
         self._completed = True
         if not self._cancelled:
             self._on_done()
+        self._on_done = None
+        self._task_runner = None
 
     def _purge_changes_async(self) -> None:
         # Supermassive hack that will go away later.
-        listeners = sublime_plugin.view_event_listeners.get(self._view.id(), [])
+        listeners = sublime_plugin.view_event_listeners.get(self._task_runner.view.id(), [])
         for listener in listeners:
             if listener.__class__.__name__ == 'DocumentSyncListener':
                 listener.purge_changes_async()  # type: ignore
                 break
 
 
-class LspSaveCommand(sublime_plugin.TextCommand):
+class LspSaveCommand(LspTextCommand):
     """
     A command used as a substitute for native save command. Runs code actions and document
     formatting before triggering the native save command.
@@ -89,7 +92,7 @@ class LspSaveCommand(sublime_plugin.TextCommand):
         sublime.set_timeout_async(self._trigger_on_pre_save_async)
         for Task in self._tasks:
             if Task.is_applicable(self.view):
-                self._pending_tasks.append(Task(self.view, self._on_task_completed_async))
+                self._pending_tasks.append(Task(self, self._on_task_completed_async))
         if self._pending_tasks:
             sublime.set_timeout_async(self._run_next_task_async)
         else:


### PR DESCRIPTION
I'm doing a little bit of cleanup and enhancement to allow SaveTasks to call `LspTextCommand.best_session` since I want to consolidate some code later and fix #1684.

I can do further changes as separate commits or separate PR. I didn't want to just throw all together as it would be hard to review.

This change should have no functional changes.
It does switch from global `sessions_for_view` function to `LspTextCommand.best_session` but I believe this should have no behavior changes? Or if it does then only for the better? I forgot what's the difference between those exactly but I believe the latter is preferred and works correctly in more cases?