### PR TITLE
Raise an exception when neither "command" nor "tcp_port" is given

### DIFF
--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -520,6 +520,8 @@ class TransportConfig:
         env: Dict[str, str],
         listener_socket: Optional[socket.socket]
     ) -> None:
+        if not command and not tcp_port:
+            raise ValueError('neither "command" nor "tcp_port" is provided; cannot start a language server')
         self.name = name
         self.command = command
         self.tcp_port = tcp_port


### PR DESCRIPTION
The TransportConfig checks this invariant now.
In practise this means the user is presented with a clearer error.
Fixes #1564.

<img width="295" alt="image" src="https://user-images.githubusercontent.com/2431823/120050146-9f599e80-c01c-11eb-9ba1-41a38d2bc442.png">
