### PR TITLE
Don't ascii-escape Unicode

### DIFF
--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -325,7 +325,13 @@ def _connect_tcp(port: int) -> Optional[socket.socket]:
 
 
 def _encode(d: Dict[str, Any]) -> bytes:
-    return json.dumps(d, sort_keys=False, check_circular=False, separators=(',', ':')).encode('utf-8')
+    return json.dumps(
+        d,
+        ensure_ascii=False,
+        sort_keys=False,
+        check_circular=False,
+        separators=(',', ':')
+    ).encode('utf-8')
 
 
 def _decode(message: bytes) -> Dict[str, Any]:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -2,6 +2,8 @@ from LSP.plugin.core.protocol import (
     Point, Range, Request, Notification
 )
 import unittest
+from LSP.plugin.core.transports import _encode, _decode
+
 
 LSP_START_POSITION = {'line': 10, 'character': 4}
 LSP_END_POSITION = {'line': 11, 'character': 3}
@@ -125,6 +127,14 @@ class RangeTests(unittest.TestCase):
         other_range = Range(Point(1, 1), Point(1, 2))
         base_range.extend(other_range)
         self.assertEqual(base_range, Range(Point(1, 0), Point(1, 5)))
+
+
+class EncodingTests(unittest.TestCase):
+    def test_encode(self):
+        encoded = _encode({"text": "😃"})
+        self.assertEqual(encoded, b'{"text":"\xF0\x9F\x98\x83"}')
+        decoded = _decode(encoded)
+        self.assertEqual(decoded, {"text": "😃"})
 
 
 class RequestTests(unittest.TestCase):


### PR DESCRIPTION
This makes the flow language server not crash with non-ascii characters.
However, inserting an emoji, and then removing that emoji brings flow into an
invalid state. It seems to be because when the emoji is removed, that counts
as two UTF-16 characters.