### PR TITLE
shellcheck works only for bash

### DIFF
--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -437,7 +437,7 @@ Follow installation instructions on [LSP-metals](https://github.com/scalameta/me
             "diagnostic-ls": {
                 "enabled": true,
                 "command": ["diagnostic-languageserver", "--stdio"],
-                "selector": "source.shell",
+                "selector": "source.shell.bash",
                 "initializationOptions": {
                     "linters": {
                         "shellcheck": {


### PR DESCRIPTION
This avoids starting it for fish https://github.com/Phidica/sublime-fish/blob/6697fdd7becc3e5991484d4365b036b9fbb1d99d/fish.sublime-syntax#L8