### PR TITLE
Apply all status messages when a SessionView is opened

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -840,6 +840,7 @@ class Session(TransportCallbacks):
         self._progress = {}  # type: Dict[str, Optional[WindowProgressReporter]]
         self._plugin_class = plugin_class
         self._plugin = None  # type: Optional[AbstractPlugin]
+        self._status_messages = {}  # type: Dict[str, str]
 
     def __getattr__(self, name: str) -> Any:
         """
@@ -883,10 +884,12 @@ class Session(TransportCallbacks):
         return None
 
     def set_window_status_async(self, key: str, message: str) -> None:
+        self._status_messages[key] = message
         for sv in self.session_views_async():
             sv.view.set_status(key, message)
 
     def erase_window_status_async(self, key: str) -> None:
+        self._status_messages.pop(key, None)
         for sv in self.session_views_async():
             sv.view.erase_status(key)
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -864,6 +864,8 @@ class Session(TransportCallbacks):
     def register_session_view_async(self, sv: SessionViewProtocol) -> None:
         self._session_views.add(sv)
         self._views_opened += 1
+        for status_key, message in self._status_messages.items():
+            sv.view.set_status(status_key, message)
 
     def unregister_session_view_async(self, sv: SessionViewProtocol) -> None:
         self._session_views.discard(sv)

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -49,8 +49,6 @@ class SessionView:
         self.session_buffer = session_buffer
         session.register_session_view_async(self)
         session.config.set_view_status(self.view, "")
-        for status_key, message in session._status_messages.items():
-            self.view.set_status(status_key, message)
         if self.session.has_capability(self.HOVER_PROVIDER_KEY):
             self._increment_hover_count()
         self._clear_auto_complete_triggers(settings)

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -49,6 +49,8 @@ class SessionView:
         self.session_buffer = session_buffer
         session.register_session_view_async(self)
         session.config.set_view_status(self.view, "")
+        for status_key, message in session._status_messages.items():
+            self.view.set_status(status_key, message)
         if self.session.has_capability(self.HOVER_PROVIDER_KEY):
             self._increment_hover_count()
         self._clear_auto_complete_triggers(settings)


### PR DESCRIPTION
Apply all permanent status messages that were set via `Session.set_window_status_async` when a file is opened.

I'm not sure why, but this also fixes an issue I saw, that `set_window_status_async` has no effect when called within `AbstractPlugin.__init__`.

Note that the `set_window_status_async` method ignores the "show_view_status" setting, but it seems much more useful to me this way, because plugin authors could add their own setting for this (or query the "show_view_status" setting from the LSP preferences) and then check that before calling `set_window_status_async`.