### PR TITLE
Open links with absolute filepaths in a new view

### DIFF
--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -704,6 +704,15 @@ def is_location_href(href: str) -> bool:
     return href.startswith("location:")
 
 
+def is_file(href: str) -> bool:
+    """
+    Check whether this href is a path to an existing file, possibly with :row or :row:col suffix.
+    """
+    drive, tail = os.path.splitdrive(href)
+    path = tail.split(':')[0]
+    return os.path.isfile(drive + path)
+
+
 def _format_diagnostic_related_info(
     config: ClientConfig,
     info: DiagnosticRelatedInformation,

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -14,6 +14,7 @@ from .core.views import diagnostic_severity
 from .core.views import first_selection_region
 from .core.views import format_diagnostic_for_html
 from .core.views import FORMAT_MARKED_STRING, FORMAT_MARKUP_CONTENT, minihtml
+from .core.views import is_file
 from .core.views import is_location_href
 from .core.views import make_command_link
 from .core.views import make_link
@@ -24,6 +25,7 @@ from .core.views import update_lsp_popup
 from .core.windows import AbstractViewListener
 from urllib.parse import urlparse
 import functools
+import os
 import sublime
 import webbrowser
 
@@ -212,6 +214,10 @@ class LspHoverCommand(LspTextCommand):
                 position = {"line": row, "character": col_utf16}  # type: Position
                 r = {"start": position, "end": position}  # type: RangeLsp
                 sublime.set_timeout_async(functools.partial(session.open_uri_async, uri, r))
+        elif os.path.isabs(href) and is_file(href):
+            window = self.view.window()
+            if window:
+                window.open_file(href, flags=sublime.ENCODED_POSITION)
         else:
             # NOTE: Remove this check when on py3.8.
             if not (href.lower().startswith("http://") or href.lower().startswith("https://")):


### PR DESCRIPTION
The Julia language server uses Markdown links in hover popups with absolute paths to other files (but without `file://` schema) and a :row suffix. For example `C:\\\\path\\\\to\\\\file.jl:123`, which corresponds to `C:\path\to\file.jl:123` without the JSON and Markdown escaping for the backslashes (on Windows).

This commit checks if the path describes an existing file and allows to open such links in a new view, instead of in a webbrowser.

I didn't find an exact description in the LSP specs how links to files should be specified (other than that Markdown should follow GFM), so I guess it's up to the client what kind of link formats are supported. I guess this implementations seems safe to not accidentally open actual weblinks in the editor.