### PR TITLE
Use box-style for multiline doc highlights

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -82,7 +82,7 @@
 
   // Highlighting style of "highlights": accentuating nearby text entities that
   // are related to the one under your cursor.
-  // Valid values are "fill", "box", "underline", "stippled", "squiggly" or "".
+  // Valid values are "fill", "underline", or "".
   // When set to the empty string (""), no document highlighting is requested.
   "document_highlight_style": "underline",
 

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -190,7 +190,7 @@ class Settings:
         r("diagnostics_highlight_style", "underline")
         r("diagnostics_panel_include_severity_level", 4)
         r("disabled_capabilities", [])
-        r("document_highlight_style", "stippled")
+        r("document_highlight_style", "underline")
         r("log_debug", False)
         r("log_max_size", 8 * 1024)
         r("lsp_code_actions_on_save", {})
@@ -236,8 +236,11 @@ class Settings:
 
         set_debug_logging(self.log_debug)
 
-    def document_highlight_style_to_add_regions_flags(self) -> int:
-        return _settings_style_to_add_regions_flag(self.document_highlight_style)
+    def document_highlight_style_to_add_regions_flags(self) -> Tuple[int, int]:
+        if self.document_highlight_style == "fill":
+            return sublime.DRAW_NO_OUTLINE, sublime.DRAW_NO_OUTLINE
+        else:
+            return sublime.DRAW_NO_FILL, sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE | sublime.DRAW_SOLID_UNDERLINE
 
     def diagnostics_highlight_style_to_add_regions_flag(self) -> int:
         return _settings_style_to_add_regions_flag(self.diagnostics_highlight_style)

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -236,7 +236,7 @@ class Settings:
 
         set_debug_logging(self.log_debug)
 
-    def document_highlight_style_to_add_regions_flags(self) -> Tuple[int, int]:
+    def document_highlight_style_region_flags(self) -> Tuple[int, int]:
         if self.document_highlight_style == "fill":
             return sublime.DRAW_NO_OUTLINE, sublime.DRAW_NO_OUTLINE
         else:

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -43,11 +43,11 @@ from functools import partial
 from weakref import WeakSet
 from weakref import WeakValueDictionary
 import functools
+import itertools
 import sublime
 import sublime_plugin
 import textwrap
 import webbrowser
-import itertools
 
 
 SUBLIME_WORD_MASK = 515

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -343,8 +343,9 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         if different:
             if not self._is_in_higlighted_region(current_region.b):
                 self._clear_highlight_regions()
-            self._when_selection_remains_stable_async(self._do_highlights_async, current_region,
-                                                      after_ms=self.highlights_debounce_time)
+            if userprefs().document_highlight_style:
+                self._when_selection_remains_stable_async(self._do_highlights_async, current_region,
+                                                          after_ms=self.highlights_debounce_time)
             self._clear_code_actions_annotation()
             if userprefs().show_code_actions:
                 self._when_selection_remains_stable_async(self._do_code_actions, current_region,

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -251,10 +251,7 @@
             "document_highlight_style": {
               "enum": [
                 "fill",
-                "box",
                 "underline",
-                "stippled",
-                "squiggly",
                 ""
               ],
               "default": "underline",


### PR DESCRIPTION
Related: #1710

I've removed the "squiggly", "dotted" and "box" options for single-line highlights. "fill" and "underline" are possible. When set to "fill", "fill" is used for multi-line as well.