### PR TITLE
Hover code action show remains consistent

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -101,6 +101,9 @@
   // using a keyboard shortcut or the context menu.
   "show_code_actions": "annotation",
 
+  // Show code actions in hover popup if available
+  "show_code_actions_in_hover": true,
+
   // Show symbol action links in hover popup if available
   "show_symbol_action_links": true,
 

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -166,6 +166,7 @@ class Settings:
     popup_max_characters_height = None  # type: int
     popup_max_characters_width = None  # type: int
     show_code_actions = None  # type: bool
+    show_code_actions_in_hover = None  # type: bool
     show_diagnostics_count_in_view_status = None  # type: bool
     show_diagnostics_in_view_status = None  # type: bool
     show_diagnostics_panel_on_save = None  # type: int
@@ -199,6 +200,7 @@ class Settings:
         r("popup_max_characters_height", 1000)
         r("popup_max_characters_width", 120)
         r("show_code_actions", "annotation")
+        r("show_code_actions_in_hover", True)
         r("show_diagnostics_count_in_view_status", False)
         r("show_diagnostics_in_view_status", True)
         r("show_diagnostics_panel_on_save", 2)

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -104,7 +104,7 @@ class LspHoverCommand(LspTextCommand):
             self._diagnostics_by_config, covering = listener.diagnostics_touching_point_async(hover_point)
             if self._diagnostics_by_config:
                 self.show_hover(listener, hover_point, only_diagnostics)
-            if not only_diagnostics and userprefs().show_code_actions:
+            if not only_diagnostics and userprefs().show_code_actions_in_hover:
                 actions_manager.request_for_region_async(
                     self.view, covering, self._diagnostics_by_config,
                     functools.partial(self.handle_code_actions, listener, hover_point))

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -104,7 +104,7 @@ class LspHoverCommand(LspTextCommand):
             self._diagnostics_by_config, covering = listener.diagnostics_touching_point_async(hover_point)
             if self._diagnostics_by_config:
                 self.show_hover(listener, hover_point, only_diagnostics)
-            if not only_diagnostics:
+            if not only_diagnostics and userprefs().show_code_actions:
                 actions_manager.request_for_region_async(
                     self.view, covering, self._diagnostics_by_config,
                     functools.partial(self.handle_code_actions, listener, hover_point))

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -285,9 +285,14 @@
               "default": "annotation",
               "markdownDescription": "Where to show `\"code actions\"`. Due to API limitations, the `\"bulb\"` icon can not be clicked so the code actions can only be triggered using a keyboard shortcut or the context menu."
             },
+            "show_code_actions_in_hover": {
+              "type": "boolean",
+              "default": true,
+              "markdownDescription": "Show code actions in hover popup if available."
+            },
             "show_symbol_action_links": {
               "type": "boolean",
-              "default": false,
+              "default": true,
               "markdownDescription": "Show symbol action links in hover popup if available."
             },
             "only_show_lsp_completions": {


### PR DESCRIPTION
if the `"show_code_actions": ""` then code action also shouldn't show in the hover