### PR TITLE
Use "_async" suffix in listener APIs

### DIFF
--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -126,10 +126,7 @@ class CodeActionsManager:
             if file_name:
                 listener = windows.listener_for_view(view)
                 if listener:
-                    for sv in listener.session_views_async():
-                        if not sv.has_capability_async('codeActionProvider'):
-                            continue
-                        session = sv.session
+                    for session in listener.sessions_async('codeActionProvider'):
                         if on_save_actions:
                             supported_kinds = session.get_capability('codeActionProvider.codeActionKinds')
                             matching_kinds = get_matching_kinds(on_save_actions, supported_kinds or [])

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -73,7 +73,7 @@ class LspTextCommand(sublime_plugin.TextCommand):
 
     def best_session(self, capability: str, point: Optional[int] = None) -> Optional[Session]:
         listener = windows.listener_for_view(self.view)
-        return listener.session(capability, point) if listener else None
+        return listener.session_async(capability, point) if listener else None
 
     def session_by_name(self, name: Optional[str] = None, capability_path: Optional[str] = None) -> Optional[Session]:
         target = name if name else self.session_name

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -46,7 +46,15 @@ class AbstractViewListener(metaclass=ABCMeta):
     view = None  # type: sublime.View
 
     @abstractmethod
-    def session(self, capability_path: str, point: Optional[int] = None) -> Optional[Session]:
+    def session_async(self, capability_path: str, point: Optional[int] = None) -> Optional[Session]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def sessions_async(self, capability_path: Optional[str] = None) -> Generator[Session, None, None]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def session_views_async(self) -> Iterable[SessionViewProtocol]:
         raise NotImplementedError()
 
     @abstractmethod
@@ -104,10 +112,6 @@ class AbstractViewListener(metaclass=ABCMeta):
 
     @abstractmethod
     def get_resolved_code_lenses_for_region(self, region: sublime.Region) -> Iterable[CodeLens]:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def session_views_async(self) -> Iterable[SessionViewProtocol]:
         raise NotImplementedError()
 
     @abstractmethod

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -371,7 +371,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         if key == "lsp.session_with_capability" and operator == sublime.OP_EQUAL and isinstance(operand, str):
             capabilities = [s.strip() for s in operand.split("|")]
             for capability in capabilities:
-                if any(self.sessions(capability)):
+                if any(self.sessions_async(capability)):
                     return True
             return False
         elif key in ("lsp.sessions", "setting.lsp_active"):
@@ -420,7 +420,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         pos = self._stored_region.a
         if pos == -1:
             return
-        session = self.session("signatureHelpProvider", pos)
+        session = self.session_async("signatureHelpProvider", pos)
         if not session:
             return
         triggers = []  # type: List[str]
@@ -515,7 +515,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
     # --- textDocument/documentColor -----------------------------------------------------------------------------------
 
     def _do_color_boxes_async(self) -> None:
-        session = self.session("colorProvider")
+        session = self.session_async("colorProvider")
         if session:
             session.send_request_async(
                 Request.documentColor(document_color_params(self.view), self.view), self._on_color_boxes)
@@ -550,7 +550,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         self.view.add_regions(self._code_lens_key(index), [region], "", "", 0, [annotation], accent)
 
     def _do_code_lenses_async(self) -> None:
-        session = self.session("codeLensProvider")
+        session = self.session_async("codeLensProvider")
         if session and session.uses_plugin():
             params = {"textDocument": text_document_identifier(self.view)}
             for sv in self.session_views_async():
@@ -581,7 +581,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         self._resolve_visible_code_lenses_async()
 
     def _resolve_visible_code_lenses_async(self) -> None:
-        session = self.session("codeLensProvider")
+        session = self.session_async("codeLensProvider")
         if session:
             for index, code_lens, region in self._unresolved_code_lenses(self.view.visible_region()):
                 callback = functools.partial(self._on_resolved_code_lens_async, session.config.name, index, region)
@@ -629,7 +629,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         if region is None:
             return
         point = region.b
-        session = self.session("documentHighlightProvider", point)
+        session = self.session_async("documentHighlightProvider", point)
         if session:
             params = text_document_position_params(self.view, point)
             request = Request.documentHighlight(params, self.view)
@@ -660,7 +660,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
     # --- textDocument/complete ----------------------------------------------------------------------------------------
 
     def _on_query_completions_async(self, resolve_completion_list: ResolveCompletionsFn, location: int) -> None:
-        sessions = list(self.sessions('completionProvider'))
+        sessions = list(self.sessions_async('completionProvider'))
         if not sessions or not self.view.is_valid():
             resolve_completion_list([], 0)
             return
@@ -721,13 +721,13 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
 
     # --- Public utility methods ---------------------------------------------------------------------------------------
 
-    def sessions(self, capability: Optional[str]) -> Generator[Session, None, None]:
+    def sessions_async(self, capability: Optional[str]) -> Generator[Session, None, None]:
         for sb in self.session_buffers_async():
             if capability is None or sb.has_capability(capability):
                 yield sb.session
 
-    def session(self, capability: str, point: Optional[int] = None) -> Optional[Session]:
-        return best_session(self.view, self.sessions(capability), point)
+    def session_async(self, capability: str, point: Optional[int] = None) -> Optional[Session]:
+        return best_session(self.view, self.sessions_async(capability), point)
 
     def session_by_name(self, name: Optional[str] = None) -> Optional[Session]:
         for sb in self.session_buffers_async():

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -721,13 +721,13 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
 
     # --- Public utility methods ---------------------------------------------------------------------------------------
 
-    def sessions_async(self, capability: Optional[str]) -> Generator[Session, None, None]:
+    def session_async(self, capability: str, point: Optional[int] = None) -> Optional[Session]:
+        return best_session(self.view, self.sessions_async(capability), point)
+
+    def sessions_async(self, capability: Optional[str] = None) -> Generator[Session, None, None]:
         for sb in self.session_buffers_async():
             if capability is None or sb.has_capability(capability):
                 yield sb.session
-
-    def session_async(self, capability: str, point: Optional[int] = None) -> Optional[Session]:
-        return best_session(self.view, self.sessions_async(capability), point)
 
     def session_by_name(self, name: Optional[str] = None) -> Optional[Session]:
         for sb in self.session_buffers_async():

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -113,7 +113,7 @@ class LspHoverCommand(LspTextCommand):
         sublime.set_timeout_async(run_async)
 
     def request_symbol_hover_async(self, listener: AbstractViewListener, point: int) -> None:
-        session = listener.session('hoverProvider', point)
+        session = listener.session_async('hoverProvider', point)
         if session:
             document_position = text_document_position_params(self.view, point)
             session.send_request_async(
@@ -134,7 +134,7 @@ class LspHoverCommand(LspTextCommand):
         self.show_hover(listener, point, only_diagnostics=False)
 
     def provider_exists(self, listener: AbstractViewListener, link: LinkKind) -> bool:
-        return bool(listener.session('{}Provider'.format(link.lsp_name)))
+        return bool(listener.session_async('{}Provider'.format(link.lsp_name)))
 
     def symbol_actions_content(self, listener: AbstractViewListener, point: int) -> str:
         if userprefs().show_symbol_action_links:


### PR DESCRIPTION
Just a tiny refactor to include the _async suffix and add
a "sessions_async" API to listener for parity.