### PR TITLE
Add back stippled option for document highlights

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -81,7 +81,7 @@
 
   // Highlighting style of "highlights": accentuating nearby text entities that
   // are related to the one under your cursor.
-  // Valid values are "fill", "underline", or "".
+  // Valid values are "fill", "underline", "stippled", or "".
   // When set to the empty string (""), no document highlighting is requested.
   "document_highlight_style": "underline",
 

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -236,7 +236,7 @@ class Settings:
         if self.document_highlight_style == "fill":
             return sublime.DRAW_NO_OUTLINE, sublime.DRAW_NO_OUTLINE
         elif self.document_highlight_style == "stippled":
-            return sublime.DRAW_NO_FILL, sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE | sublime.DRAW_STIPPLED_UNDERLINE
+            return sublime.DRAW_NO_FILL, sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE | sublime.DRAW_STIPPLED_UNDERLINE  # noqa: E501
         else:
             return sublime.DRAW_NO_FILL, sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE | sublime.DRAW_SOLID_UNDERLINE
 

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -235,6 +235,8 @@ class Settings:
     def document_highlight_style_region_flags(self) -> Tuple[int, int]:
         if self.document_highlight_style == "fill":
             return sublime.DRAW_NO_OUTLINE, sublime.DRAW_NO_OUTLINE
+        elif self.document_highlight_style == "stippled":
+            return sublime.DRAW_NO_FILL, sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE | sublime.DRAW_STIPPLED_UNDERLINE
         else:
             return sublime.DRAW_NO_FILL, sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE | sublime.DRAW_SOLID_UNDERLINE
 

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -249,6 +249,7 @@
               "enum": [
                 "fill",
                 "underline",
+                "stippled",
                 ""
               ],
               "default": "underline",


### PR DESCRIPTION
Because it is requested in #1712 by multiple users and there is already the setting for it, so I think it doesn't hurt to keep this option.