### PR TITLE
Add setting to render code lenses as a phantom

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -97,6 +97,11 @@
   // using a keyboard shortcut or the context menu.
   "show_code_actions": "annotation",
 
+  // Show code lens:
+  // "annotation" - show an annotation on the right when code actions are available
+  // "phantom" - show a phantom on the top when code actions are available
+  "show_code_lens": "annotation",
+
   // Show code actions in hover popup if available
   "show_code_actions_in_hover": true,
 

--- a/plugin/code_lens.py
+++ b/plugin/code_lens.py
@@ -134,16 +134,15 @@ class CodeLensView:
                 yield lens
 
     def _get_phantom_region(self, region: sublime.Region) -> sublime.Region:
-        line = self.view.substr(self.view.line(region))
+        line = self.view.line(region)
+        code = self.view.substr(line)
         offset = 0
-        for ch in line:
+        for ch in code:
             if ch.isspace():
                 offset += 1
             else:
                 break
-        row, _ = self.view.rowcol(region.a)
-        point = self.view.text_point(max(row - 1, 0), offset, clamp_column=True)
-        return sublime.Region(point)
+        return sublime.Region(line.a + offset, line.b)
 
     def render(self, mode: str) -> None:
         if mode == 'phantom':

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -149,7 +149,8 @@ class Settings:
     only_show_lsp_completions = None  # type: bool
     popup_max_characters_height = None  # type: int
     popup_max_characters_width = None  # type: int
-    show_code_actions = None  # type: bool
+    show_code_actions = None  # type: str
+    show_code_lens = None  # type: str
     show_code_actions_in_hover = None  # type: bool
     show_diagnostics_count_in_view_status = None  # type: bool
     show_diagnostics_highlights = None  # type: bool
@@ -184,6 +185,7 @@ class Settings:
         r("popup_max_characters_height", 1000)
         r("popup_max_characters_width", 120)
         r("show_code_actions", "annotation")
+        r("show_code_lens", "annotation")
         r("show_code_actions_in_hover", True)
         r("show_diagnostics_count_in_view_status", False)
         r("show_diagnostics_in_view_status", True)

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -314,7 +314,8 @@ class SessionView:
                 Request("codeLens/resolve", code_lens.data, self.view)
             ).then(callback)
             promises.append(promise)
-        Promise.all(promises).then(lambda _: self._code_lenses.render())
+        mode = userprefs().show_code_lens
+        Promise.all(promises).then(lambda _: self._code_lenses.render(mode))
 
     def get_resolved_code_lenses_for_region(self, region: sublime.Region) -> Generator[CodeLens, None, None]:
         yield from self._code_lenses.get_resolved_code_lenses_for_region(region)

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -308,7 +308,7 @@ class SessionView:
         if self._code_lenses.is_empty():
             return
         promises = []  # type: List[Promise[None]]
-        for code_lens in self._code_lenses.unresolved_visible_code_lens(self.view.visible_region()):
+        for code_lens in self._code_lenses.unresolved_visible_code_lenses(self.view.visible_region()):
             callback = functools.partial(code_lens.resolve, self.view)
             promise = self.session.send_request_task(
                 Request("codeLens/resolve", code_lens.data, self.view)

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -315,7 +315,8 @@ class SessionView:
             ).then(callback)
             promises.append(promise)
         mode = userprefs().show_code_lens
-        Promise.all(promises).then(lambda _: self._code_lenses.render(mode))
+        render = functools.partial(self._code_lenses.render, mode)
+        Promise.all(promises).then(lambda _: sublime.set_timeout(render))
 
     def get_resolved_code_lenses_for_region(self, region: sublime.Region) -> Generator[CodeLens, None, None]:
         yield from self._code_lenses.get_resolved_code_lenses_for_region(region)

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -298,6 +298,18 @@
               "default": "annotation",
               "markdownDescription": "Where to show `\"code actions\"`. Due to API limitations, the `\"bulb\"` icon can not be clicked so the code actions can only be triggered using a keyboard shortcut or the context menu."
             },
+            "show_code_lens": {
+              "enum": [
+                "annotation",
+                "phantom"
+              ],
+              "enumDescriptions": [
+                "Show code lens to right as a clickable greenish annotation.",
+                "Show code lens as a phantom."
+              ],
+              "default": "annotation",
+              "markdownDescription": "Where to show `\"code lens\"`."
+            },
             "show_code_actions_in_hover": {
               "type": "boolean",
               "default": true,


### PR DESCRIPTION
This also adds a setting to disable the rendering entirely.

In order to satisfy those who like their code lenses as an annotation I kept the setting as-is rather than replacing them. I did change the default setting to use a phantom since that representation is probably more common for those coming from VSCode.

I've tested this code and it works, but I'm unsure if there are any state related bugs. One thing I noticed is that the code lenses only show up when the file is reopened. This felt undesirable to me, however I did not know where exactly to fix it. In a normal plugin lifecycle I would hook into `on_load_async`, `on_activated_async`, and (potentially) `on_post_save_async`. There was the `_register_async` helper function which would have felt like an appropriate place to send the code lenses request, but I was unsure if the state was properly set there or if this was even desirable. Personally, reopening the file to get code lenses is a bad experience.

Code lenses with the `phantom` setting are rendered similarly to VSCode, as seen below:

| Sublime Text | VSCode |
| :---: | :---: |
| ![image](https://user-images.githubusercontent.com/1695103/122065796-39ad3680-cdc0-11eb-8d6a-1de0ff534a27.png) | ![image](https://user-images.githubusercontent.com/1695103/122065866-4467cb80-cdc0-11eb-88e8-767ef5a2c033.png) |

