### PR TITLE
Semantic highlighting

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -95,6 +95,42 @@
   // "" - don't show code actions.
   // Note: Due to API limitations, the "bulb" icon can not be clicked so the code actions can only be triggered
   // using a keyboard shortcut or the context menu.
+  
+
+  // Enable semantic highlighting:
+  
+  // Add the following to your color scheme
+  //  "rules":
+  //  [
+  //     {
+  //         "scope": "meta.semantic-token.lsp",
+  //         "background": "#01010101"
+  //     }
+  //  ]
+
+  // Note: most color schemes don't utilise many available SublimeText scopes,
+  // this will result in subpar semantic highlighting. Follow the example given
+  // below to customize your color_scheme.
+
+  // syntax for scopes: meta.semantic.tokenType.modifierType
+  // modifierTypes are optional.
+
+  // example rules:
+  // {
+  //     "scope": "meta.semantic.variable",
+  //     "foreground": "var(blue)",
+  // },
+  // {
+  //     "scope": "meta.semantic.method",
+  //     "foreground": "var(yellow)",
+  // },
+  // {
+  //     "scope": "meta.semantic.method.static",
+  //     "foreground": "var(red)",
+  // },
+  "enable_semantic_tokens": false,
+
+
   "show_code_actions": "annotation",
 
   // Show code lens:

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -305,6 +305,18 @@ class Request:
             "params": self.params
         }
 
+    @classmethod
+    def semanticTokens(cls, params: Mapping[str, Any], view: sublime.View) -> 'Request':
+        return Request("textDocument/semanticTokens/full", params, view)
+
+    @classmethod
+    def semanticTokensDelta(cls, params: Mapping[str, Any], view: sublime.View) -> 'Request':
+        return Request("textDocument/semanticTokens/full/delta", params, view)
+
+    @classmethod
+    def semanticTokensRange(cls, params: Mapping[str, Any], view: sublime.View) -> 'Request':
+        return Request("textDocument/semanticTokens/range", params, view)
+
 
 class ErrorCode:
     # Defined by JSON RPC

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -272,6 +272,56 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
         },
         "codeLens": {
             "dynamicRegistration": True
+        },
+        "semanticTokens": {
+            "dynamicRegistration": True,
+            "tokenTypes": [
+                "namespace",
+                "type",
+                "class",
+                "enum",
+                "interface",
+                "struct",
+                "typeParameter",
+                "parameter",
+                "variable",
+                "property",
+                "enumMember",
+                "event",
+                "function",
+                "method",
+                "macro",
+                "keyword",
+                "modifier",
+                "comment",
+                "string",
+                "number",
+                "regexp",
+                "operator"
+            ],
+            "tokenModifiers": [
+                "declaration",
+                "definition",
+                "readonly",
+                "static",
+                "deprecated",
+                "abstract",
+                "async",
+                "modification",
+                "documentation",
+                "defaultLibrary"
+            ],
+            "formats": [
+                "relative"
+            ],
+            "requests": {
+                "range": False,
+                "full": {
+                    "delta": False
+                }
+            },
+            "multilineTokenSupport": True,
+            "overlappingTokenSupport": True
         }
     }
     workspace_capabilites = {

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -158,6 +158,7 @@ class Settings:
     diagnostics_panel_include_severity_level = None  # type: int
     disabled_capabilities = None  # type: List[str]
     document_highlight_style = None  # type: str
+    enable_semantic_tokens = None  # type: bool
     inhibit_snippet_completions = None  # type: bool
     inhibit_word_completions = None  # type: bool
     log_debug = None  # type: bool
@@ -196,6 +197,7 @@ class Settings:
         r("diagnostics_panel_include_severity_level", 4)
         r("disabled_capabilities", [])
         r("document_highlight_style", "underline")
+        r("enable_semantic_tokens", False)
         r("log_debug", False)
         r("log_max_size", 8 * 1024)
         r("lsp_code_actions_on_save", {})

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -139,7 +139,6 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
     color_boxes_debounce_time = FEATURES_TIMEOUT
     highlights_debounce_time = FEATURES_TIMEOUT
     code_lenses_debounce_time = FEATURES_TIMEOUT
-    code_lenses_debounce_time = FEATURES_TIMEOUT + 2000
     semantic_tokens_debounce_time = FEATURES_TIMEOUT
 
     _uri = None  # type: str

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -695,19 +695,12 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         return scope2regions
 
     def _update_semantic_token_regions(self, scope2regions: Dict[str, List[sublime.Region]]) -> None:
-        keys = []
         for scope, regions in scope2regions.items():
             if not scope:
                 continue
             # in case of multiple modifiers, getting a _single modifier_ unique key
             # instead of a long _combined key_, to comply with init_region_keys()
             key = scope.split(', ')[0]
-            if key in keys:
-                for i in range(1, len(scope.split(', ')) - 1):
-                    if scope.split(', ')[i] not in keys:
-                        key = scope.split(', ')[i]
-                        break
-            keys.append(key)
             self.view.add_regions(key, regions, 'meta.semantic-token.lsp ' + scope, flags=sublime.DRAW_NO_OUTLINE)
 
     def _clear_semantic_token_regions(self) -> None:

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -38,6 +38,7 @@ from .core.views import text_document_position_params
 from .core.views import update_lsp_popup
 from .core.windows import AbstractViewListener
 from .core.windows import WindowManager
+from .semantic import get_semantic_scope_from_modifier
 from .session_buffer import SessionBuffer
 from .session_view import SessionView
 from functools import partial
@@ -49,7 +50,6 @@ import sublime_plugin
 import textwrap
 import weakref
 import webbrowser
-from .semantic import get_semantic_scope_from_modifier
 
 SUBLIME_WORD_MASK = 515
 

--- a/plugin/semantic.py
+++ b/plugin/semantic.py
@@ -1,0 +1,104 @@
+NON_MODIFIER_SCOPES = {
+                'variable': 'variable.other.lsp',
+                'parameter': 'variable.parameter.lsp',
+                'function': 'variable.function.lsp',
+                'method': 'variable.function.lsp',
+                'property': 'variable.other.member.lsp',
+                'class': 'support.type.lsp',
+                'enum': 'variable.enum.lsp',
+                'enumMember': 'constant.other.enum.lsp',
+                'type': 'storage.type.lsp',
+                'macro': 'variable.other.constant.lsp',
+                'namespace': 'variable.other.namespace.lsp',
+                'typeParameter': 'variable.parameter.generic.lsp',
+                'comment': 'comment.block.documentation.lsp',
+                'dependent': '',
+                'concept': '',
+                'module': '',
+                'magicFunction': '',
+                'selfParameter': '',
+
+            }
+
+DECLARATION_SCOPES = {
+            'namespace': 'entity.name.namespace.lsp',
+            'type': 'entity.name.type.lsp',
+            'class': 'entity.name.class.lsp',
+            'enum': 'entity.name.enum.lsp',
+            'interface': 'entity.name.interface.lsp',
+            'struct': 'entity.name.struct.lsp',
+            'function': 'entity.name.function.lsp',
+            'method': 'entity.name.function.lsp',
+            'macro': 'entity.name.macro.lsp'
+            }
+
+STAIC_SCOPES = NON_MODIFIER_SCOPES.copy()
+DEPRECATED_SCOPES = NON_MODIFIER_SCOPES.copy()
+ABSTRACT_SCOPES = NON_MODIFIER_SCOPES.copy()
+ASYNC_SCOPES = NON_MODIFIER_SCOPES.copy()
+MODIFICATION_SCOPES = NON_MODIFIER_SCOPES.copy()
+DEFAULT_LIB_SCOPES = NON_MODIFIER_SCOPES.copy()
+
+[NON_MODIFIER_SCOPES.update({k: v + ' meta.semantic.' + k + '.lsp'}) for k, v in NON_MODIFIER_SCOPES.items()]
+
+[DECLARATION_SCOPES.update({k: v + ' meta.semantic.' + k + '.declaration.lsp'}) for k, v in DECLARATION_SCOPES.items()]
+[STAIC_SCOPES.update({k: v + ' meta.semantic.' + k + '.satic.lsp'}) for k, v in STAIC_SCOPES.items()]
+[DEPRECATED_SCOPES.update({k: v + ' meta.semantic.' + k + '.deprecated.lsp'}) for k, v in DEPRECATED_SCOPES.items()]
+[ABSTRACT_SCOPES.update({k: v + ' meta.semantic.' + k + '.abstract.lsp'}) for k, v in ABSTRACT_SCOPES.items()]
+[ASYNC_SCOPES.update({k: v + ' meta.semantic.' + k + '.async.lsp'}) for k, v in ASYNC_SCOPES.items()]
+[MODIFICATION_SCOPES.update({k: v + ' meta.semantic.' + k + '.modification.lsp'})
+ for k, v in MODIFICATION_SCOPES.items()]
+[DEFAULT_LIB_SCOPES.update({k: v + ' meta.semantic.' + k + '.defaultLibrary.lsp'})
+ for k, v in DEFAULT_LIB_SCOPES.items()]
+
+SEMANTIC_SCOPES = {
+            '': NON_MODIFIER_SCOPES,  # if no modifiers are provided
+            "declaration": DECLARATION_SCOPES,
+            "definition": DECLARATION_SCOPES,
+            "readonly": {'variable': 'constant.other.lsp, semantic.variable.readonly.lsp'},
+            "static": STAIC_SCOPES,  # these are temporary, should be filled with real scopes
+            "deprecated": DEPRECATED_SCOPES,
+            "abstract": ABSTRACT_SCOPES,
+            "async": ASYNC_SCOPES,
+            "modification": MODIFICATION_SCOPES,
+            "documentation": {'comment': 'comment.block.documentation'},
+            "defaultLibrary": DEFAULT_LIB_SCOPES
+        }
+
+
+def get_semantic_scope_from_modifier(encoded_token: list, semantic_tokens_legends: dict) -> str:
+    token_int = encoded_token[3]
+    modifier_int = encoded_token[4]
+
+    token_type = semantic_tokens_legends['tokenTypes'][token_int]
+
+    if not modifier_int:
+        try:
+            return(SEMANTIC_SCOPES[''][token_type])
+        except KeyError:
+            pass  # print('scope not defined for tokenType: ', token_type)
+
+    modifier_binary = [int(x) for x in reversed(bin(modifier_int)[2:])]
+    modifiers = [semantic_tokens_legends['tokenModifiers'][i] for i in range(len(modifier_binary)) if i]
+
+    # print('tokenType: ' + token_type + '-- modifiers: ',modifiers)
+    scopes = []
+    for modifier in modifiers:
+        scope = None
+        try:
+            scope = SEMANTIC_SCOPES[modifier][token_type]
+        except KeyError:
+            pass  # print('scope not defined for modifier/tokenType: ', modifier+'/'+token_type)
+
+        if scope and scope not in scopes:
+            scopes.append(scope)
+
+    if not scopes:
+        try:
+            return(SEMANTIC_SCOPES[''][token_type])
+        except KeyError:
+            pass  # print('scope not defined for tokenType: ', token_type)
+    else:
+        return ', '.join(scopes)
+
+    return ''


### PR DESCRIPTION
adding semantic highlighting using "add regions" not an ideal solution but works for time being. 

instruction for editing colorscheme, to work with this is in -- LSP/plugin/semantic.py

I'm not very familiar with LSP package or python, code probably needs little tune up.
I've tested with "clangd" it works, other server I tried was pyrigtht doesn't work with that, MS is keeping semantic highlighting for themselves in Pylance.
Edit: attached screenshot
<img width="1739" alt="semantic_highlighting" src="https://user-images.githubusercontent.com/72250074/122085908-cee01780-ce20-11eb-9295-6f9ce70b8020.png">
