### PR TITLE
Refactor code lenses

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -37,8 +37,8 @@ from .plugin.core.transports import kill_all_subprocesses
 from .plugin.core.types import ClientConfig
 from .plugin.core.typing import Any, Optional, List, Type, Callable, Dict, Tuple
 from .plugin.core.views import LspRunTextCommandHelperCommand
+from .plugin.code_lens import LspCodeLensCommand
 from .plugin.documents import DocumentSyncListener
-from .plugin.documents import LspCodeLensCommand
 from .plugin.documents import TextChangeListener
 from .plugin.edit import LspApplyDocumentEditCommand
 from .plugin.execute_command import LspExecuteCommand

--- a/plugin/code_lens.py
+++ b/plugin/code_lens.py
@@ -1,0 +1,185 @@
+from .core.protocol import CodeLens, Range
+from .core.typing import List, Tuple, Dict, Iterable, Generator
+from .core.registry import LspTextCommand
+from .core.registry import windows
+from .core.views import make_command_link
+from .core.views import range_to_region
+from html import escape as html_escape
+import itertools
+import sublime
+
+
+class CodeLensData:
+    __slots__ = (
+        'data',
+        'region',
+        'session_name',
+        'annotation',
+    )
+
+    def __init__(self, data: CodeLens, view: sublime.View, session_name: str) -> None:
+        self.data = data
+        self.region = range_to_region(Range.from_lsp(data['range']), view)
+        self.session_name = session_name
+        self.annotation = '...'
+        self.resolve_annotation()
+
+    def __repr__(self) -> str:
+        return 'CodeLensData(resolved={0}, region={1!r})'.format(self.is_resolved(), self.region)
+
+    def is_resolved(self) -> bool:
+        """A code lens is considered resolved if the inner data contains the 'command' key."""
+        return 'command' in self.data
+
+    def to_lsp(self) -> CodeLens:
+        copy = self.data.copy()
+        copy['session_name'] = self.session_name
+        return copy
+
+    @property
+    def small_html(self) -> str:
+        return '<small style="font-family: system">{}</small>'.format(self.annotation)
+
+    def resolve_annotation(self) -> None:
+        command = self.data.get('command')
+        if command is not None:
+            command_name = command.get('command')
+            if command_name:
+                self.annotation = make_command_link('lsp_execute', command['title'], {
+                    'session_name': self.session_name,
+                    'command_name': command_name,
+                    'command_args': command.get('arguments', []),
+                })
+            else:
+                self.annotation = html_escape(command['title'])
+        else:
+            self.annotation = '...'
+
+    def resolve(self, view: sublime.View, code_lens: CodeLens) -> None:
+        self.data = code_lens
+        self.region = range_to_region(Range.from_lsp(code_lens['range']), view)
+        self.resolve_annotation()
+
+
+class CodeLensView:
+    CODE_LENS_KEY = 'lsp_code_lens'
+
+    def __init__(self, view: sublime.View) -> None:
+        self.view = view
+        self._code_lenses = {}  # type: Dict[Tuple[int, int], List[CodeLensData]]
+
+    def clear(self) -> None:
+        self._code_lenses.clear()
+
+    def is_empty(self) -> bool:
+        return not self._code_lenses
+
+    def clear_annotations(self) -> None:
+        for index, _ in enumerate(self._flat_iteration()):
+            self.view.erase_regions(self._region_key(index))
+
+    def _region_key(self, index: int) -> str:
+        return '{0}.{1}'.format(self.CODE_LENS_KEY, index)
+
+    def clear_view(self) -> None:
+        self.clear_annotations()
+
+    def handle_response(self, session_name: str, response: List[CodeLens]) -> None:
+        result = [CodeLensData(data, self.view, session_name) for data in response]
+        result.sort(key=lambda c: c.region)
+        result = {
+            region.to_tuple(): list(groups)
+            for region, groups in itertools.groupby(result, key=lambda c: c.region)
+        }
+
+        # Fast path: no extra work to do
+        if self.is_empty():
+            self._code_lenses = result
+            return
+
+        # Update new code lenses with cached data to prevent the editor
+        # from jumping around due to some code lenses going from resolved
+        # to unresolved due to a requery of the document data
+        for key, groups in result.items():
+            try:
+                old_groups = self._code_lenses[key]
+            except KeyError:
+                continue
+
+            # It's only really safe to do this when both groups are the same
+            if len(groups) == len(old_groups):
+                for old, new in zip(old_groups, groups):
+                    # This assignment is only temporary, the resolve call in the future
+                    # will fill it in with the actual data after resolve_annotation() is called
+                    # However assigning the annotation if they're the same makes the screen not jump
+                    # from the phantoms moving around too much
+                    new.annotation = old.annotation
+
+        self._code_lenses = result
+
+    def _flat_iteration(self) -> Iterable[CodeLensData]:
+        for group in self._code_lenses.values():
+            yield from group
+
+    def unresolved_visible_code_lens(self, visible: sublime.Region) -> Iterable[CodeLensData]:
+        for lens in self._flat_iteration():
+            if not lens.is_resolved() and visible.intersects(lens.region):
+                yield lens
+
+    def resolved_code_lens(self) -> Iterable[CodeLensData]:
+        for lens in self._flat_iteration():
+            if lens.is_resolved():
+                yield lens
+
+    def render(self) -> None:
+        accent = self.view.style_for_scope("region.greenish markup.accent.codelens.lsp")["foreground"]
+        for index, lens in enumerate(self._flat_iteration()):
+            self.view.add_regions(self._region_key(index), [lens.region], "", "", 0, [lens.small_html], accent)
+
+    def get_resolved_code_lenses_for_region(self, region: sublime.Region) -> Generator[CodeLens, None, None]:
+        region = self.view.line(region)
+        for lens in self._flat_iteration():
+            if lens.is_resolved() and lens.region.intersects(region):
+                yield lens.to_lsp()
+
+
+class LspCodeLensCommand(LspTextCommand):
+
+    def run(self, edit: sublime.Edit) -> None:
+        listener = windows.listener_for_view(self.view)
+        if not listener:
+            return
+        code_lenses = []  # type: List[CodeLens]
+        for region in self.view.sel():
+            for sv in listener.session_views_async():
+                code_lenses.extend(sv.get_resolved_code_lenses_for_region(region))
+        if not code_lenses:
+            return
+        elif len(code_lenses) == 1:
+            command = code_lenses[0]["command"]
+            assert command
+            args = {
+                "session_name": code_lenses[0]["session_name"],
+                "command_name": command["command"],
+                "command_args": command["arguments"]
+            }
+            self.view.run_command("lsp_execute", args)
+        else:
+            self.view.show_popup_menu(
+                [c["command"]["title"] for c in code_lenses],  # type: ignore
+                lambda i: self.on_select(code_lenses, i)
+            )
+
+    def on_select(self, code_lenses: List[CodeLens], index: int) -> None:
+        try:
+            code_lens = code_lenses[index]
+        except IndexError:
+            return
+        command = code_lens["command"]
+        assert command
+        args = {
+            "session_name": code_lens["session_name"],
+            "command_name": command["command"],
+            "command_args": command["arguments"]
+        }
+        self.view.run_command("lsp_execute", args)

--- a/plugin/code_lens.py
+++ b/plugin/code_lens.py
@@ -85,12 +85,12 @@ class CodeLensView:
         self.clear_annotations()
 
     def handle_response(self, session_name: str, response: List[CodeLens]) -> None:
-        result = [CodeLensData(data, self.view, session_name) for data in response]
-        result.sort(key=lambda c: c.region)
+        responses = [CodeLensData(data, self.view, session_name) for data in response]
+        responses.sort(key=lambda c: c.region)
         result = {
             region.to_tuple(): list(groups)
-            for region, groups in itertools.groupby(result, key=lambda c: c.region)
-        }
+            for region, groups in itertools.groupby(responses, key=lambda c: c.region)
+        }  # type: Dict[Tuple[int, int], List[CodeLensData]]
 
         # Fast path: no extra work to do
         if self.is_empty():

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -8,7 +8,7 @@ from .open import open_externally
 from .progress import WindowProgressReporter
 from .promise import PackagedTask
 from .promise import Promise
-from .protocol import CodeAction, Location, LocationLink, Position
+from .protocol import CodeAction, CodeLens, Location, LocationLink, Position
 from .protocol import Command
 from .protocol import CompletionItemTag
 from .protocol import Diagnostic
@@ -338,6 +338,15 @@ class SessionViewProtocol(Protocol):
         ...
 
     def on_request_progress(self, request_id: int, params: Dict[str, Any]) -> None:
+        ...
+
+    def start_code_lenses_async(self) -> None:
+        ...
+
+    def resolve_visible_code_lenses_async(self) -> None:
+        ...
+
+    def get_resolved_code_lenses_for_region(self, region: sublime.Region) -> Generator[CodeLens, None, None]:
         ...
 
 

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -111,10 +111,6 @@ class AbstractViewListener(metaclass=ABCMeta):
         raise NotImplementedError()
 
     @abstractmethod
-    def get_resolved_code_lenses_for_region(self, region: sublime.Region) -> Iterable[CodeLens]:
-        raise NotImplementedError()
-
-    @abstractmethod
     def get_language_id(self) -> str:
         raise NotImplementedError()
 

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -6,7 +6,7 @@ from .logging import debug
 from .logging import exception_log
 from .message_request_handler import MessageRequestHandler
 from .panels import log_server_message
-from .protocol import CodeLens, Diagnostic
+from .protocol import Diagnostic
 from .protocol import Error
 from .sessions import get_plugin
 from .sessions import Logger

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -3,7 +3,6 @@ from .code_actions import CodeActionsByConfigName
 from .completion import LspResolveDocsCommand
 from .core.logging import debug
 from .core.promise import Promise
-from .core.protocol import CodeLens
 from .core.protocol import CompletionItem
 from .core.protocol import CompletionList
 from .core.protocol import Diagnostic

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -161,6 +161,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         triggers = [trigger for trigger in triggers if 'server' not in trigger]
         settings.set("auto_complete_triggers", triggers)
         self._stored_region = sublime.Region(-1, -1)
+        self._color_phantoms.update([])
         self.view.erase_status(AbstractViewListener.TOTAL_ERRORS_AND_WARNINGS_STATUS_KEY)
         self._clear_highlight_regions()
         self._clear_session_views_async()

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -1,12 +1,16 @@
+from .code_lens import CodeLensView
 from .core.progress import ViewProgressReporter
+from .core.promise import Promise
+from .core.protocol import CodeLens
 from .core.protocol import DiagnosticTag
 from .core.protocol import Notification
 from .core.protocol import Request
 from .core.sessions import Session
 from .core.settings import userprefs
 from .core.types import debounced
-from .core.typing import Any, Iterable, List, Tuple, Optional, Dict
+from .core.typing import Any, Iterable, List, Tuple, Optional, Dict, Generator
 from .core.views import DIAGNOSTIC_SEVERITY
+from .core.views import text_document_identifier
 from .core.windows import AbstractViewListener
 from .session_buffer import SessionBuffer
 from weakref import ref
@@ -37,6 +41,7 @@ class SessionView:
         self.active_requests = {}  # type: Dict[int, Request]
         self.listener = ref(listener)
         self.progress = {}  # type: Dict[int, ViewProgressReporter]
+        self._code_lenses = CodeLensView(self.view)
         settings = self.view.settings()
         buffer_id = self.view.buffer_id()
         key = (session.config.name, session.window.id(), buffer_id)
@@ -57,6 +62,7 @@ class SessionView:
     def __del__(self) -> None:
         settings = self.view.settings()  # type: sublime.Settings
         self._clear_auto_complete_triggers(settings)
+        self._code_lenses.clear_view()
         if self.session.has_capability(self.HOVER_PROVIDER_KEY):
             self._decrement_hover_count()
         # If the session is exiting then there's no point in sending textDocument/didClose and there's also no point
@@ -266,6 +272,43 @@ class SessionView:
         )
         self.progress[request_id] = progress
         return progress
+
+    # --- textDocument/codeLens ----------------------------------------------------------------------------------------
+
+    def start_code_lenses_async(self) -> None:
+        name = self.session.config.name
+        params = { 'textDocument': text_document_identifier(self.view) }
+        for request_id, request in self.active_requests.items():
+            if request.method == "codeAction/resolve":
+                self.session.send_notification(Notification("$/cancelRequest", {"id": request_id}))
+        self.session.send_request_async(
+            Request("textDocument/codeLens", params, self.view),
+            self._on_code_lenses_async
+        )
+
+    def _on_code_lenses_async(self, response: Optional[List[CodeLens]]) -> None:
+        self._code_lenses.clear_annotations()
+        if not isinstance(response, list):
+            return
+        self._code_lenses.handle_response(self.session.config.name, response)
+        self.resolve_visible_code_lenses_async()
+
+    def resolve_visible_code_lenses_async(self) -> None:
+        if self._code_lenses.is_empty():
+            self.start_code_lenses_async()
+            return
+
+        promises = []  # type: List[Promise[None]]
+        for code_lens in self._code_lenses.unresolved_visible_code_lens(self.view.visible_region()):
+            callback = functools.partial(code_lens.resolve, self.view)
+            promise = self.session.send_request_task(
+                Request("codeLens/resolve", code_lens.data, self.view)
+            ).then(callback)
+            promises.append(promise)
+        Promise.all(promises).then(lambda _: self._code_lenses.render())
+
+    def get_resolved_code_lenses_for_region(self, region: sublime.Region) -> Generator[CodeLens, None, None]:
+        yield from self._code_lenses.get_resolved_code_lenses_for_region(region)
 
     def __str__(self) -> str:
         return '{}:{}'.format(self.session.config.name, self.view.id())

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -276,8 +276,7 @@ class SessionView:
     # --- textDocument/codeLens ----------------------------------------------------------------------------------------
 
     def start_code_lenses_async(self) -> None:
-        name = self.session.config.name
-        params = { 'textDocument': text_document_identifier(self.view) }
+        params = {'textDocument': text_document_identifier(self.view)}
         for request_id, request in self.active_requests.items():
             if request.method == "codeAction/resolve":
                 self.session.send_notification(Notification("$/cancelRequest", {"id": request_id}))


### PR DESCRIPTION
This changes the following:

* Code lens state is stored in its own class
* Code lenses are moved to SessionView instead of DocumentSyncListener
* The code lens debounce time is lowered to 300ms from 2300ms

I'm aware this is a big change. The development was discussed in the Discord server in preparation of allowing to render code lenses as phantoms. As a result the PR for that one is blocked until this one is finalised since it depends on the refactoring done here.

I tried my best to separate the code that dealt with the phantom representation but some of the data changes might still linger and seem bizarre.