### PR TITLE
New key binding context: lsp.session_with_name

### DIFF
--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -354,21 +354,27 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         self._clear_session_views_async()
 
     def on_query_context(self, key: str, operator: int, operand: Any, match_all: bool) -> bool:
+        # You can filter key bindings by the precense of a provider,
         if key == "lsp.session_with_capability" and operator == sublime.OP_EQUAL and isinstance(operand, str):
             capabilities = [s.strip() for s in operand.split("|")]
             for capability in capabilities:
                 if any(self.sessions_async(capability)):
                     return True
             return False
+        # You can filter key bindings by the precense of a specific name of a configuration.
+        elif key == "lsp.session_with_name" and operator == sublime.OP_EQUAL and isinstance(operand, str):
+            return bool(self.session_by_name(operand))
+        # You can check if there is at least one session attached to this view.
         elif key in ("lsp.sessions", "setting.lsp_active"):
             return bool(self._session_views)
+        # Signature Help handling
         elif key == "lsp.signature_help":
             if not self.view.is_popup_visible():
                 if operand == 0:
                     sublime.set_timeout_async(lambda: self.do_signature_help_async(manual=True))
                     return True
             elif self._sighelp and self._sighelp.has_multiple_signatures() and not self.view.is_auto_complete_visible():
-                # We use the "operand" for the number -1 or +1. See the keybindings.
+                # We use the "operand" for the number -1 or +1. See the key bindings.
                 self._sighelp.select_signature(operand)
                 self._update_sighelp_popup(self._sighelp.render(self.view))
                 return True  # We handled this keybinding.


### PR DESCRIPTION
Useful for helper packages like LSP-rust-analyzer. Related: https://github.com/sublimelsp/LSP-rust-analyzer/pull/14