### PR TITLE
Add API for registering an external file watcher implementation

### DIFF
--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -2,7 +2,7 @@ from .core.collections import DottedDict
 from .core.css import css
 from .core.file_watcher import FileWatcher
 from .core.file_watcher import FileWatcherEvent
-from .core.file_watcher import FileWatcherKind
+from .core.file_watcher import FileWatcherEventType
 from .core.file_watcher import FileWatcherProtocol
 from .core.file_watcher import register_file_watcher_implementation
 from .core.protocol import Notification
@@ -29,7 +29,7 @@ __all__ = [
     'filename_to_uri',
     'FileWatcher',
     'FileWatcherEvent',
-    'FileWatcherKind',
+    'FileWatcherEventType',
     'FileWatcherProtocol',
     'Notification',
     'register_file_watcher_implementation',

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -1,5 +1,10 @@
 from .core.collections import DottedDict
 from .core.css import css
+from .core.file_watcher import WatchKind
+from .core.file_watcher import WatchKindValue
+from .core.file_watcher import FileWatcher
+from .core.file_watcher import FileWatcherProtocol
+from .core.file_watcher import register_file_watcher_implementation
 from .core.protocol import Notification
 from .core.protocol import Request
 from .core.protocol import Response
@@ -21,14 +26,19 @@ __all__ = [
     'ClientConfig',
     'css',
     'DottedDict',
+    'FileWatcher',
+    'FileWatcherProtocol',
     'filename_to_uri',
     'Notification',
     'register_plugin',
+    'register_file_watcher_implementation',
     'Request',
     'Response',
     'Session',
     'SessionBufferProtocol',
     'unregister_plugin',
     'uri_to_filename',
+    'WatchKind',
+    'WatchKindValue',
     'WorkspaceFolder',
 ]

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -1,8 +1,7 @@
 from .core.collections import DottedDict
 from .core.css import css
-from .core.file_watcher import WatchKind
-from .core.file_watcher import WatchKindValue
 from .core.file_watcher import FileWatcher
+from .core.file_watcher import FileWatcherKind
 from .core.file_watcher import FileWatcherProtocol
 from .core.file_watcher import register_file_watcher_implementation
 from .core.protocol import Notification
@@ -26,19 +25,18 @@ __all__ = [
     'ClientConfig',
     'css',
     'DottedDict',
-    'FileWatcher',
-    'FileWatcherProtocol',
     'filename_to_uri',
+    'FileWatcher',
+    'FileWatcherKind',
+    'FileWatcherProtocol',
     'Notification',
-    'register_plugin',
     'register_file_watcher_implementation',
+    'register_plugin',
     'Request',
     'Response',
     'Session',
     'SessionBufferProtocol',
     'unregister_plugin',
     'uri_to_filename',
-    'WatchKind',
-    'WatchKindValue',
     'WorkspaceFolder',
 ]

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -1,6 +1,7 @@
 from .core.collections import DottedDict
 from .core.css import css
 from .core.file_watcher import FileWatcher
+from .core.file_watcher import FileWatcherEvent
 from .core.file_watcher import FileWatcherKind
 from .core.file_watcher import FileWatcherProtocol
 from .core.file_watcher import register_file_watcher_implementation
@@ -27,6 +28,7 @@ __all__ = [
     'DottedDict',
     'filename_to_uri',
     'FileWatcher',
+    'FileWatcherEvent',
     'FileWatcherKind',
     'FileWatcherProtocol',
     'Notification',

--- a/plugin/core/file_watcher.py
+++ b/plugin/core/file_watcher.py
@@ -1,0 +1,76 @@
+from .typing import List, Optional, Protocol, Tuple, Type
+from abc import ABCMeta
+from abc import abstractmethod
+
+
+DEFAULT_IGNORES = ['**/.git/**', '**/node_modules/**', '**/.hg/**']
+
+WatchKind = int
+FilePath = str
+FileEvent = Tuple[WatchKind, FilePath]
+
+
+class WatchKindValue:
+    CREATE = 1
+    CHANGE = 2
+    DELETE = 4
+
+
+WATCHER_TYPE_TO_KIND = {
+    'create': WatchKindValue.CREATE,
+    'change': WatchKindValue.CHANGE,
+    'delete': WatchKindValue.DELETE,
+}
+
+
+class FileWatcherProtocol(Protocol):
+    def on_file_event(self, events: List[FileEvent]) -> None:
+        ...
+
+
+class FileWatcher(metaclass=ABCMeta):
+    """
+    A public interface of a file watcher implementation.
+    """
+
+    @classmethod
+    @abstractmethod
+    def create(
+        cls,
+        root_path: str,
+        glob: str,
+        kind: WatchKind,
+        ignores: List[str],
+        handler: FileWatcherProtocol
+    ) -> 'FileWatcher':
+        """
+        Creates a new instance of the file watcher.
+
+        :param glob: The glob pattern to enable watching for.
+        :param kind: The kind of events that should be watched.
+        :param ignores: The list of glob patterns that should excluded from file watching.
+
+        :returns: A new instance of file watcher.
+        """
+        pass
+
+    @abstractmethod
+    def destroy(self) -> None:
+        """
+        Called before the file watcher is disabled.
+        """
+        pass
+
+
+watcher_implementation = None  # type: Optional[Type[FileWatcher]]
+
+
+def register_file_watcher_implementation(file_watcher: Type[FileWatcher]) -> None:
+    global watcher_implementation
+    if watcher_implementation:
+        print('LSP: Watcher implementation already registered. Overwriting.')
+    watcher_implementation = file_watcher
+
+
+def get_file_watcher_implementation() -> Optional[Type[FileWatcher]]:
+    return watcher_implementation

--- a/plugin/core/file_watcher.py
+++ b/plugin/core/file_watcher.py
@@ -32,13 +32,22 @@ def file_watcher_kind_to_lsp_file_change_type(kind: FileWatcherKind) -> FileChan
 
 
 class FileWatcherProtocol(Protocol):
-    def on_file_event(self, events: List[FileWatcherEvent]) -> None:
+    def on_file_event_async(self, events: List[FileWatcherEvent]) -> None:
+        """
+        Called on file watcher events.
+        This API must be triggered on async thread.
+
+        :param events: The list of events to notify about.
+        """
         ...
 
 
 class FileWatcher(metaclass=ABCMeta):
     """
     A public interface of a file watcher implementation.
+
+    The interface implements the file watcher and notifies the `handler` (through the `on_file_event_async` method)
+    on file event changes.
     """
 
     @classmethod

--- a/plugin/core/file_watcher.py
+++ b/plugin/core/file_watcher.py
@@ -55,16 +55,16 @@ class FileWatcher(metaclass=ABCMeta):
     def create(
         cls,
         root_path: str,
-        glob: str,
-        kind: List[FileWatcherKind],
+        pattern: str,
+        events: List[FileWatcherKind],
         ignores: List[str],
         handler: FileWatcherProtocol
     ) -> 'FileWatcher':
         """
         Creates a new instance of the file watcher.
 
-        :param glob: The glob pattern to enable watching for.
-        :param kind: The kind of events that should be watched.
+        :param pattern: The glob pattern to enable watching for.
+        :param events: The type of events that should be watched.
         :param ignores: The list of glob patterns that should excluded from file watching.
 
         :returns: A new instance of file watcher.

--- a/plugin/core/file_watcher.py
+++ b/plugin/core/file_watcher.py
@@ -7,23 +7,23 @@ from abc import abstractmethod
 DEFAULT_IGNORES = ['**/.git/**', '**/node_modules/**', '**/.hg/**']
 DEFAULT_KIND = WatchKindCreate | WatchKindChange | WatchKindDelete
 
-FileWatcherKind = Union[Literal['create'], Literal['change'], Literal['delete']]
+FileWatcherEventType = Union[Literal['create'], Literal['change'], Literal['delete']]
 FilePath = str
-FileWatcherEvent = Tuple[FileWatcherKind, FilePath]
+FileWatcherEvent = Tuple[FileWatcherEventType, FilePath]
 
 
-def lsp_watch_kind_to_file_watcher_kind(kind: WatchKind) -> List[FileWatcherKind]:
-    kinds = []  # type: List[FileWatcherKind]
+def lsp_watch_kind_to_file_watcher_event_types(kind: WatchKind) -> List[FileWatcherEventType]:
+    event_types = []  # type: List[FileWatcherEventType]
     if kind & WatchKindCreate:
-        kinds.append('create')
+        event_types.append('create')
     if kind & WatchKindChange:
-        kinds.append('change')
+        event_types.append('change')
     if kind & WatchKindDelete:
-        kinds.append('delete')
-    return kinds
+        event_types.append('delete')
+    return event_types
 
 
-def file_watcher_kind_to_lsp_file_change_type(kind: FileWatcherKind) -> FileChangeType:
+def file_watcher_event_type_to_lsp_file_change_type(kind: FileWatcherEventType) -> FileChangeType:
     return {
         'create': FileChangeTypeCreated,
         'change': FileChangeTypeChanged,
@@ -56,7 +56,7 @@ class FileWatcher(metaclass=ABCMeta):
         cls,
         root_path: str,
         pattern: str,
-        events: List[FileWatcherKind],
+        events: List[FileWatcherEventType],
         ignores: List[str],
         handler: FileWatcherProtocol
     ) -> 'FileWatcher':

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -218,8 +218,23 @@ FileSystemWatcher = TypedDict('FileSystemWatcher', {
     'kind': int,
 }, total=True)
 
-DidChangeWatchedFilesRegistrationOptions  = TypedDict('DidChangeWatchedFilesRegistrationOptions', {
+DidChangeWatchedFilesRegistrationOptions = TypedDict('DidChangeWatchedFilesRegistrationOptions', {
     'watchers': List[FileSystemWatcher],
+}, total=True)
+
+WatchKind = int
+WatchKindCreate = 1
+WatchKindChange = 2
+WatchKindDelete = 4
+
+FileChangeType = int
+FileChangeTypeCreated = 1
+FileChangeTypeChanged = 2
+FileChangeTypeDeleted = 3
+
+FileEvent = TypedDict("FileEvent", {
+    "uri": DocumentUri,
+    "type": FileChangeType,
 }, total=True)
 
 

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -206,12 +206,21 @@ CompletionList = TypedDict('CompletionList', {
     'items': List[CompletionItem],
 }, total=True)
 
-
 PublishDiagnosticsParams = TypedDict('PublishDiagnosticsParams', {
     'uri': DocumentUri,
     'version': Optional[int],
     'diagnostics': List[Diagnostic],
 }, total=False)
+
+
+FileSystemWatcher = TypedDict('FileSystemWatcher', {
+    'globPattern': str,
+    'kind': int,
+}, total=True)
+
+DidChangeWatchedFilesRegistrationOptions  = TypedDict('DidChangeWatchedFilesRegistrationOptions', {
+    'watchers': List[FileSystemWatcher],
+}, total=True)
 
 
 class Request:
@@ -376,6 +385,10 @@ class Notification:
     @classmethod
     def didChangeConfiguration(cls, params: dict) -> 'Notification':
         return Notification("workspace/didChangeConfiguration", params)
+
+    @classmethod
+    def didChangeWatchedFiles(cls, params: dict) -> 'Notification':
+        return Notification("workspace/didChangeWatchedFiles", params)
 
     @classmethod
     def didChangeWorkspaceFolders(cls, params: dict) -> 'Notification':

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -965,7 +965,7 @@ class Session(TransportCallbacks):
 
     # --- FileWatcherProtocol ------------------------------------------------------------------------------------------
 
-    def on_file_event(self, events: List[FileWatcherEvent]) -> None:
+    def on_file_event_async(self, events: List[FileWatcherEvent]) -> None:
         changes = []  # type: List[FileEvent]
         for event in events:
             kind, filepath = event

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1063,12 +1063,12 @@ class Session(TransportCallbacks):
             debug('{}: supported code action kinds: {}'.format(self.config.name, code_action_kinds))
         if self._watcher_impl:
             config = self.config.file_watcher
-            glob = config.get('glob')
-            if glob:
-                kind = config.get('kind') or ['create', 'change', 'delete']
+            pattern = config.get('pattern')
+            if pattern:
+                events = config.get('events') or ['create', 'change', 'delete']
                 ignores = config.get('ignores') or DEFAULT_IGNORES
                 for folder in self.get_workspace_folders():
-                    watcher = self._watcher_impl.create(folder.path, glob, kind, ignores, self)
+                    watcher = self._watcher_impl.create(folder.path, pattern, events, ignores, self)
                     self._static_file_watchers.append(watcher)
         if self._init_callback:
             self._init_callback(self, False)
@@ -1292,10 +1292,10 @@ class Session(TransportCallbacks):
                 capability_options = cast(DidChangeWatchedFilesRegistrationOptions, options)
                 file_watchers = []  # type: List[FileWatcher]
                 for config in capability_options.get("watchers", []):
-                    glob = config.get("globPattern", '')
+                    pattern = config.get("globPattern", '')
                     kind = lsp_watch_kind_to_file_watcher_kind(config.get("kind") or DEFAULT_KIND)
                     for folder in self.get_workspace_folders():
-                        watcher = self._watcher_impl.create(folder.path, glob, kind, DEFAULT_IGNORES, self)
+                        watcher = self._watcher_impl.create(folder.path, pattern, kind, DEFAULT_IGNORES, self)
                         file_watchers.append(watcher)
                 self._dynamic_file_watchers[registration_id] = file_watchers
         self.send_response(Response(request_id, None))

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1290,11 +1290,10 @@ class Session(TransportCallbacks):
             debug("{}: unregistering capability:".format(self.config.name), capability_path)
             data = self._registrations.pop(registration_id, None)
             if self._watcher_impl and capability_path == "workspace.didChangeWatchedFiles":
-                file_watchers = self._dynamic_file_watchers.get(registration_id)
+                file_watchers = self._dynamic_file_watchers.pop(registration_id, None)
                 if file_watchers:
                     for file_watcher in file_watchers:
                         file_watcher.destroy()
-                    del self._dynamic_file_watchers[registration_id]
             if data and not data.selector:
                 discarded = self.capabilities.unregister(registration_id, capability_path, registration_path)
                 # We must inform our SessionViews of the removed capabilities, in case it's for instance a hoverProvider

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -973,7 +973,6 @@ class Session(TransportCallbacks):
                 'uri': filename_to_uri(filepath),
                 'type': file_watcher_kind_to_lsp_file_change_type(kind),
             })
-        print(self.config.name, changes)
         self.send_notification(Notification.didChangeWatchedFiles({'changes': changes}))
 
     # --- misc methods -------------------------------------------------------------------------------------------------
@@ -1255,7 +1254,7 @@ class Session(TransportCallbacks):
                     # Inform only after the response is sent, otherwise we might start doing requests for capabilities
                     # which are technically not yet done registering.
                     sublime.set_timeout_async(inform)
-            if self._watcher_impl and capability_path == "workspace.didChangeWatchedFiles":
+            if self._watcher_impl and capability_path == "didChangeWatchedFilesProvider":
                 capability_options = cast(DidChangeWatchedFilesRegistrationOptions, options)
                 file_watchers = []  # type: List[FileWatcher]
                 for config in capability_options.get("watchers", []):

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -3,11 +3,11 @@ from .edit import apply_workspace_edit
 from .edit import parse_workspace_edit
 from .file_watcher import DEFAULT_IGNORES
 from .file_watcher import DEFAULT_KIND
-from .file_watcher import file_watcher_kind_to_lsp_file_change_type
+from .file_watcher import file_watcher_event_type_to_lsp_file_change_type
 from .file_watcher import FileWatcher
 from .file_watcher import FileWatcherEvent
 from .file_watcher import get_file_watcher_implementation
-from .file_watcher import lsp_watch_kind_to_file_watcher_kind
+from .file_watcher import lsp_watch_kind_to_file_watcher_event_types
 from .logging import debug
 from .logging import exception_log
 from .open import center_selection
@@ -998,10 +998,10 @@ class Session(TransportCallbacks):
     def on_file_event_async(self, events: List[FileWatcherEvent]) -> None:
         changes = []  # type: List[FileEvent]
         for event in events:
-            kind, filepath = event
+            event_type, filepath = event
             changes.append({
                 'uri': filename_to_uri(filepath),
-                'type': file_watcher_kind_to_lsp_file_change_type(kind),
+                'type': file_watcher_event_type_to_lsp_file_change_type(event_type),
             })
         self.send_notification(Notification.didChangeWatchedFiles({'changes': changes}))
 
@@ -1293,7 +1293,7 @@ class Session(TransportCallbacks):
                 file_watchers = []  # type: List[FileWatcher]
                 for config in capability_options.get("watchers", []):
                     pattern = config.get("globPattern", '')
-                    kind = lsp_watch_kind_to_file_watcher_kind(config.get("kind") or DEFAULT_KIND)
+                    kind = lsp_watch_kind_to_file_watcher_event_types(config.get("kind") or DEFAULT_KIND)
                     for folder in self.get_workspace_folders():
                         watcher = self._watcher_impl.create(folder.path, pattern, kind, DEFAULT_IGNORES, self)
                         file_watchers.append(watcher)

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -1,7 +1,8 @@
 from .collections import DottedDict
+from .file_watcher import FileWatcherKind
 from .logging import debug, set_debug_logging
 from .protocol import TextDocumentSyncKindNone
-from .typing import Any, Optional, List, Dict, Generator, Callable, Iterable, Union, Set, Tuple, TypeVar
+from .typing import Any, Optional, List, Dict, Generator, Callable, Iterable, Union, Set, Tuple, TypedDict, TypeVar
 from .url import filename_to_uri
 from .url import uri_to_filename
 from threading import RLock
@@ -19,6 +20,12 @@ FEATURES_TIMEOUT = 300  # milliseconds
 
 PANEL_FILE_REGEX = r"^(?!\s+\d+:\d+)(.*)(:)$"
 PANEL_LINE_REGEX = r"^\s+(\d+):(\d+)"
+
+FileWatcherConfig = TypedDict("FileWatcherConfig", {
+    "glob": Optional[str],
+    "kind": Optional[List[FileWatcherKind]],
+    "ignores": Optional[List[str]],
+}, total=False)
 
 
 def basescope2languageid(base_scope: str) -> str:
@@ -542,7 +549,7 @@ class ClientConfig:
                  env: Dict[str, str] = {},
                  experimental_capabilities: Optional[Dict[str, Any]] = None,
                  disabled_capabilities: DottedDict = DottedDict(),
-                 file_watcher: Optional[Dict[str, Any]] = None,
+                 file_watcher: FileWatcherConfig = {},
                  path_maps: Optional[List[PathMap]] = None) -> None:
         self.name = name
         self.selector = selector
@@ -590,7 +597,7 @@ class ClientConfig:
             env=read_dict_setting(s, "env", {}),
             experimental_capabilities=s.get("experimental_capabilities"),
             disabled_capabilities=disabled_capabilities,
-            file_watcher=s.get("file_watcher"),
+            file_watcher=s.get("file_watcher", {}),
             path_maps=PathMap.parse(s.get("path_maps"))
         )
 
@@ -614,7 +621,7 @@ class ClientConfig:
             env=d.get("env", dict()),
             experimental_capabilities=d.get("experimental_capabilities"),
             disabled_capabilities=disabled_capabilities,
-            file_watcher=d.get("file_watcher"),
+            file_watcher=d.get("file_watcher", dict()),
             path_maps=PathMap.parse(d.get("path_maps"))
         )
 

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -1,5 +1,5 @@
 from .collections import DottedDict
-from .file_watcher import FileWatcherKind
+from .file_watcher import FileWatcherEventType
 from .logging import debug, set_debug_logging
 from .protocol import TextDocumentSyncKindNone
 from .typing import Any, Optional, List, Dict, Generator, Callable, Iterable, Union, Set, Tuple, TypedDict, TypeVar
@@ -26,7 +26,7 @@ PANEL_LINE_REGEX = r"^\s+(\d+):(\d+)"
 
 FileWatcherConfig = TypedDict("FileWatcherConfig", {
     "pattern": Optional[str],
-    "events": Optional[List[FileWatcherKind]],
+    "events": Optional[List[FileWatcherEventType]],
     "ignores": Optional[List[str]],
 }, total=False)
 

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -2,7 +2,7 @@ from .collections import DottedDict
 from .file_watcher import FileWatcherKind
 from .logging import debug, set_debug_logging
 from .protocol import TextDocumentSyncKindNone
-from .typing import Any, Optional, List, Dict, Generator, Callable, Iterable, Union, Set, Tuple, TypedDict, TypeVar
+from .typing import Any, cast, Optional, List, Dict, Generator, Callable, Iterable, Union, Set, Tuple, TypedDict, TypeVar
 from .url import filename_to_uri
 from .url import uri_to_filename
 from threading import RLock
@@ -579,6 +579,7 @@ class ClientConfig:
         init_options = DottedDict(base.get("initializationOptions", {}))
         init_options.update(read_dict_setting(s, "initializationOptions", {}))
         disabled_capabilities = s.get("disabled_capabilities")
+        file_watcher = cast(FileWatcherConfig, read_dict_setting(s, "file_watcher", {}))
         if isinstance(disabled_capabilities, dict):
             disabled_capabilities = DottedDict(disabled_capabilities)
         else:
@@ -597,7 +598,7 @@ class ClientConfig:
             env=read_dict_setting(s, "env", {}),
             experimental_capabilities=s.get("experimental_capabilities"),
             disabled_capabilities=disabled_capabilities,
-            file_watcher=s.get("file_watcher", {}),
+            file_watcher=file_watcher,
             path_maps=PathMap.parse(s.get("path_maps"))
         )
 

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -2,7 +2,8 @@ from .collections import DottedDict
 from .file_watcher import FileWatcherKind
 from .logging import debug, set_debug_logging
 from .protocol import TextDocumentSyncKindNone
-from .typing import Any, cast, Optional, List, Dict, Generator, Callable, Iterable, Union, Set, Tuple, TypedDict, TypeVar
+from .typing import Any, Optional, List, Dict, Generator, Callable, Iterable, Union, Set, Tuple, TypedDict, TypeVar
+from .typing import cast
 from .url import filename_to_uri
 from .url import uri_to_filename
 from threading import RLock

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -542,6 +542,7 @@ class ClientConfig:
                  env: Dict[str, str] = {},
                  experimental_capabilities: Optional[Dict[str, Any]] = None,
                  disabled_capabilities: DottedDict = DottedDict(),
+                 file_watcher: Optional[Dict[str, Any]] = None,
                  path_maps: Optional[List[PathMap]] = None) -> None:
         self.name = name
         self.selector = selector
@@ -559,6 +560,7 @@ class ClientConfig:
         self.env = env
         self.experimental_capabilities = experimental_capabilities
         self.disabled_capabilities = disabled_capabilities
+        self.file_watcher = file_watcher
         self.path_maps = path_maps
         self.status_key = "lsp_{}".format(self.name)
 
@@ -588,6 +590,7 @@ class ClientConfig:
             env=read_dict_setting(s, "env", {}),
             experimental_capabilities=s.get("experimental_capabilities"),
             disabled_capabilities=disabled_capabilities,
+            file_watcher=s.get("file_watcher"),
             path_maps=PathMap.parse(s.get("path_maps"))
         )
 
@@ -611,6 +614,7 @@ class ClientConfig:
             env=d.get("env", dict()),
             experimental_capabilities=d.get("experimental_capabilities"),
             disabled_capabilities=disabled_capabilities,
+            file_watcher=d.get("file_watcher"),
             path_maps=PathMap.parse(d.get("path_maps"))
         )
 
@@ -637,6 +641,7 @@ class ClientConfig:
             experimental_capabilities=override.get(
                 "experimental_capabilities", src_config.experimental_capabilities),
             disabled_capabilities=disabled_capabilities,
+            file_watcher=override.get("file_watcher", src_config.file_watcher),
             path_maps=path_map_override if path_map_override else src_config.path_maps
         )
 

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -25,8 +25,8 @@ PANEL_FILE_REGEX = r"^(?!\s+\d+:\d+)(.*)(:)$"
 PANEL_LINE_REGEX = r"^\s+(\d+):(\d+)"
 
 FileWatcherConfig = TypedDict("FileWatcherConfig", {
-    "glob": Optional[str],
-    "kind": Optional[List[FileWatcherKind]],
+    "pattern": Optional[str],
+    "events": Optional[List[FileWatcherKind]],
     "ignores": Optional[List[str]],
 }, total=False)
 

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -280,10 +280,7 @@ class SessionView:
         for request_id, request in self.active_requests.items():
             if request.method == "codeAction/resolve":
                 self.session.send_notification(Notification("$/cancelRequest", {"id": request_id}))
-        self.session.send_request_async(
-            Request("textDocument/codeLens", params, self.view),
-            self._on_code_lenses_async
-        )
+        self.session.send_request_async(Request("textDocument/codeLens", params, self.view), self._on_code_lenses_async)
 
     def _on_code_lenses_async(self, response: Optional[List[CodeLens]]) -> None:
         self._code_lenses.clear_annotations()

--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -485,7 +485,7 @@ class Window:
     def project_data(self) -> Optional[dict]:
         ...
 
-    def set_project_data(self, v: dict) -> None:
+    def set_project_data(self, v: Union[dict, None]) -> None:
         ...
 
     def settings(self) -> Settings:

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -26,6 +26,41 @@
               "type": "string",
               "deprecationMessage": "Use the \"selector\" key instead."
             },
+            "FileWatcher": {
+              "type": "object",
+              "examples": [
+                {
+                  "glob": "{**/*.js,**/*.ts,**/*.json}",
+                  "kind": ["create", "change", "delete"],
+                  "ignores": ["**/.git/**", "**/node_modules/**", "**/.hg/**"]
+                }
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "glob": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "create",
+                      "change",
+                      "delete"
+                    ]
+                  },
+                  "uniqueItems": true
+                },
+                "ignores": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true
+                }
+              }
+            },
             "ClientCommand": {
               "type": "array",
               "default": [
@@ -94,6 +129,9 @@
                 },
                 "enabled": {
                   "$ref": "sublime://settings/LSP#/definitions/ClientEnabled"
+                },
+                "file_watcher": {
+                  "$ref": "sublime://settings/LSP#/definitions/FileWatcher"
                 },
                 "tcp_port": {
                   "type": "integer",
@@ -425,6 +463,9 @@
             },
             "enabled": {
               "$ref": "sublime://settings/LSP#/definitions/ClientEnabled"
+            },
+            "file_watcher": {
+              "$ref": "sublime://settings/LSP#/definitions/FileWatcher"
             },
             "selector": {
               "$ref": "sublime://settings/LSP#/definitions/ClientSelector"

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -30,17 +30,17 @@
               "type": "object",
               "examples": [
                 {
-                  "glob": "{**/*.js,**/*.ts,**/*.json}",
-                  "kind": ["create", "change", "delete"],
+                  "pattern": "{**/*.js,**/*.ts,**/*.json}",
+                  "events": ["create", "change", "delete"],
                   "ignores": ["**/.git/**", "**/node_modules/**", "**/.hg/**"]
                 }
               ],
               "additionalProperties": false,
               "properties": {
-                "glob": {
+                "pattern": {
                   "type": "string"
                 },
-                "kind": {
+                "events": {
                   "type": "array",
                   "items": {
                     "type": "string",

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -106,7 +106,7 @@ class TextDocumentTestCase(DeferrableTestCase):
             "timeout": TIMEOUT_TIME}
         cls.session = cls.wm.get_session(cls.config.name, filename)
         yield {"condition": lambda: cls.session.state == ClientStates.READY, "timeout": TIMEOUT_TIME}
-        yield from cls.await_message("initialize")
+        cls.initialize_params = yield from cls.await_message("initialize")
         yield from cls.await_message("initialized")
         yield from close_test_view(cls.view)
 

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -4,7 +4,7 @@ from LSP.plugin import FileWatcherKind
 from LSP.plugin import FileWatcherProtocol
 from LSP.plugin.core.file_watcher import file_watcher_kind_to_lsp_file_change_type
 from LSP.plugin.core.file_watcher import register_file_watcher_implementation
-from LSP.plugin.core.protocol import WatchKindChange, WatchKindCreate
+from LSP.plugin.core.protocol import WatchKindChange, WatchKindCreate, WatchKindDelete
 from LSP.plugin.core.types import ClientConfig
 from LSP.plugin.core.typing import Generator, List
 from os.path import join
@@ -154,7 +154,7 @@ class FileWatcherDynamicTests(FileWatcherDocumentTestCase):
                         'watchers': [
                             {
                                 'globPattern': '*.py',
-                                'kind': WatchKindCreate | WatchKindChange,
+                                'kind': WatchKindCreate | WatchKindChange | WatchKindDelete,
                             }
                         ]
                     }
@@ -165,7 +165,7 @@ class FileWatcherDynamicTests(FileWatcherDocumentTestCase):
         self.assertEqual(len(TestFileWatcher._active_watchers), 1)
         watcher = TestFileWatcher._active_watchers[0]
         self.assertEqual(watcher.glob, '*.py')
-        self.assertEqual(watcher.kind, ['create', 'change'])
+        self.assertEqual(watcher.kind, ['create', 'change', 'delete'])
         self.assertEqual(watcher.root_path, self.folder_root_path)
         # Trigger the file event
         filepath = join(self.folder_root_path, 'file.py')

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -1,0 +1,175 @@
+from LSP.plugin import FileWatcher
+from LSP.plugin import FileWatcherEvent
+from LSP.plugin import FileWatcherKind
+from LSP.plugin import FileWatcherProtocol
+from LSP.plugin.core.file_watcher import file_watcher_kind_to_lsp_file_change_type
+from LSP.plugin.core.file_watcher import register_file_watcher_implementation
+from LSP.plugin.core.protocol import WatchKindCreate
+from LSP.plugin.core.types import ClientConfig
+from LSP.plugin.core.typing import Generator, List
+from LSP.plugin.core.url import uri_to_filename
+from os.path import join
+from setup import expand
+from setup import TextDocumentTestCase
+import sublime
+
+
+class TestFileWatcher(FileWatcher):
+
+    # The list of watchers created by active sessions.
+    _active_watchers = []  # type: List[TestFileWatcher]
+
+    @classmethod
+    def create(
+        cls,
+        root_path: str,
+        glob: str,
+        kind: List[FileWatcherKind],
+        ignores: List[str],
+        handler: FileWatcherProtocol
+    ) -> 'TestFileWatcher':
+        watcher = TestFileWatcher(root_path, glob, kind, ignores, handler)
+        cls._active_watchers.append(watcher)
+        return watcher
+
+    def __init__(
+        self,
+        root_path: str,
+        glob: str,
+        kind: List[FileWatcherKind],
+        ignores: List[str],
+        handler: FileWatcherProtocol
+    ) -> None:
+        self.root_path = root_path
+        self.glob = glob
+        self.kind = kind
+        self.ignores = ignores
+        self.handler = handler
+
+    def destroy(self) -> None:
+        self.handler = None
+        self._active_watchers.remove(self)
+
+    def trigger_event(self, events: List[FileWatcherEvent]) -> None:
+
+        def trigger_async():
+            if self.handler:
+                self.handler.on_file_event_async(events)
+
+        sublime.set_timeout_async(trigger_async)
+
+
+class FileWatcherStaticTests(TextDocumentTestCase):
+
+    @classmethod
+    def get_stdio_test_config(cls) -> ClientConfig:
+        return ClientConfig.from_config(
+            super().get_stdio_test_config(),
+            {
+                'file_watcher': {
+                    'glob': '*.js',
+                    'kind': ['change'],
+                    'ignores': ['.git'],
+                }
+            }
+        )
+
+    @classmethod
+    def setUpClass(cls) -> Generator:
+        # Watchers are only registered when there are workspace folders so add a folder.
+        window = sublime.active_window()
+        cls.original_project_data = window.project_data()
+        cls.folder_root_path = expand(join('$packages', 'LSP', 'tests'), window)
+        window.set_project_data({
+            'folders': [
+                {
+                    'name': 'folder',
+                    'path': cls.folder_root_path,
+                }
+            ]
+        })
+        register_file_watcher_implementation(TestFileWatcher)
+        yield from super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls) -> Generator:
+        yield from super().tearDownClass()
+        # Restore original project data.
+        window = sublime.active_window()
+        window.set_project_data(cls.original_project_data)
+        cls.original_project_data = None
+
+    def test_initialize_params_includes_capability(self) -> None:
+        self.assertIn('didChangeWatchedFiles', self.initialize_params['capabilities']['textDocument'])
+
+    def test_creates_a_static_watcher(self) -> None:
+        # Starting a session should have created a watcher.
+        self.assertEqual(len(TestFileWatcher._active_watchers), 1)
+        watcher = TestFileWatcher._active_watchers[0]
+        self.assertEqual(watcher.glob, '*.js')
+        self.assertEqual(watcher.kind, ['change'])
+        self.assertEqual(watcher.ignores, ['.git'])
+        self.assertEqual(watcher.root_path, self.folder_root_path)
+
+    def test_handles_file_event(self) -> Generator:
+        watcher = TestFileWatcher._active_watchers[0]
+        filepath = join(self.folder_root_path, 'file.js')
+        watcher.trigger_event([('change', filepath)])
+        sent_notification = yield from self.await_message('workspace/didChangeWatchedFiles')
+        self.assertIs(type(sent_notification['changes']), list)
+        self.assertEqual(len(sent_notification['changes']), 1)
+        change = sent_notification['changes'][0]
+        self.assertEqual(change['type'], file_watcher_kind_to_lsp_file_change_type('change'))
+        self.assertEqual(uri_to_filename(change['uri']), filepath)
+
+
+class FileWatcherDynamicTests(TextDocumentTestCase):
+
+    @classmethod
+    def setUpClass(cls) -> Generator:
+        # Watchers are only registered when there are workspace folders so add a folder.
+        window = sublime.active_window()
+        cls.original_project_data = window.project_data()
+        cls.folder_root_path = expand(join('$packages', 'LSP', 'tests'), window)
+        window.set_project_data({
+            'folders': [
+                {
+                    'name': 'folder',
+                    'path': cls.folder_root_path,
+                }
+            ]
+        })
+        register_file_watcher_implementation(TestFileWatcher)
+        yield from super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls) -> Generator:
+        yield from super().tearDownClass()
+        # Restore original project data.
+        window = sublime.active_window()
+        window.set_project_data(cls.original_project_data)
+        cls.original_project_data = None
+
+    def test_handles_dynamic_watcher_registration(self) -> Generator:
+        registration_params = {
+            'registrations': [
+                {
+                    'id': '111',
+                    'method': 'workspace/didChangeWatchedFiles',
+                    'registerOptions': {
+                        'watchers': [
+                            {
+                                'globPattern': '*.py',
+                                'kind': WatchKindCreate,
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+        yield self.make_server_do_fake_request('client/registerCapability', registration_params)
+        self.assertEqual(len(TestFileWatcher._active_watchers), 1)
+        watcher = TestFileWatcher._active_watchers[0]
+        self.assertEqual(watcher.glob, '*.py')
+        self.assertEqual(watcher.kind, ['create'])
+        self.assertEqual(watcher.root_path, self.folder_root_path)

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -2,7 +2,7 @@ from LSP.plugin import FileWatcher
 from LSP.plugin import FileWatcherEvent
 from LSP.plugin import FileWatcherKind
 from LSP.plugin import FileWatcherProtocol
-from LSP.plugin.core.file_watcher import FilePath, file_watcher_kind_to_lsp_file_change_type
+from LSP.plugin.core.file_watcher import file_watcher_kind_to_lsp_file_change_type
 from LSP.plugin.core.file_watcher import register_file_watcher_implementation
 from LSP.plugin.core.protocol import WatchKindChange, WatchKindCreate
 from LSP.plugin.core.types import ClientConfig

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -36,26 +36,26 @@ class TestFileWatcher(FileWatcher):
     def create(
         cls,
         root_path: str,
-        glob: str,
-        kind: List[FileWatcherKind],
+        pattern: str,
+        events: List[FileWatcherKind],
         ignores: List[str],
         handler: FileWatcherProtocol
     ) -> 'TestFileWatcher':
-        watcher = TestFileWatcher(root_path, glob, kind, ignores, handler)
+        watcher = TestFileWatcher(root_path, pattern, events, ignores, handler)
         cls._active_watchers.append(watcher)
         return watcher
 
     def __init__(
         self,
         root_path: str,
-        glob: str,
-        kind: List[FileWatcherKind],
+        pattern: str,
+        events: List[FileWatcherKind],
         ignores: List[str],
         handler: FileWatcherProtocol
     ) -> None:
         self.root_path = root_path
-        self.glob = glob
-        self.kind = kind
+        self.pattern = pattern
+        self.events = events
         self.ignores = ignores
         self.handler = handler
 
@@ -111,8 +111,8 @@ class FileWatcherStaticTests(FileWatcherDocumentTestCase):
             super().get_stdio_test_config(),
             {
                 'file_watcher': {
-                    'glob': '*.js',
-                    'kind': ['change'],
+                    'pattern': '*.js',
+                    'events': ['change'],
                     'ignores': ['.git'],
                 }
             }
@@ -125,8 +125,8 @@ class FileWatcherStaticTests(FileWatcherDocumentTestCase):
         # Starting a session should have created a watcher.
         self.assertEqual(len(TestFileWatcher._active_watchers), 1)
         watcher = TestFileWatcher._active_watchers[0]
-        self.assertEqual(watcher.glob, '*.js')
-        self.assertEqual(watcher.kind, ['change'])
+        self.assertEqual(watcher.pattern, '*.js')
+        self.assertEqual(watcher.events, ['change'])
         self.assertEqual(watcher.ignores, ['.git'])
         self.assertEqual(watcher.root_path, self.folder_root_path)
 
@@ -164,8 +164,8 @@ class FileWatcherDynamicTests(FileWatcherDocumentTestCase):
         yield self.make_server_do_fake_request('client/registerCapability', registration_params)
         self.assertEqual(len(TestFileWatcher._active_watchers), 1)
         watcher = TestFileWatcher._active_watchers[0]
-        self.assertEqual(watcher.glob, '*.py')
-        self.assertEqual(watcher.kind, ['create', 'change', 'delete'])
+        self.assertEqual(watcher.pattern, '*.py')
+        self.assertEqual(watcher.events, ['create', 'change', 'delete'])
         self.assertEqual(watcher.root_path, self.folder_root_path)
         # Trigger the file event
         filepath = join(self.folder_root_path, 'file.py')

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -121,7 +121,7 @@ class FileWatcherStaticTests(FileWatcherDocumentTestCase):
     def test_initialize_params_includes_capability(self) -> None:
         self.assertIn('didChangeWatchedFiles', self.initialize_params['capabilities']['textDocument'])
 
-    def test_creates_a_static_watcher(self) -> None:
+    def test_creates_static_watcher(self) -> None:
         # Starting a session should have created a watcher.
         self.assertEqual(len(TestFileWatcher._active_watchers), 1)
         watcher = TestFileWatcher._active_watchers[0]

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -1,8 +1,8 @@
 from LSP.plugin import FileWatcher
 from LSP.plugin import FileWatcherEvent
-from LSP.plugin import FileWatcherKind
+from LSP.plugin import FileWatcherEventType
 from LSP.plugin import FileWatcherProtocol
-from LSP.plugin.core.file_watcher import file_watcher_kind_to_lsp_file_change_type
+from LSP.plugin.core.file_watcher import file_watcher_event_type_to_lsp_file_change_type
 from LSP.plugin.core.file_watcher import register_file_watcher_implementation
 from LSP.plugin.core.protocol import WatchKindChange, WatchKindCreate, WatchKindDelete
 from LSP.plugin.core.types import ClientConfig
@@ -37,7 +37,7 @@ class TestFileWatcher(FileWatcher):
         cls,
         root_path: str,
         pattern: str,
-        events: List[FileWatcherKind],
+        events: List[FileWatcherEventType],
         ignores: List[str],
         handler: FileWatcherProtocol
     ) -> 'TestFileWatcher':
@@ -49,7 +49,7 @@ class TestFileWatcher(FileWatcher):
         self,
         root_path: str,
         pattern: str,
-        events: List[FileWatcherKind],
+        events: List[FileWatcherEventType],
         ignores: List[str],
         handler: FileWatcherProtocol
     ) -> None:
@@ -138,7 +138,7 @@ class FileWatcherStaticTests(FileWatcherDocumentTestCase):
         self.assertIs(type(sent_notification['changes']), list)
         self.assertEqual(len(sent_notification['changes']), 1)
         change = sent_notification['changes'][0]
-        self.assertEqual(change['type'], file_watcher_kind_to_lsp_file_change_type('change'))
+        self.assertEqual(change['type'], file_watcher_event_type_to_lsp_file_change_type('change'))
         self.assertTrue(change['uri'].endswith('file.js'))
 
 
@@ -174,8 +174,8 @@ class FileWatcherDynamicTests(FileWatcherDocumentTestCase):
         self.assertIs(type(sent_notification['changes']), list)
         self.assertEqual(len(sent_notification['changes']), 2)
         change1 = sent_notification['changes'][0]
-        self.assertEqual(change1['type'], file_watcher_kind_to_lsp_file_change_type('create'))
+        self.assertEqual(change1['type'], file_watcher_event_type_to_lsp_file_change_type('create'))
         self.assertTrue(change1['uri'].endswith('file.py'))
         change2 = sent_notification['changes'][1]
-        self.assertEqual(change2['type'], file_watcher_kind_to_lsp_file_change_type('change'))
+        self.assertEqual(change2['type'], file_watcher_event_type_to_lsp_file_change_type('change'))
         self.assertTrue(change2['uri'].endswith('file.py'))


### PR DESCRIPTION
Allows to create external package that implements the file watcher API.

See example implementation at https://github.com/sublimelsp/LSP-file-watcher-chokidar/pull/1