### PR TITLE
Send a code lens request if one hasn't been sent yet

### DIFF
--- a/plugin/code_lens.py
+++ b/plugin/code_lens.py
@@ -66,6 +66,7 @@ class CodeLensView:
 
     def __init__(self, view: sublime.View) -> None:
         self.view = view
+        self._init = False
         self._code_lenses = {}  # type: Dict[Tuple[int, int], List[CodeLensData]]
 
     def clear(self) -> None:
@@ -73,6 +74,9 @@ class CodeLensView:
 
     def is_empty(self) -> bool:
         return not self._code_lenses
+
+    def is_initialized(self) -> bool:
+        return self._init
 
     def clear_annotations(self) -> None:
         for index, _ in enumerate(self._flat_iteration()):
@@ -85,6 +89,7 @@ class CodeLensView:
         self.clear_annotations()
 
     def handle_response(self, session_name: str, response: List[CodeLens]) -> None:
+        self._init = True
         responses = [CodeLensData(data, self.view, session_name) for data in response]
         responses.sort(key=lambda c: c.region)
         result = {

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -293,6 +293,9 @@ class SessionView:
         self.resolve_visible_code_lenses_async()
 
     def resolve_visible_code_lenses_async(self) -> None:
+        if not self._code_lenses.is_initialized():
+            self.start_code_lenses_async()
+            return
         if self._code_lenses.is_empty():
             return
         promises = []  # type: List[Promise[None]]


### PR DESCRIPTION
This is an extended fix related to #1759. The original intent of the code was to allow code lenses to be filled without resorting to
reopening the file. However, the naive implementation caused an infinite loop so it requires a separate sentinel value to differentiate between an actual empty request vs an uninitialised request.