### PR TITLE
Normalize drive letter in Windows filepaths to uppercase

### DIFF
--- a/plugin/core/url.py
+++ b/plugin/core/url.py
@@ -21,7 +21,6 @@ def filename_to_uri(file_name: str) -> str:
     if file_name.startswith(prefix) and not os.path.exists(file_name):
         return _to_resource_uri(file_name, prefix)
     path = pathname2url(file_name)
-    re.sub(r"^([A-Z]):/", _lowercase_driveletter, path)
     return urljoin("file:", path)
 
 
@@ -77,10 +76,3 @@ def _uppercase_driveletter(match: Any) -> str:
     For compatibility with Sublime's VCS status in the status bar.
     """
     return "{}:".format(match.group(1).upper())
-
-
-def _lowercase_driveletter(match: Any) -> str:
-    """
-    For compatibility with certain other language clients.
-    """
-    return "{}:/".format(match.group(1).lower())

--- a/plugin/core/url.py
+++ b/plugin/core/url.py
@@ -42,7 +42,8 @@ def uri_to_filename(uri: str) -> str:
     assert parsed.scheme == "file"
     if os.name == 'nt':
         # url2pathname does not understand %3A (VS Code's encoding forced on all servers :/)
-        return url2pathname(parsed.path).strip('\\')
+        path = url2pathname(parsed.path).strip('\\')
+        return re.sub(r"^([a-z]):", _uppercase_driveletter, path)
     else:
         return url2pathname(parsed.path)
 
@@ -69,6 +70,13 @@ def _to_resource_uri(path: str, prefix: str) -> str:
     See: https://github.com/sublimehq/sublime_text/issues/3742
     """
     return "res://Packages{}".format(quote(path[len(prefix):]))
+
+
+def _uppercase_driveletter(match: Any) -> str:
+    """
+    For compatibility with Sublime's VCS status in the status bar.
+    """
+    return "{}:".format(match.group(1).upper())
 
 
 def _lowercase_driveletter(match: Any) -> str:

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -16,7 +16,7 @@ class WindowsTests(unittest.TestCase):
     @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
     def test_converts_encoded_bad_drive_uri_to_path(self):
         # url2pathname does not understand %3A
-        self.assertEqual("c:\\dir ectory\\file.txt", uri_to_filename("file:///c%3A/dir%20ectory/file.txt"))
+        self.assertEqual("C:\\dir ectory\\file.txt", uri_to_filename("file:///c%3A/dir%20ectory/file.txt"))
 
 
 class NixTests(unittest.TestCase):


### PR DESCRIPTION
This fixes a bug with wrong labels for quick panel items after "Find References" and "Goto Definition..." if the server returns filepaths with lowercase drive letter, and also for Sublime's VCS status in the status bar when such a file link is opened.

Closes #1770.