### PR TITLE
Fix file comparisons

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -927,6 +927,8 @@ class Session(TransportCallbacks):
     def get_session_buffer_for_uri_async(self, uri: DocumentUri) -> Optional[SessionBufferProtocol]:
         scheme, parsed = parse_uri(uri)
         if scheme == "file":
+            if not os.path.exists(parsed):
+                return debug("{}: path does not exist:".format(self.config.name), uri)
 
             def compare_by_samefile(sb: Optional[SessionBufferProtocol]) -> bool:
                 if not sb:
@@ -934,10 +936,8 @@ class Session(TransportCallbacks):
                 candidate = sb.get_uri()
                 if not isinstance(candidate, str):
                     return False
-                candidate_isfile, candidate_path = parse_uri(candidate)
-                if not candidate_isfile:
-                    return False
-                return os.path.samefile(parsed, candidate_path)
+                candidate_scheme, candidate_path = parse_uri(candidate)
+                return candidate_scheme == "file" and os.path.samefile(parsed, candidate_path)
 
             predicate = compare_by_samefile
         else:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -928,7 +928,8 @@ class Session(TransportCallbacks):
         scheme, parsed = parse_uri(uri)
         if scheme == "file":
             if not os.path.exists(parsed):
-                return debug("{}: path does not exist:".format(self.config.name), uri)
+                debug("{}: path does not exist:".format(self.config.name), uri)
+                return None
 
             def compare_by_samefile(sb: Optional[SessionBufferProtocol]) -> bool:
                 if not sb:


### PR DESCRIPTION
candidate_isfile is not a bool but a str.
Also protect against bad server URIs.
For instance pyright translates

    res://Packages/symbol.py

to

    file:///Packages/symbol.py

Fixes #1774