### PR TITLE
Allow styling of code lens phantoms

### DIFF
--- a/plugin/code_lens.py
+++ b/plugin/code_lens.py
@@ -150,7 +150,8 @@ class CodeLensView:
             for key, group in self._code_lenses.items():
                 region = sublime.Region(*key)
                 phantom_region = self._get_phantom_region(region)
-                html = '\n<small style="font-family: system">|</small>\n'.join(lens.small_html for lens in group)
+                html = '<body id="lsp-code-lens">{}</body>'.format(
+                    '\n<small style="font-family: system">|</small>\n'.join(lens.small_html for lens in group))
                 phantoms.append(sublime.Phantom(phantom_region, html, sublime.LAYOUT_BELOW))
             self._phantom.update(phantoms)
         else:  # 'annotation'


### PR DESCRIPTION
I installed LSP-jdtls and dug out an old Java project to try out the new code lens phantoms, and saw that I could not target them specifically to adjust their style. Fixed it now.

Example with `"phantom_css": "html{background-color:transparent;color:var(--foreground)}a{color:var(--bluish)}#lsp-code-lens a{color:color(var(--foreground) alpha(0.5));text-decoration: none}",` in Mariana:

![codelens](https://user-images.githubusercontent.com/6579999/124364057-5ad6a980-dc3f-11eb-88bc-1b6bece417f0.png)

***

By the way, there is still a bug (and error in the console) with file URIs to filepaths conversion when I click on the phantom (or annotation). The normal references request e.g. via the context menu works. I will look into that later.