### PR TITLE
Open existing views with custom URIs

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -944,8 +944,6 @@ class Session(TransportCallbacks):
         else:
 
             def compare_by_string(sb: Optional[SessionBufferProtocol]) -> bool:
-                if not sb:
-                    return False
                 return sb.get_uri() == parsed if sb else False
 
             predicate = compare_by_string

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -929,7 +929,6 @@ class Session(TransportCallbacks):
         scheme, parsed = parse_uri(uri)
         if scheme == "file":
             if not os.path.exists(parsed):
-                debug("{}: path does not exist:".format(self.config.name), uri)
                 return None
 
             def compare_by_samefile(sb: Optional[SessionBufferProtocol]) -> bool:
@@ -943,12 +942,10 @@ class Session(TransportCallbacks):
 
             predicate = compare_by_samefile
         else:
-            print("comparing by string... searching for", parsed)
 
             def compare_by_string(sb: Optional[SessionBufferProtocol]) -> bool:
                 if not sb:
                     return False
-                print("does", sb.get_uri(), "match?")
                 return sb.get_uri() == parsed if sb else False
 
             predicate = compare_by_string

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -121,6 +121,13 @@ class SessionBuffer:
             return sv.get_language_id()
         return None
 
+    def get_view_in_group(self, group: int) -> sublime.View:
+        for sv in self.session_views:
+            view = sv.get_view_for_group(group)
+            if view:
+                return view
+        return next(iter(self.session_views)).view
+
     @property
     def language_id(self) -> str:
         """

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -160,6 +160,9 @@ class SessionView:
         listener = self.listener()
         return listener.get_language_id() if listener else None
 
+    def get_view_for_group(self, group: int) -> Optional[sublime.View]:
+        return self.view if self.view.sheet().group() == group else None
+
     def get_capability_async(self, capability_path: str) -> Optional[Any]:
         return self.session_buffer.get_capability(capability_path)
 

--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -621,6 +621,9 @@ class Sheet:
     def window(self) -> Optional[Window]:
         ...
 
+    def group(self) -> int:
+        ...
+
     def view(self) -> 'Optional[View]':
         ...
 

--- a/tests/test_single_document.py
+++ b/tests/test_single_document.py
@@ -28,6 +28,11 @@ GOTO_RESPONSE = [
                 'character': 5,
                 'line': 1
             },
+            'end':
+            {
+                'character': 5,
+                'line': 1
+            }
         }
     }
 ]

--- a/unittesting.json
+++ b/unittesting.json
@@ -3,7 +3,7 @@
     "verbosity": 0,
     "capture_console": true,
     "failfast": false,
-    "reload_package_on_testing": true,
+    "reload_package_on_testing": false,
     "start_coverage_after_reload": false,
     "show_reload_progress": false,
     "output": null,


### PR DESCRIPTION
This doesn't actually work correctly for session buffers that get a different
session attached to them. For example, when you open a remote JSON schema with
the yaml-language-server, then the vscode-json-language-server is attached to
that virtual view. In that case this code fails.

We should instead have something like a per-window iteration over all session
buffers for all session. But this works okay for now for e.g. deno.


https://user-images.githubusercontent.com/2431823/124381676-0e817d00-dcc4-11eb-8271-1136b39835ba.mov

