### PR TITLE
Even more fixes for matching up buffers with URIs

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -928,8 +928,6 @@ class Session(TransportCallbacks):
     def get_session_buffer_for_uri_async(self, uri: DocumentUri) -> Optional[SessionBufferProtocol]:
         scheme, path = parse_uri(uri)
         if scheme == "file":
-            if not os.path.exists(path):
-                return None
 
             def compare_by_samefile(sb: Optional[SessionBufferProtocol]) -> bool:
                 if not sb:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -926,9 +926,9 @@ class Session(TransportCallbacks):
         yield from self._session_buffers
 
     def get_session_buffer_for_uri_async(self, uri: DocumentUri) -> Optional[SessionBufferProtocol]:
-        scheme, parsed = parse_uri(uri)
+        scheme, path = parse_uri(uri)
         if scheme == "file":
-            if not os.path.exists(parsed):
+            if not os.path.exists(path):
                 return None
 
             def compare_by_samefile(sb: Optional[SessionBufferProtocol]) -> bool:
@@ -940,10 +940,10 @@ class Session(TransportCallbacks):
                 candidate_scheme, candidate_path = parse_uri(candidate)
                 if candidate_scheme != "file":
                     return False
-                if parsed == candidate_path:
+                if path == candidate_path:
                     return True
                 try:
-                    return os.path.samefile(parsed, candidate_path)
+                    return os.path.samefile(path, candidate_path)
                 except FileNotFoundError:
                     return False
 
@@ -951,7 +951,7 @@ class Session(TransportCallbacks):
         else:
 
             def compare_by_string(sb: Optional[SessionBufferProtocol]) -> bool:
-                return sb.get_uri() == parsed if sb else False
+                return sb.get_uri() == path if sb else False
 
             predicate = compare_by_string
         return next(filter(predicate, self.session_buffers_async()), None)

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -933,7 +933,14 @@ class Session(TransportCallbacks):
                 if not isinstance(candidate, str):
                     return False
                 candidate_scheme, candidate_path = parse_uri(candidate)
-                return candidate_scheme == "file" and os.path.samefile(parsed, candidate_path)
+                if candidate_scheme != "file":
+                    return False
+                if parsed == candidate_path:
+                    return True
+                try:
+                    return os.path.samefile(parsed, candidate_path)
+                except FileNotFoundError:
+                    return False
 
             predicate = compare_by_samefile
         else:


### PR DESCRIPTION
If the paths compare equal as strings, then we consider this a match, *even* if
the candidate file does not actually exist on-disk. This catches a case where
you delete a file on the file system but you have a view of it open in
Sublime Text. There is no callback in the API for that. And even so,
view.file_name() will still return the (now non-existing) file name.