### PR TITLE
Fix mypy type issue on windows

### DIFF
--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -236,12 +236,13 @@ def kill_all_subprocesses() -> None:
             pass
 
 
-def _fixup_startup_args(args: List[str]) -> Any:
+def _fixup_startup_args(args: List[str]) -> Optional[subprocess.STARTUPINFO]:
+    startupinfo = None  # type: Optional[subprocess.STARTUPINFO]
     if sublime.platform() == "windows":
-        startupinfo = subprocess.STARTUPINFO()  # type: ignore
-        startupinfo.dwFlags |= subprocess.SW_HIDE | subprocess.STARTF_USESHOWWINDOW  # type: ignore
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.SW_HIDE | subprocess.STARTF_USESHOWWINDOW
         executable_arg = args[0]
-        fname, ext = os.path.splitext(executable_arg)
+        _, ext = os.path.splitext(executable_arg)
         if len(ext) < 1:
             path_to_executable = shutil.which(executable_arg)
             # what extensions should we append so CreateProcess can find it?
@@ -252,8 +253,6 @@ def _fixup_startup_args(args: List[str]) -> Any:
                 if path_to_executable and path_to_executable.lower().endswith(extension):
                     args[0] = executable_arg + extension
                     break
-    else:
-        startupinfo = None
     return startupinfo
 
 

--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -239,8 +239,8 @@ def kill_all_subprocesses() -> None:
 def _fixup_startup_args(args: List[str]) -> Any:
     startupinfo = None
     if sublime.platform() == "windows":
-        startupinfo = subprocess.STARTUPINFO()
-        startupinfo.dwFlags |= subprocess.SW_HIDE | subprocess.STARTF_USESHOWWINDOW
+        startupinfo = subprocess.STARTUPINFO()  # type: ignore
+        startupinfo.dwFlags |= subprocess.SW_HIDE | subprocess.STARTF_USESHOWWINDOW  # type: ignore
         executable_arg = args[0]
         _, ext = os.path.splitext(executable_arg)
         if len(ext) < 1:

--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -236,8 +236,8 @@ def kill_all_subprocesses() -> None:
             pass
 
 
-def _fixup_startup_args(args: List[str]) -> Optional[subprocess.STARTUPINFO]:
-    startupinfo = None  # type: Optional[subprocess.STARTUPINFO]
+def _fixup_startup_args(args: List[str]) -> Any:
+    startupinfo = None
     if sublime.platform() == "windows":
         startupinfo = subprocess.STARTUPINFO()
         startupinfo.dwFlags |= subprocess.SW_HIDE | subprocess.STARTF_USESHOWWINDOW


### PR DESCRIPTION
It complained about this:

```
plugin\core\transports.py:256: error: Incompatible types in assignment (expression has type "None", variable has type "STARTUPINFO")
```