### PR TITLE
LSP-Serenata doesn't support ST4

### DIFF
--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -311,15 +311,7 @@ Follow installation instructions on [LSP-promql](https://github.com/prometheus-c
 
 ## PHP
 
-There are multiple options:
-
-### Intelephense
-
 Follow installation instructions on [LSP-intelephense](https://github.com/sublimelsp/LSP-intelephense).
-
-### Serenata
-
-Follow installation instructions on [LSP-serenata](https://github.com/Cloudstek/LSP-serenata).
 
 ## PowerShell
 


### PR DESCRIPTION
As stated in https://github.com/Cloudstek/LSP-serenata/issues/1#issuecomment-851055572
Until LSP-serenata supports ST4 I think the only client for PHP is LSP-intelephense