### PR TITLE
Make hover popup also follow the show_diagnostics_severity_level setting

### DIFF
--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -8,6 +8,7 @@ from .message_request_handler import MessageRequestHandler
 from .panels import log_server_message
 from .promise import Promise
 from .protocol import Diagnostic
+from .protocol import DiagnosticSeverity
 from .protocol import Error
 from .protocol import Location
 from .sessions import get_plugin
@@ -82,7 +83,8 @@ class AbstractViewListener(metaclass=ABCMeta):
     @abstractmethod
     def diagnostics_touching_point_async(
         self,
-        pt: int
+        pt: int,
+        max_diagnostic_severity_level: int = DiagnosticSeverity.Hint
     ) -> Tuple[Sequence[Tuple[SessionBufferProtocol, Sequence[Diagnostic]]], sublime.Region]:
         raise NotImplementedError()
 

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -23,6 +23,7 @@ from .core.types import SettingsRegistration
 from .core.typing import Any, Callable, Optional, Dict, Generator, Iterable, List, Tuple, Union
 from .core.url import view_to_uri
 from .core.views import DIAGNOSTIC_SEVERITY
+from .core.views import diagnostic_severity
 from .core.views import document_color_params
 from .core.views import first_selection_region
 from .core.views import format_completion
@@ -280,9 +281,13 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
     ) -> Tuple[List[Tuple[SessionBuffer, List[Diagnostic]]], sublime.Region]:
         covering = sublime.Region(pt, pt)
         result = []  # type: List[Tuple[SessionBuffer, List[Diagnostic]]]
+        max_severity_level = userprefs().show_diagnostics_severity_level
         for sb, diagnostics in self.diagnostics_async():
             intersections = []  # type: List[Diagnostic]
             for diagnostic, candidate in diagnostics:
+                severity = diagnostic_severity(diagnostic)
+                if severity > max_severity_level:
+                    continue
                 if candidate.contains(pt):
                     covering = covering.cover(candidate)
                     intersections.append(diagnostic)

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -6,6 +6,7 @@ from .core.promise import Promise
 from .core.protocol import CompletionItem
 from .core.protocol import CompletionList
 from .core.protocol import Diagnostic
+from .core.protocol import DiagnosticSeverity
 from .core.protocol import DocumentHighlightKind
 from .core.protocol import Error
 from .core.protocol import Range
@@ -277,16 +278,16 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
 
     def diagnostics_touching_point_async(
         self,
-        pt: int
+        pt: int,
+        max_diagnostic_severity_level: int = DiagnosticSeverity.Hint
     ) -> Tuple[List[Tuple[SessionBuffer, List[Diagnostic]]], sublime.Region]:
         covering = sublime.Region(pt, pt)
         result = []  # type: List[Tuple[SessionBuffer, List[Diagnostic]]]
-        max_severity_level = userprefs().show_diagnostics_severity_level
         for sb, diagnostics in self.diagnostics_async():
             intersections = []  # type: List[Diagnostic]
             for diagnostic, candidate in diagnostics:
                 severity = diagnostic_severity(diagnostic)
-                if severity > max_severity_level:
+                if severity > max_diagnostic_severity_level:
                     continue
                 if candidate.contains(pt):
                     covering = covering.cover(candidate)
@@ -305,7 +306,8 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         if userprefs().show_diagnostics_in_view_status:
             r = self._stored_region
             if r is not None:
-                session_buffer_diagnostics, _ = self.diagnostics_touching_point_async(r.b)
+                session_buffer_diagnostics, _ = self.diagnostics_touching_point_async(
+                    r.b, userprefs().show_diagnostics_severity_level)
                 if session_buffer_diagnostics:
                     for _, diagnostics in session_buffer_diagnostics:
                         diag = next(iter(diagnostics), None)

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -102,7 +102,8 @@ class LspHoverCommand(LspTextCommand):
                 return
             if not only_diagnostics:
                 self.request_symbol_hover_async(listener, hover_point)
-            self._diagnostics_by_config, covering = listener.diagnostics_touching_point_async(hover_point)
+            self._diagnostics_by_config, covering = listener.diagnostics_touching_point_async(
+                hover_point, userprefs().show_diagnostics_severity_level)
             if self._diagnostics_by_config:
                 self.show_hover(listener, hover_point, only_diagnostics)
             if not only_diagnostics and userprefs().show_code_actions_in_hover:


### PR DESCRIPTION
This change also affects what is shown in the status bar with "show_diagnostics_in_view_status" enabled.

I don't think it would make sense to have yet another setting specifically for the hover popup and status bar.

I've tried to make test for it but we don't have ability to override or mock the global LSP settings per-test so I couldn't find a way to test it.

Fixes #1797