### PR TITLE
Rewrite / reorganize the troubleshooting documentation

### DIFF
--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -1,34 +1,3 @@
-## Common problems
-
-### 1. LSP doesn't start my language server
-
-When language server is started, its name appears on the left side of the status bar. If you expect your server to start for a particular file but it doesn't then:
-
-* Make sure that the root scope (eg. `source.php`) of the file matches the scope handled by the language server. You can check the root scope of the file by running `Show Scope Name` from the `Tools -> Developer` menu. Refer to the documentation of the language server or its own settings to know the expected scope.
-* Make sure that the language server is not disabled globally either in its own settings or in `Preferences: LSP Settings`, or in the project settings (`Project: Edit Project` from the Command Palette).
-
-### 2. LSP cannot find my language server (`No such file or directory: 'xyz'`)
-
-If you are getting an error that the server binary can't be found but it does start when running it from the terminal, then the issue is likely due to Sublime Text's internal environment not picking up the same `PATH` environment variable as you've configured in your shell.
-
-See ["Updating the PATH used by LSP servers"](troubleshooting.md#updating-the-path-used-by-lsp-servers) on how to make Sublime Text aware of the location of your langugage server.
-
-### 3. Popup error `Language server <your_server_language_name> has crashed`
-
-The reason for this can be the same as in problem number 2. Additionally, the language servers may have dependencies that should also be in your `PATH` in addition to the server binary itself.
-
-For instance if you have installed the `haskell-language-server` using [ghcup-hs](https://gitlab.haskell.org/haskell/ghcup-hs) you should expose its specific installation folder `~/.ghcup/bin`. If the build process uses `stack` then it should also be in your `PATH`.
-
-If that doesn't solve the issue, try running `LSP: Troubleshoot server` and providing its output when asking for help.
-
-## Known Issues
-
-### Completions not shown after certain keywords
-
-Sublime Text's built-in `Completion Rules.tmPreferences` for some languages suppresses completions after certain keywords.
-The solution is to put an edited version of the `Completion Rules.tmPreferences` in the `Packages` folder (you may need to clear the copy in the Cache folder afterwards).
-More details on [workaround and a final fix for Lua](https://forum.sublimetext.com/t/bug-lua-autocomplete-not-working-between-if-then/36635)
-
 ## Self-help instructions
 
 To get more visibility into the inner-workings of the LSP client and the server and be able to diagnose problems, open `Preferences: LSP Settings` from the Command Palette and set the following options:
@@ -94,3 +63,34 @@ Another solution could be (at least on Linux) to update the server `PATH` using 
     }
 }
 ```
+
+## Common problems
+
+### 1. LSP doesn't start my language server
+
+When language server is started, its name appears on the left side of the status bar. If you expect your server to start for a particular file but it doesn't then:
+
+* Make sure that the root scope (eg. `source.php`) of the file matches the scope handled by the language server. You can check the root scope of the file by running `Show Scope Name` from the `Tools -> Developer` menu. Refer to the documentation of the language server or its own settings to know the expected scope.
+* Make sure that the language server is not disabled globally either in its own settings or in `Preferences: LSP Settings`, or in the project settings (`Project: Edit Project` from the Command Palette).
+
+### 2. LSP cannot find my language server (`No such file or directory: 'xyz'`)
+
+If you are getting an error that the server binary can't be found but it does start when running it from the terminal, then the issue is likely due to Sublime Text's internal environment not picking up the same `PATH` environment variable as you've configured in your shell.
+
+See ["Updating the PATH used by LSP servers"](troubleshooting.md#updating-the-path-used-by-lsp-servers) on how to make Sublime Text aware of the location of your langugage server.
+
+### 3. Popup error `Language server <your_server_language_name> has crashed`
+
+The reason for this can be the same as in problem number 2. Additionally, the language servers may have dependencies that should also be in your `PATH` in addition to the server binary itself.
+
+For instance if you have installed the `haskell-language-server` using [ghcup-hs](https://gitlab.haskell.org/haskell/ghcup-hs) you should expose its specific installation folder `~/.ghcup/bin`. If the build process uses `stack` then it should also be in your `PATH`.
+
+If that doesn't solve the issue, try running `LSP: Troubleshoot server` and providing its output when asking for help.
+
+## Known Issues
+
+### Completions not shown after certain keywords
+
+Sublime Text's built-in `Completion Rules.tmPreferences` for some languages suppresses completions after certain keywords.
+The solution is to put an edited version of the `Completion Rules.tmPreferences` in the `Packages` folder (you may need to clear the copy in the Cache folder afterwards).
+More details on [workaround and a final fix for Lua](https://forum.sublimetext.com/t/bug-lua-autocomplete-not-working-between-if-then/36635)

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -1,3 +1,34 @@
+## Common problems
+
+### 1. LSP doesn't start my language server
+
+When language server is started, its name appears on the left side of the status bar. If you expect your server to start for a particular file but it doesn't then:
+
+* Make sure that the root scope (eg. `source.php`) of the file matches the scope handled by the language server. You can check the root scope of the file by running `Show Scope Name` from the `Tools -> Developer` menu. Refer to the documentation of the language server or its own settings to know the expected scope.
+* Make sure that the language server is not disabled globally either in its own settings or in `Preferences: LSP Settings`, or in the project settings (`Project: Edit Project` from the Command Palette).
+
+### 2. LSP cannot find my language server (`No such file or directory: 'xyz'`)
+
+If you are getting an error that the server binary can't be found but it does start when running it from the terminal, then the issue is likely due to Sublime Text's internal environment not picking up the same `PATH` environment variable as you've configured in your shell.
+
+See ["Updating the PATH used by LSP servers"](troubleshooting.md#updating-the-path-used-by-lsp-servers) on how to make Sublime Text aware of the location of your langugage server.
+
+### 3. Popup error `Language server <your_server_language_name> has crashed`
+
+The reason for this can be the same as in problem number 2. Additionally, the language servers may have dependencies that should also be in your `PATH` in addition to the server binary itself.
+
+For instance if you have installed the `haskell-language-server` using [ghcup-hs](https://gitlab.haskell.org/haskell/ghcup-hs) you should expose its specific installation folder `~/.ghcup/bin`. If the build process uses `stack` then it should also be in your `PATH`.
+
+If that doesn't solve the issue, try running `LSP: Troubleshoot server` and providing its output when asking for help.
+
+## Known Issues
+
+### Completions not shown after certain keywords
+
+Sublime Text's built-in `Completion Rules.tmPreferences` for some languages suppresses completions after certain keywords.
+The solution is to put an edited version of the `Completion Rules.tmPreferences` in the `Packages` folder (you may need to clear the copy in the Cache folder afterwards).
+More details on [workaround and a final fix for Lua](https://forum.sublimetext.com/t/bug-lua-autocomplete-not-working-between-if-then/36635)
+
 ## Self-help instructions
 
 To get more visibility into the inner-workings of the LSP client and the server and be able to diagnose problems, open `Preferences: LSP Settings` from the Command Palette and set the following options:
@@ -15,13 +46,11 @@ If the server is crashing on startup, try running `LSP: Troubleshoot server` fro
 
 ## Updating the PATH used by LSP servers
 
-You can confirm that your issue is due to `PATH` being different by starting Sublime Text from the command line so that it inherits your shell's environment.
+Sublime Text might see a different `PATH` from what your shell environment uses and might not be able to find the server binary due to that. You can see what ST thinks your `PATH` is by opening the ST console by clicking on *View > Show Console*, and running `import os; os.environ["PATH"]` in that console.
 
-The solution is to make ST read the same `PATH` that is read by your shell (or OS in general, in case of Windows).
+The solution is to make ST use the same `PATH` that is read by your shell (or OS in general in the case of Windows).
 
-> **Note**: You can see what ST thinks your `PATH` is by opening the ST console by clicking on *View > Show Console*, and running `import os; os.environ["PATH"]` in that console.
-
-Adjusting `PATH` can differ based on the operating system and the default shell used. Refer to the following table on where this can be adjusted:
+Adjusting `PATH` can differ based on the operating system and the default shell used. Refer to the following table on where this should be adjusted:
 
 <table>
 <tr>
@@ -38,10 +67,19 @@ Adjusting `PATH` can differ based on the operating system and the default shell 
 </tr>
 </table>
 
-> **Note**: It might be necessary to re-login your user account after changing the shell initialization script for the changes to be picked up.
+For macOS and Linux you can extend the path like so:
 
+```sh
+export PATH="/usr/local/bin:$PATH"
+```
+
+For package managers like `nvm` (Node version manager), the recommended way is to insert its [initialization script](https://github.com/nvm-sh/nvm#install--update-script) in the respective location specified above.
+
+!!! note
+    On macOS, it's enough to restart ST for the changes to be picked up. On other platforms, you might have to re-login your user account.
 
 Another solution could be (at least on Linux) to update the server `PATH` using the `env`parameter in your **LSP** configuration file. The following template can be used where:
+
   - `<your_language_server_name>` is the server name
   - `<added_path>` is the directory needed for the server to behave correctly
 
@@ -56,48 +94,3 @@ Another solution could be (at least on Linux) to update the server `PATH` using 
     }
 }
 ```
-
-## Common problems
-
-### 1. LSP doesn't start my language server
-
-* Make sure you have a folder added in your Sublime workspace.
-* Make sure the document you are opening lives under that folder.
-
-Your client configuration requires two settings to match the document your are editing:
-
-* Scope (eg. `source.php`): Verify this is correct by running "Show Scope Name" from the developer menu.
-* Syntax (eg. `Packages\PHP\PHP.sublime-syntax`): Verify by running `view.settings().get("syntax")` in the console.
-
-### 2. LSP cannot find my language server (`No such file or directory: 'xyz'`)
-Assuming that the server is actually installed, and that you can start it from your shell, this issue is likely due to Sublime Text's internal environment not picking up the same `PATH` environment variable as you've configured in your shell.
-
-The exact changes to make can differ depending on what program you want to expose to Sublime Text. The simplest way is to extend the path like so (replacing `/usr/local/bin` with the path of your choice):
-```sh
-export PATH="/usr/local/bin:$PATH"
-```
-
-If, for example, you want to expose a `Node` binary to ST and you have it installed through a version manager like `nvm`, you need to insert its [initialization script](https://github.com/nvm-sh/nvm#install--update-script) in the location specified in [this table](troubleshooting.md#updating-the-path-used-by-lsp-servers)
-
-The complete procedure of updating the `PATH` used by Sublime Text depends on your platform and is explained [here](troubleshooting.md#updating-the-path-used-by-lsp-servers).
-
-
-### 3. Popup error `Language server <your_server_language_name> has crashed`
-Assuming that the server is actually installed, and that you can start it from your shell, this issue is likely due to Sublime Text's internal environment not picking up the same `PATH` environment variable as you've configured in your shell.
-
-> **Note** : Language servers may have dependencies that should also be in your `PATH` in addition to the server binary itself.
-
-For instance if you have installed the `haskell-language-server` using [ghcup-hs](https://gitlab.haskell.org/haskell/ghcup-hs) you should expose its specific installation folder `~/.ghcup/bin`. If the build process uses `stack` then it should also be in your `PATH`.
-
-The complete procedure of updating the `PATH` used by Sublime Text depends on your platform and is explained [here](troubleshooting.md#updating-the-path-used-by-lsp-servers).
-
-
-
-## Known Issues
-
-### Completions not shown after certain keywords
-
-Sublime Text's built-in `Completion Rules.tmPreferences` for some languages surpress completions after certain keywords.
-Python's `import` keyword is an example - no completions are shown at `import a|` (See [this LSP issue](https://github.com/sublimelsp/LSP/issues/203)).
-The solution is to put an edited version of the `Completion Rules.tmPreferences` in the `Packages` folder (you may need to clear the copy in the Cache folder afterwards).
-More details on [workaround and a final fix for Lua](https://forum.sublimetext.com/t/bug-lua-autocomplete-not-working-between-if-then/36635)


### PR DESCRIPTION
- common problems moved to the beginning
- common problems rewritten to be more concise, remove repetition
- in "Completions not shown after certain keywords" removed note about python completion inhibiting issue as that is fixed
- other small changes that are hard to summarize