### PR TITLE
Allow lists in `env` dict of client configuration

### DIFF
--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -553,7 +553,7 @@ class ClientConfig:
                  enabled: bool = True,
                  init_options: DottedDict = DottedDict(),
                  settings: DottedDict = DottedDict(),
-                 env: Dict[str, str] = {},
+                 env: Dict[str, Union[str, List[str]]] = {},
                  experimental_capabilities: Optional[Dict[str, Any]] = None,
                  disabled_capabilities: DottedDict = DottedDict(),
                  file_watcher: FileWatcherConfig = {},
@@ -693,6 +693,8 @@ class ClientConfig:
             command = [a.replace('{port}', str(tcp_port)) for a in command]
         env = os.environ.copy()
         for key, value in self.env.items():
+            if isinstance(value, list):
+                value = os.path.pathsep.join(value)
             if key == 'PATH':
                 env[key] = sublime.expand_variables(value, variables) + os.path.pathsep + env[key]
             else:

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -106,9 +106,20 @@
               "type": "object",
               "markdownDescription": "Specify environment variables to pass to the language server process on startup.",
               "additionalProperties": {
-                "type": "string",
-                "markdownDescription": "The value for this environment variable."
-              },
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "markdownDescription": "The value for this environment variable."
+                  },
+                  {
+                    "type": "array",
+                    "markdownDescription": "A list of values. The list will be joined into a string with your native file system's path separator. For example, `[\"a\", \"b\"]` will turn into `\"a;b\"` on Windows.",
+                      "items": {
+                        "type": "string"
+                      }
+                  }
+                ]
+              }
             },
             "ClientSelector": {
               // \u00A0 is used as a workaround for https://github.com/sublimehq/sublime_text/issues/3373

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -114,9 +114,9 @@
                   {
                     "type": "array",
                     "markdownDescription": "A list of values. The list will be joined into a string with your native file system's path separator. For example, `[\"a\", \"b\"]` will turn into `\"a;b\"` on Windows.",
-                      "items": {
-                        "type": "string"
-                      }
+                    "items": {
+                      "type": "string"
+                    }
                   }
                 ]
               }


### PR DESCRIPTION
The lists are joined into a string with the native file system's path
separator.

Resolves #1811