### PR TITLE
Discard diagnostics in a few cases

### DIFF
--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -15,6 +15,7 @@ from .core.sessions import Session
 from .core.sessions import SessionBufferProtocol
 from .core.sessions import unregister_plugin
 from .core.types import ClientConfig
+from .core.types import matches_pattern
 from .core.url import filename_to_uri
 from .core.url import uri_to_filename
 from .core.version import __version__
@@ -31,6 +32,7 @@ __all__ = [
     'FileWatcherEvent',
     'FileWatcherEventType',
     'FileWatcherProtocol',
+    'matches_pattern',
     'Notification',
     'register_file_watcher_implementation',
     'register_plugin',

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1283,16 +1283,13 @@ class Session(TransportCallbacks):
         uri = params["uri"]
         mgr = self.manager()
         if not mgr:
-            # debug("ignoring diagnostics for", uri, "due to missing window manager")
             return
         reason = mgr.should_present_diagnostics(uri)
         if isinstance(reason, str):
             return debug("ignoring unsuitable diagnostics for", uri, "reason:", reason)
         sb = self.get_session_buffer_for_uri_async(uri)
-        if not sb:
-            # debug("ignoring diagnostics for", uri, "due to missing session buffer")
-            return
-        sb.on_diagnostics_async(params["diagnostics"], params.get("version"))
+        if sb:
+            sb.on_diagnostics_async(params["diagnostics"], params.get("version"))
 
     def m_client_registerCapability(self, params: Any, request_id: Any) -> None:
         """handles the client/registerCapability request"""

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -11,6 +11,7 @@ from wcmatch.glob import BRACE
 from wcmatch.glob import globmatch
 from wcmatch.glob import GLOBSTAR
 import contextlib
+import fnmatch
 import os
 import socket
 import sublime
@@ -57,6 +58,17 @@ def diff(old: Iterable[T], new: Iterable[T]) -> Tuple[Set[T], Set[T]]:
     added = new_set - old_set
     removed = old_set - new_set
     return added, removed
+
+
+def matches_pattern(path: str, patterns: Any) -> bool:
+    if not isinstance(patterns, list):
+        return False
+    for pattern in patterns:
+        if not isinstance(pattern, str):
+            continue
+        if fnmatch.fnmatch(path, pattern):
+            return True
+    return False
 
 
 def debounced(f: Callable[[], Any], timeout_ms: int = 0, condition: Callable[[], bool] = lambda: True,

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -21,6 +21,7 @@ from .sessions import SessionViewProtocol
 from .settings import userprefs
 from .transports import create_transport
 from .types import ClientConfig
+from .types import matches_pattern
 from .typing import Optional, Any, Dict, Deque, List, Generator, Tuple, Iterable, Sequence, Union
 from .url import parse_uri
 from .views import extract_variables
@@ -34,7 +35,6 @@ from subprocess import CalledProcessError
 from time import time
 from weakref import ref
 from weakref import WeakSet
-import fnmatch
 import functools
 import json
 import os
@@ -450,23 +450,13 @@ class WindowManager(Manager):
         if not view:
             return None
         settings = view.settings()
-        if self._matches_glob(path, settings.get("binary_file_patterns")):
-            return "matches a glob in binary_file_patterns"
-        if self._matches_glob(path, settings.get("file_exclude_patterns")):
-            return "matches a glob in file_exclude_patterns"
-        if self._matches_glob(path, settings.get("folder_exclude_patterns")):
-            return "matches a glob in folder_exclude_patterns"
+        if matches_pattern(path, settings.get("binary_file_patterns")):
+            return "matches a pattern in binary_file_patterns"
+        if matches_pattern(path, settings.get("file_exclude_patterns")):
+            return "matches a pattern in file_exclude_patterns"
+        if matches_pattern(path, settings.get("folder_exclude_patterns")):
+            return "matches a pattern in folder_exclude_patterns"
         return None
-
-    def _matches_glob(self, path: str, patterns: Any) -> bool:
-        if not isinstance(patterns, list):
-            return False
-        for pattern in patterns:
-            if not isinstance(pattern, str):
-                continue
-            if fnmatch.fnmatch(path, pattern):
-                return True
-        return False
 
     def on_post_exit_async(self, session: Session, exit_code: int, exception: Optional[Exception]) -> None:
         self._sessions.discard(session)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,5 +1,6 @@
 from LSP.plugin.core.collections import DottedDict
 from LSP.plugin.core.protocol import Diagnostic
+from LSP.plugin.core.protocol import DocumentUri
 from LSP.plugin.core.protocol import Error
 from LSP.plugin.core.protocol import TextDocumentSyncKindFull
 from LSP.plugin.core.protocol import TextDocumentSyncKindIncremental
@@ -30,6 +31,9 @@ class MockManager(Manager):
         pass
 
     def get_project_path(self, file_name: str) -> Optional[str]:
+        return None
+
+    def should_present_diagnostics(self, uri: DocumentUri) -> Optional[str]:
         return None
 
     def start_async(self, configuration: ClientConfig, initiating_view: sublime.View) -> None:


### PR DESCRIPTION
- When the file is outside the window folders, ignore diagnostics
- When the file matches binary_exclude_patterns, ignore it
- When the file matches file_exclude_patterns, ignore it
- When the file matches folder_exclude_patterns, ignore it

This doesn't take care of the index_exclude_patterns and
index_exclude_gitignore settings.

Resolves #1727 