### PR TITLE
Make code lenses have the same behavior for both variants

### DIFF
--- a/plugin/code_lens.py
+++ b/plugin/code_lens.py
@@ -79,7 +79,7 @@ class CodeLensView:
     def is_initialized(self) -> bool:
         return self._init
 
-    def clear_annotations(self) -> None:
+    def _clear_annotations(self) -> None:
         for index, _ in enumerate(self._flat_iteration()):
             self.view.erase_regions(self._region_key(index))
 
@@ -88,7 +88,7 @@ class CodeLensView:
 
     def clear_view(self) -> None:
         self._phantom.update([])
-        self.clear_annotations()
+        self._clear_annotations()
 
     def handle_response(self, session_name: str, response: List[CodeLens]) -> None:
         self._init = True

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -294,7 +294,6 @@ class SessionView:
         self.session.send_request_async(Request("textDocument/codeLens", params, self.view), self._on_code_lenses_async)
 
     def _on_code_lenses_async(self, response: Optional[List[CodeLens]]) -> None:
-        self._code_lenses.clear_annotations()
         if not isinstance(response, list):
             return
         self._code_lenses.handle_response(self.session.config.name, response)


### PR DESCRIPTION
This makes the annotation style a bit less janky.