### PR TITLE
Take care of InsertTextMode for completions

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -14,7 +14,7 @@ from .open import open_externally
 from .progress import WindowProgressReporter
 from .promise import PackagedTask
 from .promise import Promise
-from .protocol import CodeAction, CodeLens, Location, LocationLink, Position
+from .protocol import CodeAction, CodeLens, InsertTextMode, Location, LocationLink, Position
 from .protocol import Command
 from .protocol import CompletionItemTag
 from .protocol import Diagnostic
@@ -179,11 +179,15 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
                 "resolveSupport": {
                     "properties": ["detail", "documentation", "additionalTextEdits"]
                 },
+                "insertTextModeSupport": {
+                    "valueSet": [InsertTextMode.AdjustIndentation]
+                },
                 "labelDetailsSupport": True
             },
             "completionItemKind": {
                 "valueSet": completion_kinds
-            }
+            },
+            "insertTextMode": InsertTextMode.AdjustIndentation
         },
         "signatureHelp": {
             "dynamicRegistration": True,


### PR DESCRIPTION
This advertises that we only support "adjust indentation"-style completions.

When a completion contains a newline, say `a\nb`, then the question becomes whether the language server should account for the current indentation the cursor is at, or whether the editor should take care of that. For this package the editor takes care of that.

While adding this property in the client capabilities I discovered that we actually had an inconsistency with this. In the case of a plaintext textEdit, we did in fact not account for indentation level. This is now fixed as well in 0b1d6d3. The two commits can be rebased as-is.