### PR TITLE
Send hover request to all sessions that supports hoverProvider

### DIFF
--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -212,6 +212,11 @@ CompletionList = TypedDict('CompletionList', {
     'items': List[CompletionItem],
 }, total=True)
 
+Hover = TypedDict('Hover', {
+    'contents': Union[str, Dict[str, str], list],
+    'range': RangeLsp,
+}, total=False)
+
 PublishDiagnosticsParams = TypedDict('PublishDiagnosticsParams', {
     'uri': DocumentUri,
     'version': Optional[int],

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -213,7 +213,7 @@ CompletionList = TypedDict('CompletionList', {
 }, total=True)
 
 Hover = TypedDict('Hover', {
-    'contents': Union[str, Dict[str, str], list],
+    'contents': Union[str, Dict[str, str], List[str]],
     'range': RangeLsp,
 }, total=False)
 

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -212,8 +212,12 @@ CompletionList = TypedDict('CompletionList', {
     'items': List[CompletionItem],
 }, total=True)
 
+MarkedString = Union[str, Dict[str, str]]
+
+MarkupContent = Dict[str, str]
+
 Hover = TypedDict('Hover', {
-    'contents': Union[str, Dict[str, str], List[Union[str, dict]]],
+    'contents': Union[MarkedString, MarkupContent, List[MarkedString]],
     'range': RangeLsp,
 }, total=False)
 

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -213,7 +213,7 @@ CompletionList = TypedDict('CompletionList', {
 }, total=True)
 
 Hover = TypedDict('Hover', {
-    'contents': Union[str, Dict[str, str], List[str]],
+    'contents': Union[str, Dict[str, str], List[Union[str, dict]]],
     'range': RangeLsp,
 }, total=False)
 

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -7,6 +7,8 @@ from .protocol import DiagnosticSeverity
 from .protocol import DocumentUri
 from .protocol import Location
 from .protocol import LocationLink
+from .protocol import MarkedString
+from .protocol import MarkupContent
 from .protocol import Notification
 from .protocol import Point
 from .protocol import Position
@@ -433,7 +435,11 @@ FORMAT_MARKED_STRING = 0x2
 FORMAT_MARKUP_CONTENT = 0x4
 
 
-def minihtml(view: sublime.View, content: Union[str, Dict[str, str], List[Union[str, dict]]], allowed_formats: int) -> str:
+def minihtml(
+    view: sublime.View,
+    content: Union[MarkedString, MarkupContent, List[MarkedString]],
+    allowed_formats: int
+) -> str:
     """
     Formats provided input content into markup accepted by minihtml.
 

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -433,7 +433,7 @@ FORMAT_MARKED_STRING = 0x2
 FORMAT_MARKUP_CONTENT = 0x4
 
 
-def minihtml(view: sublime.View, content: Union[str, Dict[str, str], list], allowed_formats: int) -> str:
+def minihtml(view: sublime.View, content: Union[str, Dict[str, str], List[Union[str, dict]]], allowed_formats: int) -> str:
     """
     Formats provided input content into markup accepted by minihtml.
 

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -194,7 +194,7 @@ class LspHoverCommand(LspTextCommand):
         for hover_response in self._hover_responses:
             content = (hover_response.get('contents') or '') if isinstance(hover_response, dict) else ''
             contents.append(minihtml(self.view, content, allowed_formats=FORMAT_MARKED_STRING | FORMAT_MARKUP_CONTENT))
-        return ''.join(contents)
+        return '<hr>'.join(contents)
 
     def show_hover(self, listener: AbstractViewListener, point: int, only_diagnostics: bool) -> None:
         sublime.set_timeout(lambda: self._show_hover(listener, point, only_diagnostics))

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -119,7 +119,6 @@ class LspHoverCommand(LspTextCommand):
         sublime.set_timeout_async(run_async)
 
     def request_symbol_hover_async(self, listener: AbstractViewListener, point: int) -> None:
-        sessions = list(listener.sessions_async('hoverProvider'))
         hover_promises = []  # type: List[Promise[ResolvedHover]]
         document_position = text_document_position_params(self.view, point)
         for session in listener.sessions_async('hoverProvider'):

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -122,7 +122,7 @@ class LspHoverCommand(LspTextCommand):
         sessions = list(listener.sessions_async('hoverProvider'))
         hover_promises = []  # type: List[Promise[ResolvedHover]]
         document_position = text_document_position_params(self.view, point)
-        for session in sessions:
+        for session in listener.sessions_async('hoverProvider'):
             hover_promises.append(session.send_request_task(
                 Request("textDocument/hover", document_position, self.view)
             ))

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -12,7 +12,7 @@ from .core.registry import LspTextCommand
 from .core.registry import windows
 from .core.sessions import SessionBufferProtocol
 from .core.settings import userprefs
-from .core.typing import List, Optional, Any, Dict, Tuple, Sequence, Union
+from .core.typing import List, Optional, Dict, Tuple, Sequence, Union
 from .core.views import diagnostic_severity
 from .core.views import first_selection_region
 from .core.views import format_diagnostic_for_html

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -143,7 +143,7 @@ class LspHoverCommand(LspTextCommand):
                 hovers.append(response)
         if errors:
             error_messages = ", ".join(str(error) for error in errors)
-            sublime.status_message('Completion error: {}'.format(error_messages))
+            sublime.status_message('Hover error: {}'.format(error_messages))
         self._hover_responses = hovers
         self.show_hover(listener, point, only_diagnostics=False)
 

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -123,12 +123,9 @@ class LspHoverCommand(LspTextCommand):
         hover_promises = []  # type: List[Promise[ResolvedHover]]
         document_position = text_document_position_params(self.view, point)
         for session in sessions:
-            def hover_request() -> Promise[ResolvedHover]:
-                return session.send_request_task(
-                    Request("textDocument/hover", document_position, self.view),
-                )
-
-            hover_promises.append(hover_request())
+            hover_promises.append(session.send_request_task(
+                Request("textDocument/hover", document_position, self.view)
+            ))
 
         Promise.all(hover_promises).then(lambda responses: self._on_all_settled(responses, listener, point))
 


### PR DESCRIPTION
closes #https://github.com/sublimelsp/LSP-tailwindcss/issues/19

Currently LSP sends only one hover request, which doesn't work nicely when there are multiple sessions running in a file.
LSP should send hover requests to all sessions that supports the `hoverProvider`.(like we do when requesting completions)