### PR TITLE
Ensure the process is killed if it didn't exit within 1 second

### DIFF
--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -119,7 +119,7 @@ class JsonRpcTransport(Transport):
                 exit_code = self._process.wait(1)
             except (AttributeError, ProcessLookupError, subprocess.TimeoutExpired):
                 pass
-        if self._process.poll() is not None:
+        if self._process.poll() is None:
             try:
                 # The process didn't stop itself. Terminate!
                 self._process.kill()


### PR DESCRIPTION
The logic seemed to be backwards. The poll() will return an exit code
if the process has already exited and "None" otherwise. So we want to
kill the process when the value is "None".