### PR TITLE
Ensure lsp_save actually runs when context is active for keybinding

### DIFF
--- a/plugin/save_command.py
+++ b/plugin/save_command.py
@@ -91,6 +91,12 @@ class LspSaveCommand(LspTextCommand):
             self._trigger_native_save()
 
     def is_enabled(self, event: Optional[dict] = None, point: Optional[int] = None) -> bool:
+        # Workaround to ensure that the command will run, even if a view was dragged out to a new window,
+        # see https://github.com/sublimelsp/LSP/issues/1791.
+        # The check to determine whether the keybinding for lsp_save is applicable already happens in
+        # DocumentSyncListener.on_query_context and should not be required here, if lsp_save is only used for the
+        # keybinding. A proper fix should ensure that LspTextCommand.is_enabled returns the correct value even for
+        # dragged out views and that LSP keeps working as expected.
         return True
 
     def _trigger_on_pre_save_async(self) -> None:

--- a/plugin/save_command.py
+++ b/plugin/save_command.py
@@ -1,6 +1,6 @@
 from .core.registry import LspTextCommand
 from .core.settings import userprefs
-from .core.typing import Callable, List, Type
+from .core.typing import Callable, List, Optional, Type
 from abc import ABCMeta, abstractmethod
 import sublime
 import sublime_plugin
@@ -90,7 +90,7 @@ class LspSaveCommand(LspTextCommand):
         else:
             self._trigger_native_save()
 
-    def is_enabled(self) -> bool:
+    def is_enabled(self, event: Optional[dict] = None, point: Optional[int] = None) -> bool:
         return True
 
     def _trigger_on_pre_save_async(self) -> None:

--- a/plugin/save_command.py
+++ b/plugin/save_command.py
@@ -90,6 +90,9 @@ class LspSaveCommand(LspTextCommand):
         else:
             self._trigger_native_save()
 
+    def is_enabled(self) -> bool:
+        return True
+
     def _trigger_on_pre_save_async(self) -> None:
         # Supermassive hack that will go away later.
         listeners = sublime_plugin.view_event_listeners.get(self.view.id(), [])


### PR DESCRIPTION
Fixes #1791.

Not sure if it is a proper fix, but the logic to determine whether the keybinding is active or not, is already present in documents.py/on_query_context(). Otherwise, the `is_enabled` evaluating to False from LspTextCommand resulted in preventing <kbd>Ctrl</kbd>+<kbd>S</kbd> from doing anything, because that binding was active, but not actually run.

I would assume that the code actions on save still won't work in the case described in #1791, but I haven't tested it.