### PR TITLE
Remove obsolete dependencies

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -3,12 +3,7 @@
         ">=3124": [
             "backrefs",
             "bracex",
-            "markupsafe",
             "mdpopups",
-            "pygments",
-            "pymdownx",
-            "python-jinja2",
-            "python-markdown",
             "pyyaml",
             "wcmatch"
         ]


### PR DESCRIPTION
As mdpopups vendors all required libraries as of 4.2.1 its dependencies can be removed.