### PR TITLE
use config_name, because session.config.name can change

### DIFF
--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -647,9 +647,10 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         for session in sessions:
 
             def completion_request() -> Promise[ResolvedCompletions]:
+                config_name = session.config.name
                 return session.send_request_task(
                     Request.complete(text_document_position_params(self.view, location), self.view)
-                ).then(lambda response: (response, session.config.name))
+                ).then(lambda response: (response, config_name))
 
             completion_promises.append(completion_request())
 


### PR DESCRIPTION
When triggering the documentation popup and when there are multiple sessions in the file.
Trying to resolve the completion item will fail for one session:
![a](https://user-images.githubusercontent.com/22029477/133897775-32c7e5df-688a-4fc0-a4d7-75532c2e30b3.gif)

**Why?**

Because the resolve request is send to the wrong session.
If you put a print statement in `_on_all_settled`, 
```
for response, session_name in responses:
    print('session_name', session_name)
```
I expected to see:
```
session_name LSP-tailwindcss
session_name LSP-volar
```

But currently it logs:
```
session_name LSP-tailwindcss
session_name LSP-tailwindcss
```

----
This PR will introduce the correct behavior.
