### PR TITLE
Support multiple patterns in file_watcher client configuration

### DIFF
--- a/plugin/core/file_watcher.py
+++ b/plugin/core/file_watcher.py
@@ -54,7 +54,7 @@ class FileWatcher(metaclass=ABCMeta):
     def create(
         cls,
         root_path: str,
-        pattern: str,
+        patterns: List[str],
         events: List[FileWatcherEventType],
         ignores: List[str],
         handler: FileWatcherProtocol
@@ -62,7 +62,7 @@ class FileWatcher(metaclass=ABCMeta):
         """
         Creates a new instance of the file watcher.
 
-        :param pattern: The glob pattern to enable watching for.
+        :param patterns: The list of glob pattern to enable watching for.
         :param events: The type of events that should be watched.
         :param ignores: The list of glob patterns that should excluded from file watching.
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1106,12 +1106,12 @@ class Session(TransportCallbacks):
             debug('{}: supported code action kinds: {}'.format(self.config.name, code_action_kinds))
         if self._watcher_impl:
             config = self.config.file_watcher
-            pattern = config.get('pattern')
-            if pattern:
+            patterns = config.get('patterns')
+            if patterns:
                 events = config.get('events') or ['create', 'change', 'delete']
                 for folder in self.get_workspace_folders():
                     ignores = config.get('ignores') or self._get_global_ignore_globs(folder.path)
-                    watcher = self._watcher_impl.create(folder.path, pattern, events, ignores, self)
+                    watcher = self._watcher_impl.create(folder.path, patterns, events, ignores, self)
                     self._static_file_watchers.append(watcher)
         if self._init_callback:
             self._init_callback(self, False)
@@ -1373,7 +1373,7 @@ class Session(TransportCallbacks):
                     kind = lsp_watch_kind_to_file_watcher_event_types(config.get("kind") or DEFAULT_KIND)
                     for folder in self.get_workspace_folders():
                         ignores = self._get_global_ignore_globs(folder.path)
-                        watcher = self._watcher_impl.create(folder.path, pattern, kind, ignores, self)
+                        watcher = self._watcher_impl.create(folder.path, [pattern], kind, ignores, self)
                         file_watchers.append(watcher)
                 self._dynamic_file_watchers[registration_id] = file_watchers
         self.send_response(Response(request_id, None))

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -27,7 +27,7 @@ PANEL_FILE_REGEX = r"^(?!\s+\d+:\d+)(.*)(:)$"
 PANEL_LINE_REGEX = r"^\s+(\d+):(\d+)"
 
 FileWatcherConfig = TypedDict("FileWatcherConfig", {
-    "pattern": Optional[str],
+    "patterns": List[str],
     "events": Optional[List[FileWatcherEventType]],
     "ignores": Optional[List[str]],
 }, total=False)

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -30,15 +30,18 @@
               "type": "object",
               "examples": [
                 {
-                  "pattern": "{**/*.js,**/*.ts,**/*.json}",
-                  "events": ["create", "change", "delete"],
-                  "ignores": ["**/.git/**", "**/node_modules/**", "**/.hg/**"]
+                  "patterns": ["{**/*.js,**/*.ts,**/*.json}"],
                 }
               ],
               "additionalProperties": false,
+              "required": ["patterns"],
               "properties": {
-                "pattern": {
-                  "type": "string"
+                "patterns": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true
                 },
                 "events": {
                   "type": "array",

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -113,7 +113,7 @@ class FileWatcherStaticTests(FileWatcherDocumentTestCase):
             super().get_stdio_test_config(),
             {
                 'file_watcher': {
-                    'patterns': '*.js',
+                    'patterns': ['*.js'],
                     'events': ['change'],
                     'ignores': ['.git'],
                 }

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -38,25 +38,25 @@ class TestFileWatcher(FileWatcher):
     def create(
         cls,
         root_path: str,
-        pattern: str,
+        patterns: List[str],
         events: List[FileWatcherEventType],
         ignores: List[str],
         handler: FileWatcherProtocol
     ) -> 'TestFileWatcher':
-        watcher = TestFileWatcher(root_path, pattern, events, ignores, handler)
+        watcher = TestFileWatcher(root_path, patterns, events, ignores, handler)
         cls._active_watchers.append(watcher)
         return watcher
 
     def __init__(
         self,
         root_path: str,
-        pattern: str,
+        patterns: List[str],
         events: List[FileWatcherEventType],
         ignores: List[str],
         handler: FileWatcherProtocol
     ) -> None:
         self.root_path = root_path
-        self.pattern = pattern
+        self.patterns = patterns
         self.events = events
         self.ignores = ignores
         self.handler = handler
@@ -113,7 +113,7 @@ class FileWatcherStaticTests(FileWatcherDocumentTestCase):
             super().get_stdio_test_config(),
             {
                 'file_watcher': {
-                    'pattern': '*.js',
+                    'patterns': '*.js',
                     'events': ['change'],
                     'ignores': ['.git'],
                 }
@@ -127,7 +127,7 @@ class FileWatcherStaticTests(FileWatcherDocumentTestCase):
         # Starting a session should have created a watcher.
         self.assertEqual(len(TestFileWatcher._active_watchers), 1)
         watcher = TestFileWatcher._active_watchers[0]
-        self.assertEqual(watcher.pattern, '*.js')
+        self.assertEqual(watcher.patterns, ['*.js'])
         self.assertEqual(watcher.events, ['change'])
         self.assertEqual(watcher.ignores, ['.git'])
         self.assertEqual(watcher.root_path, self.folder_root_path)
@@ -166,7 +166,7 @@ class FileWatcherDynamicTests(FileWatcherDocumentTestCase):
         yield self.make_server_do_fake_request('client/registerCapability', registration_params)
         self.assertEqual(len(TestFileWatcher._active_watchers), 1)
         watcher = TestFileWatcher._active_watchers[0]
-        self.assertEqual(watcher.pattern, '*.py')
+        self.assertEqual(watcher.patterns, ['*.py'])
         self.assertEqual(watcher.events, ['create', 'change', 'delete'])
         self.assertEqual(watcher.root_path, self.folder_root_path)
         # Trigger the file event


### PR DESCRIPTION
I've realized that supporting only one pattern doesn't allow to handle the use-case of eslint which needs three patterns that are not possible to handle with a single pattern and braces:
 - `**/.eslintr{c.js,c.yaml,c.yml,c,c.json}`
 - `**/.eslintignore`
 - `**/package.json`