### PR TITLE
Fix console exception with panel logger enabled

### DIFF
--- a/plugin/core/panels.py
+++ b/plugin/core/panels.py
@@ -152,9 +152,9 @@ def is_server_panel_open(window: sublime.Window) -> bool:
 
 
 def log_server_message(window: sublime.Window, prefix: str, message: str) -> None:
-    if not window.is_valid():
-        return
     window_id = window.id()
+    if not window.is_valid() or window_id not in WindowPanelListener.server_log_map:
+        return
     WindowPanelListener.server_log_map[window_id].append((prefix, message))
     list_len = len(WindowPanelListener.server_log_map[window_id])
     if list_len >= SERVER_PANEL_MAX_LINES:


### PR DESCRIPTION
After window is closed, the server messages can keep coming for a while
and the "is_valid()" check doesn't really work as expected for closed
Window so we need to do the "is in" check instead.