### PR TITLE
Revert "Add AbstractPlugin.additional_formatting_options (#1832)" 

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -50,7 +50,6 @@ from .url import parse_uri
 from .version import __version__
 from .views import COMPLETION_KINDS
 from .views import extract_variables
-from .views import formatting_options
 from .views import get_storage_path
 from .views import get_uri_and_range_from_location
 from .views import SYMBOL_KINDS
@@ -648,17 +647,6 @@ class AbstractPlugin(metaclass=ABCMeta):
         """
         pass
 
-    def additional_formatting_options(self, view: sublime.View) -> Dict[str, Any]:
-        """
-        Called when a language server is about to perform a document or range formatting. The returned formatting
-        options will be merged with the default options.
-
-        :param view: The view on which formatting is about to be performed.
-
-        :returns: An object with formatting options.
-        """
-        return {}
-
     def on_open_uri_async(self, uri: DocumentUri, callback: Callable[[str, str, str], None]) -> bool:
         """
         Called when a language server reports to open an URI. If you know how to handle this URI, then return True and
@@ -1200,12 +1188,6 @@ class Session(TransportCallbacks):
         # must apply the edits before running the command.
         code_action = cast(CodeAction, code_action)
         return self._maybe_resolve_code_action(code_action).then(self._apply_code_action_async)
-
-    def get_formatting_options(self, view: sublime.View) -> Dict[str, Any]:
-        options = formatting_options(view.settings())
-        if self._plugin:
-            options.update(self._plugin.additional_formatting_options(view))
-        return options
 
     def open_uri_async(
         self,

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -361,17 +361,17 @@ def formatting_options(settings: sublime.Settings) -> Dict[str, Any]:
     }
 
 
-def text_document_formatting(view: sublime.View, options: Dict[str, Any]) -> Request:
+def text_document_formatting(view: sublime.View) -> Request:
     return Request("textDocument/formatting", {
         "textDocument": text_document_identifier(view),
-        "options": options
+        "options": formatting_options(view.settings())
     }, view, progress=True)
 
 
-def text_document_range_formatting(view: sublime.View, options: Dict[str, Any], region: sublime.Region) -> Request:
+def text_document_range_formatting(view: sublime.View, region: sublime.Region) -> Request:
     return Request("textDocument/rangeFormatting", {
         "textDocument": text_document_identifier(view),
-        "options": options,
+        "options": formatting_options(view.settings()),
         "range": region_to_range(view, region).to_lsp()
     }, view, progress=True)
 

--- a/plugin/formatting.py
+++ b/plugin/formatting.py
@@ -23,13 +23,11 @@ def format_document(text_command: LspTextCommand) -> Promise[FormatResponse]:
     session = text_command.best_session(LspFormatDocumentCommand.capability)
     if session:
         # Either use the documentFormattingProvider ...
-        options = session.get_formatting_options(view)
-        return session.send_request_task(text_document_formatting(view, options))
+        return session.send_request_task(text_document_formatting(view))
     session = text_command.best_session(LspFormatDocumentRangeCommand.capability)
     if session:
         # ... or use the documentRangeFormattingProvider and format the entire range.
-        options = session.get_formatting_options(view)
-        return session.send_request_task(text_document_range_formatting(view, options, entire_content_region(view)))
+        return session.send_request_task(text_document_range_formatting(view, entire_content_region(view)))
     return Promise.resolve(None)
 
 
@@ -126,5 +124,5 @@ class LspFormatDocumentRangeCommand(LspTextCommand):
         session = self.best_session(self.capability)
         selection = first_selection_region(self.view)
         if session and selection is not None:
-            req = text_document_range_formatting(self.view, session.get_formatting_options(self.view), selection)
+            req = text_document_range_formatting(self.view, selection)
             session.send_request(req, lambda response: apply_response_to_view(response, self.view))

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -10,7 +10,6 @@ from LSP.plugin.core.views import did_save
 from LSP.plugin.core.views import document_color_params
 from LSP.plugin.core.views import format_diagnostic_for_html
 from LSP.plugin.core.views import FORMAT_STRING, FORMAT_MARKED_STRING, FORMAT_MARKUP_CONTENT, minihtml
-from LSP.plugin.core.views import formatting_options
 from LSP.plugin.core.views import lsp_color_to_html
 from LSP.plugin.core.views import lsp_color_to_phantom
 from LSP.plugin.core.views import MissingUriError
@@ -123,8 +122,7 @@ class ViewsTest(DeferrableTestCase):
             "ensure_newline_at_eof_on_save": True,
             "lsp_uri": filename_to_uri(self.mock_file_name)
         })
-        options = formatting_options(self.view.settings())
-        self.assertEqual(text_document_formatting(self.view, options).params, {
+        self.assertEqual(text_document_formatting(self.view).params, {
             "textDocument": {"uri": filename_to_uri(self.mock_file_name)},
             "options": {
                 "tabSize": 1234,
@@ -140,8 +138,7 @@ class ViewsTest(DeferrableTestCase):
             "tab_size": 4321,
             "lsp_uri": filename_to_uri(self.mock_file_name)
         })
-        options = formatting_options(self.view.settings())
-        self.assertEqual(text_document_range_formatting(self.view, options, sublime.Region(0, 2)).params, {
+        self.assertEqual(text_document_range_formatting(self.view, sublime.Region(0, 2)).params, {
             "textDocument": {"uri": filename_to_uri(self.mock_file_name)},
             "options": {
                 "tabSize": 4321,


### PR DESCRIPTION
This reverts commit 8576d48017a7da96f0330397cfee26a0058cd9ac.

This was solved natively in `typescript-language-server`.

Since we are pretty confident that nothing else than `LSP-typescript` was using it, I think we can revert it.