### PR TITLE
Ensure timeout messages during code-action-on-save are visible

### DIFF
--- a/plugin/save_command.py
+++ b/plugin/save_command.py
@@ -23,7 +23,7 @@ class SaveTask(metaclass=ABCMeta):
         self._on_done = on_done
         self._completed = False
         self._cancelled = False
-        self._status_key = 'lsp_save_task_timeout'
+        self._status_key = type(self).__name__
 
     def run_async(self) -> None:
         self._erase_view_status()


### PR DESCRIPTION
Since all tasks shared the same status key, on earlier task failing we would
set the status but then the later task would clear it.

Ensure that every task uses separate key so that they don't clear
status messages shown by other task.