### PR TITLE
Don't restart all servers on changing LSP-* plugin settings

### DIFF
--- a/plugin/configuration.py
+++ b/plugin/configuration.py
@@ -47,7 +47,7 @@ class LspDisableLanguageServerGloballyCommand(sublime_plugin.WindowCommand):
             config_name = self._items[index]
             client_configs.disable(config_name)
             wm = windows.lookup(self.window)
-            sublime.set_timeout_async(lambda: wm.end_config_sessions_async(config_name))
+            sublime.set_timeout_async(lambda: wm._end_sessions_async(config_name))
 
 
 class LspDisableLanguageServerInProjectCommand(sublime_plugin.WindowCommand):

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -122,7 +122,7 @@ class LspRestartServerCommand(LspTextCommand):
             config_name = self._config_names[index]
             if not config_name:
                 return
-            self._wm.end_config_sessions_async(config_name)
+            self._wm._end_sessions_async(config_name)
             listener = windows.listener_for_view(self.view)
             if listener:
                 self._wm.register_listener_async(listener)
@@ -131,5 +131,5 @@ class LspRestartServerCommand(LspTextCommand):
 
 
 class LspRecheckSessionsCommand(sublime_plugin.WindowCommand):
-    def run(self) -> None:
-        sublime.set_timeout_async(lambda: windows.lookup(self.window).restart_sessions_async())
+    def run(self, config_name: Optional[str] = None) -> None:
+        sublime.set_timeout_async(lambda: windows.lookup(self.window).restart_sessions_async(config_name))

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -25,11 +25,11 @@ class ClientConfigs:
     def add_for_testing(self, config: ClientConfig) -> None:
         assert config.name not in self.all
         self.all[config.name] = config
-        self._notify_listener(config.name)
+        self._notify_listener()
 
     def remove_for_testing(self, config: ClientConfig) -> None:
         self.all.pop(config.name)
-        self._notify_listener(config.name)
+        self._notify_listener()
 
     def add_external_config(self, name: str, s: sublime.Settings, file: str, notify_listener: bool) -> bool:
         if name in self.external:

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -16,20 +16,20 @@ class ClientConfigs:
     def __init__(self) -> None:
         self.all = {}  # type: Dict[str, ClientConfig]
         self.external = {}  # type: Dict[str, ClientConfig]
-        self._listener = None  # type: Optional[Callable[[], None]]
+        self._listener = None  # type: Optional[Callable[[Optional[str]], None]]
 
-    def _notify_listener(self) -> None:
+    def _notify_listener(self, config_name: Optional[str] = None) -> None:
         if callable(self._listener):
-            self._listener()
+            self._listener(config_name)
 
     def add_for_testing(self, config: ClientConfig) -> None:
         assert config.name not in self.all
         self.all[config.name] = config
-        self._notify_listener()
+        self._notify_listener(config.name)
 
     def remove_for_testing(self, config: ClientConfig) -> None:
         self.all.pop(config.name)
-        self._notify_listener()
+        self._notify_listener(config.name)
 
     def add_external_config(self, name: str, s: sublime.Settings, file: str, notify_listener: bool) -> bool:
         if name in self.external:
@@ -50,13 +50,13 @@ class ClientConfigs:
             # That causes many calls to WindowConfigManager.match_view, which is relatively speaking an expensive
             # operation. To ensure that this dance is done only once, we delay notifying the ConfigManager until all
             # plugins have done their `register_plugin` call.
-            debounced(self._notify_listener, 200, lambda: len(self.external) == size)
+            debounced(lambda: self._notify_listener(name), 200, lambda: len(self.external) == size)
         return True
 
     def remove_external_config(self, name: str) -> None:
         self.external.pop(name, None)
         if self.all.pop(name, None):
-            self._notify_listener()
+            self._notify_listener(name)
 
     def update_external_config(self, name: str, s: sublime.Settings, file: str) -> None:
         try:
@@ -67,7 +67,7 @@ class ClientConfigs:
             return
         self.external[name] = config
         self.all[name] = config
-        self._notify_listener()
+        self._notify_listener(name)
 
     def update_configs(self) -> None:
         global _settings_obj
@@ -97,7 +97,7 @@ class ClientConfigs:
     def disable(self, config_name: str) -> None:
         self._set_enabled(config_name, False)
 
-    def set_listener(self, recipient: Callable[[], None]) -> None:
+    def set_listener(self, recipient: Callable[[Optional[str]], None]) -> None:
         self._listener = recipient
 
 

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -414,22 +414,17 @@ class WindowManager(Manager):
         if view:
             MessageRequestHandler(view, session, request_id, params, session.config.name).show()
 
-    def restart_sessions_async(self) -> None:
-        self._end_sessions_async()
+    def restart_sessions_async(self, config_name: Optional[str] = None) -> None:
+        self._end_sessions_async(config_name)
         listeners = list(self._listeners)
         self._listeners.clear()
         for listener in listeners:
             self.register_listener_async(listener)
 
-    def _end_sessions_async(self) -> None:
-        for session in self._sessions:
-            session.end_async()
-        self._sessions.clear()
-
-    def end_config_sessions_async(self, config_name: str) -> None:
+    def _end_sessions_async(self, config_name: Optional[str] = None) -> None:
         sessions = list(self._sessions)
         for session in sessions:
-            if session.config.name == config_name:
+            if config_name is None or config_name == session.config.name:
                 session.end_async()
                 self._sessions.discard(session)
 


### PR DESCRIPTION
Ensure that only the server who's settings were saved is restarted.

This of course only addresses changes in LSP-* settings, not
client settings within the main LSP settings.

Also consolidated almost identical `WindowManager._end_sessions_async`
and `WindowManager.end_config_sessions_async` into one.