### PR TITLE
Remove unused context in "goto definition" keybindings

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -261,11 +261,6 @@
     //     "keys": [
     //         "f8"
     //     ],
-    //     "context": [
-    //         {
-    //             "key": "setting.lsp_active"
-    //         }
-    //     ]
     // },
     // Goto Diagnostic in Project
     // {
@@ -273,11 +268,6 @@
     //     "keys": [
     //         "shift+f8"
     //     ],
-    //     "context": [
-    //         {
-    //             "key": "setting.lsp_active"
-    //         }
-    //     ]
     // },
     // Rename
     // {


### PR DESCRIPTION
This is a Window command so this context check does not work (always matches).