### PR TITLE
Include diagnostics when triggering codeAction request on save

### DIFF
--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -24,7 +24,7 @@ from .core.types import SettingsRegistration
 from .core.typing import Any, Callable, Optional, Dict, Generator, Iterable, List, Tuple, Union
 from .core.url import parse_uri
 from .core.url import view_to_uri
-from .core.views import diagnostic_severity, region_to_range
+from .core.views import diagnostic_severity
 from .core.views import document_color_params
 from .core.views import first_selection_region
 from .core.views import format_completion
@@ -252,13 +252,12 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
     ) -> Tuple[List[Tuple[SessionBuffer, List[Diagnostic]]], sublime.Region]:
         covering = sublime.Region(region.a, region.b)
         result = []  # type: List[Tuple[SessionBuffer, List[Diagnostic]]]
-        requested_range = region_to_range(self.view, region)
         for sb, diagnostics in self.diagnostics_async():
             intersections = []  # type: List[Diagnostic]
             for diagnostic, candidate in diagnostics:
-                # Perform intersection checks on Range since it's inclusive unlike Region which is exclusive.
-                diagnostic_range = region_to_range(self.view, candidate)
-                if requested_range.intersects(diagnostic_range):
+                # Checking against points is inclusive unline checking against regions which
+                # are exclusive at the end and we want an inclusive behavior in this case.
+                if region.intersects(candidate.a) or region.intersects(candidate.b):
                     covering = covering.cover(candidate)
                     intersections.append(diagnostic)
             if intersections:

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -250,7 +250,6 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         self,
         region: sublime.Region
     ) -> Tuple[List[Tuple[SessionBuffer, List[Diagnostic]]], sublime.Region]:
-        print(region)
         covering = sublime.Region(region.begin(), region.end())
         result = []  # type: List[Tuple[SessionBuffer, List[Diagnostic]]]
         for sb, diagnostics in self.diagnostics_async():

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -255,7 +255,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         for sb, diagnostics in self.diagnostics_async():
             intersections = []  # type: List[Diagnostic]
             for diagnostic, candidate in diagnostics:
-                # Checking against points is inclusive unline checking whether region intersects another
+                # Checking against points is inclusive unlike checking whether region intersects another
                 # region which is exclusive (at region end) and we want an inclusive behavior in this case.
                 if region.contains(candidate.a) or region.contains(candidate.b):
                     covering = covering.cover(candidate)

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -250,14 +250,15 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         self,
         region: sublime.Region
     ) -> Tuple[List[Tuple[SessionBuffer, List[Diagnostic]]], sublime.Region]:
-        covering = sublime.Region(region.a, region.b)
+        print(region)
+        covering = sublime.Region(region.begin(), region.end())
         result = []  # type: List[Tuple[SessionBuffer, List[Diagnostic]]]
         for sb, diagnostics in self.diagnostics_async():
             intersections = []  # type: List[Diagnostic]
             for diagnostic, candidate in diagnostics:
-                # Checking against points is inclusive unline checking against regions which
-                # are exclusive at the end and we want an inclusive behavior in this case.
-                if region.intersects(candidate.a) or region.intersects(candidate.b):
+                # Checking against points is inclusive unline checking whether region intersects another
+                # region which is exclusive (at region end) and we want an inclusive behavior in this case.
+                if region.contains(candidate.a) or region.contains(candidate.b):
                     covering = covering.cover(candidate)
                     intersections.append(diagnostic)
             if intersections:

--- a/tests/test_code_actions.py
+++ b/tests/test_code_actions.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from LSP.plugin.code_actions import CodeActionsByConfigName
 from LSP.plugin.code_actions import get_matching_kinds
 from LSP.plugin.core.protocol import Point, Range
 from LSP.plugin.core.typing import Any, Dict, Generator, List, Tuple, Optional
@@ -102,6 +101,24 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
         self.set_response('textDocument/codeAction', [code_action])
         self.view.run_command('lsp_save')
         yield from self.await_message('textDocument/codeAction')
+        yield from self.await_message('textDocument/didSave')
+        self.assertEquals(entire_content(self.view), 'const x = 1;')
+        self.assertEquals(self.view.is_dirty(), False)
+
+    def test_requests_with_diagnostics(self) -> Generator:
+        yield from self._setup_document_with_missing_semicolon()
+        code_action_kind = 'source.fixAll'
+        code_action = create_test_code_action(
+            self.view,
+            self.view.change_count(),
+            [(';', Range(Point(0, 11), Point(0, 11)))],
+            code_action_kind
+        )
+        self.set_response('textDocument/codeAction', [code_action])
+        self.view.run_command('lsp_save')
+        code_action_request = yield from self.await_message('textDocument/codeAction')
+        self.assertEquals(len(code_action_request['context']['diagnostics']), 1)
+        self.assertEquals(code_action_request['context']['diagnostics'][0]['message'], 'Missing semicolon')
         yield from self.await_message('textDocument/didSave')
         self.assertEquals(entire_content(self.view), 'const x = 1;')
         self.assertEquals(self.view.is_dirty(), False)
@@ -222,7 +239,7 @@ class CodeActionsListenerTestCase(TextDocumentTestCase):
         self.original_debounce_time = DocumentSyncListener.code_actions_debounce_time
         DocumentSyncListener.code_actions_debounce_time = 0
 
-    def tearDown(self) -> Generator:
+    def tearDown(self) -> None:
         DocumentSyncListener.code_actions_debounce_time = self.original_debounce_time
         super().tearDown()
 
@@ -282,8 +299,6 @@ class CodeActionsListenerTestCase(TextDocumentTestCase):
         self.assertEquals(annotations_range[0].b, 0)
 
     def test_extends_range_to_include_diagnostics(self) -> Generator:
-        def handle_response(actions_by_config: CodeActionsByConfigName) -> None:
-            pass
         self.insert_characters('x diagnostic')
         yield from self.await_message("textDocument/didChange")
         yield from self.await_client_notification(


### PR DESCRIPTION
Some servers might apply different logic depending on provided
diagnostics. For example theia server might not want to apply
destructive action like removing import statements when there are
error diagnostics.

While testing this new logic, uncovered a bug where we didn't include
diagnostics "touching" the selection region which also affected the
case when getting diagnostics for the whole document range on save,
which didn't include diagnostics that were at the end of the document.