### PR TITLE
Allow user to send textDocument/hover with range if needed

### DIFF
--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -72,6 +72,11 @@ TextDocumentPositionParams = TypedDict('TextDocumentPositionParams', {
     'position': Position,
 }, total=True)
 
+TextDocumentRangeParams = TypedDict('TextDocumentRangeParams', {
+    'textDocument': TextDocumentIdentifier,
+    'range': RangeLsp,
+}, total=True)
+
 CodeDescription = TypedDict('CodeDescription', {
     'href': str
 }, total=True)

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -17,6 +17,7 @@ from .protocol import RangeLsp
 from .protocol import Request
 from .protocol import TextDocumentIdentifier
 from .protocol import TextDocumentPositionParams
+from .protocol import TextDocumentRangeParams
 from .settings import userprefs
 from .types import ClientConfig
 from .typing import Callable, Optional, Dict, Any, Iterable, List, Union, Tuple, Sequence, cast
@@ -270,6 +271,9 @@ def versioned_text_document_identifier(view: sublime.View, version: int) -> Dict
 def text_document_position_params(view: sublime.View, location: int) -> TextDocumentPositionParams:
     return {"textDocument": text_document_identifier(view), "position": position(view, location)}
 
+def text_document_range_params(view: sublime.View, region: sublime.Region) -> TextDocumentRangeParams:
+    return {"textDocument": text_document_identifier(view), "range": region_to_range(view, region).to_lsp()}
+
 
 def did_open_text_document_params(view: sublime.View, language_id: str) -> Dict[str, Any]:
     return {"textDocument": text_document_item(view, language_id)}
@@ -404,6 +408,8 @@ def text_document_code_action_params(
 # Workaround for a limited margin-collapsing capabilities of the minihtml.
 LSP_POPUP_SPACER_HTML = '<div class="lsp_popup--spacer"></div>'
 
+def hide_lsp_popup(view: sublime.View) -> None:
+    mdpopups.hide_popup(view)
 
 def show_lsp_popup(view: sublime.View, contents: str, location: int = -1, md: bool = False, flags: int = 0,
                    css: Optional[str] = None, wrapper_class: Optional[str] = None,


### PR DESCRIPTION
This a better alternative to https://github.com/scalameta/metals-sublime/pull/45 and this implementation is just a workaround until https://github.com/microsoft/language-server-protocol/issues/377 is part of the LSP spec

![Peek 2021-11-15 15-57](https://user-images.githubusercontent.com/1632384/141803581-78b0c9ad-25bc-434b-b8da-f60e1d36b4a6.gif)


On the LSP-* packages the users just have to set `{"keys": ["ctrl+h"], "command": "lsp_hover", "args": {"use_selection": true}}` a key binding 