### PR TITLE
Fix color boxes not updating in some cases

### DIFF
--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -273,7 +273,7 @@ class SessionBuffer:
             return sv.view
         return None
 
-    def _if_view_version_stable(self, f: Callable[[sublime.View, Any], None], version: int) -> Callable[[Any], None]:
+    def _if_view_unchanged(self, f: Callable[[sublime.View, Any], None], version: int) -> Callable[[Any], None]:
         """
         Ensures that the view is at the same version when we were called, before calling the `f` function.
         """
@@ -290,7 +290,7 @@ class SessionBuffer:
         if self.session.has_capability("colorProvider"):
             self.session.send_request_async(
                 Request.documentColor(document_color_params(view), view),
-                self._if_view_version_stable(self._on_color_boxes_async, version)
+                self._if_view_unchanged(self._on_color_boxes_async, version)
             )
 
     def _on_color_boxes_async(self, view: sublime.View, response: Any) -> None:

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -2,6 +2,7 @@ from .core.protocol import Diagnostic
 from .core.protocol import DiagnosticSeverity
 from .core.protocol import DocumentUri
 from .core.protocol import Range
+from .core.protocol import Request
 from .core.protocol import TextDocumentSyncKindFull
 from .core.protocol import TextDocumentSyncKindNone
 from .core.sessions import SessionViewProtocol
@@ -10,13 +11,15 @@ from .core.types import Capabilities
 from .core.types import debounced
 from .core.types import Debouncer
 from .core.types import FEATURES_TIMEOUT
-from .core.typing import Any, Iterable, Optional, List, Dict, Tuple
+from .core.typing import Any, Callable, Iterable, Optional, List, Dict, Tuple
 from .core.views import DIAGNOSTIC_SEVERITY
 from .core.views import diagnostic_severity
 from .core.views import did_change
 from .core.views import did_close
 from .core.views import did_open
 from .core.views import did_save
+from .core.views import document_color_params
+from .core.views import lsp_color_to_phantom
 from .core.views import MissingUriError
 from .core.views import range_to_region
 from .core.views import will_save
@@ -81,6 +84,7 @@ class SessionBuffer:
         self.total_warnings = 0
         self.should_show_diagnostics_panel = False
         self.diagnostics_debouncer = Debouncer()
+        self.color_phantoms = sublime.PhantomSet(view, "lsp_color")
         self._check_did_open(view)
         self.session.register_session_buffer_async(self)
 
@@ -88,6 +92,7 @@ class SessionBuffer:
         mgr = self.session.manager()
         if mgr:
             mgr.update_diagnostics_panel_async()
+        self.color_phantoms.update([])
         # If the session is exiting then there's no point in sending textDocument/didClose and there's also no point
         # in unregistering ourselves from the session.
         if not self.session.exiting:
@@ -103,6 +108,7 @@ class SessionBuffer:
                 return
             self.session.send_notification(did_open(view, language_id))
             self.opened = True
+            self._do_color_boxes_async(view, view.change_count())
             self.session.notify_plugin_on_session_buffer_change(self)
 
     def _check_did_close(self) -> None:
@@ -235,8 +241,10 @@ class SessionBuffer:
                 notification = did_change(view, version, changes)
                 self.session.send_notification(notification)
             except MissingUriError:
-                pass  # we're closing
-            self.pending_changes = None
+                return  # we're closing
+            finally:
+                self.pending_changes = None
+            self._do_color_boxes_async(view, version)
             self.session.notify_plugin_on_session_buffer_change(self)
 
     def on_pre_save_async(self, view: sublime.View) -> None:
@@ -264,6 +272,32 @@ class SessionBuffer:
         for sv in self.session_views:
             return sv.view
         return None
+
+    def _if_view_version_stable(self, f: Callable[[sublime.View, Any], None], version: int) -> Callable[[Any], None]:
+        """
+        Ensures that the view is at the same version when we were called, before calling the `f` function.
+        """
+        def handler(*args: Any) -> None:
+            view = self.some_view()
+            if view and view.change_count() == version:
+                f(view, *args)
+
+        return handler
+
+    # --- textDocument/documentColor -----------------------------------------------------------------------------------
+
+    def _do_color_boxes_async(self, view: sublime.View, version: int) -> None:
+        if self.session.has_capability("colorProvider"):
+            self.session.send_request_async(
+                Request.documentColor(document_color_params(view), view),
+                self._if_view_version_stable(self._on_color_boxes_async, version)
+            )
+
+    def _on_color_boxes_async(self, view: sublime.View, response: Any) -> None:
+        color_infos = response if response else []
+        self.color_phantoms.update([lsp_color_to_phantom(view, color_info) for color_info in color_infos])
+
+    # --- textDocument/publishDiagnostics ------------------------------------------------------------------------------
 
     def on_diagnostics_async(self, raw_diagnostics: List[Diagnostic], version: Optional[int]) -> None:
         data_per_severity = {}  # type: Dict[Tuple[int, bool], DiagnosticSeverityData]

--- a/unittesting.json
+++ b/unittesting.json
@@ -3,7 +3,7 @@
     "verbosity": 2,
     "capture_console": true,
     "failfast": false,
-    "reload_package_on_testing": true,
+    "reload_package_on_testing": false,
     "start_coverage_after_reload": false,
     "show_reload_progress": false,
     "output": null,


### PR DESCRIPTION
As was noticed in https://github.com/sublimelsp/LSP/pull/1839#discussion_r750288905, it was incorrect to use `_when_selection_remains_stable_async` for the features that relied on view changes being reported first.

The `_when_selection_remains_stable_async` would cause the request to be skipped if the selection has changed since it was called. That means that changing the document and then quickly moving the cursor would result in color boxes not being requested/updated.

And on top of that, we might have also requested color boxes before the `didChange` notification has been triggered thus resulting in out of sync positioning of boxes.

Moved the logic to `SessionBuffer` where it can be called after the `didChange` notification and added checks if view is still alive and whether the document has remained the same on getting results from session.

We also shouldn't need any extra debouncing as `didChange` notifications are already debounced.

As a side effect, we'll request color boxes from all active sessions that support them rather then only the first one. This might be good or bad but if it's an issue, the user can disable relevant capability for one of the sessions.