### PR TITLE
Send range with textDocument/hover when possible

### DIFF
--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -74,6 +74,7 @@ TextDocumentPositionParams = TypedDict('TextDocumentPositionParams', {
 
 ExperimentalTextDocumentRangeParams = TypedDict('ExperimentalTextDocumentRangeParams', {
     'textDocument': TextDocumentIdentifier,
+    'position': Position,
     'range': RangeLsp,
 }, total=True)
 

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -72,6 +72,11 @@ TextDocumentPositionParams = TypedDict('TextDocumentPositionParams', {
     'position': Position,
 }, total=True)
 
+ExperimentalTextDocumentRangeParams = TypedDict('ExperimentalTextDocumentRangeParams', {
+    'textDocument': TextDocumentIdentifier,
+    'range': RangeLsp,
+}, total=True)
+
 CodeDescription = TypedDict('CodeDescription', {
     'href': str
 }, total=True)

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -272,8 +272,13 @@ def text_document_position_params(view: sublime.View, location: int) -> TextDocu
     return {"textDocument": text_document_identifier(view), "position": position(view, location)}
 
 
-def text_document_range_params(view: sublime.View, region: sublime.Region) -> ExperimentalTextDocumentRangeParams:
-    return {"textDocument": text_document_identifier(view), "range": region_to_range(view, region).to_lsp()}
+def text_document_range_params(view: sublime.View, location: int,
+                               region: sublime.Region) -> ExperimentalTextDocumentRangeParams:
+    return {
+        "textDocument": text_document_identifier(view),
+        "position": position(view, location),
+        "range": region_to_range(view, region).to_lsp()
+    }
 
 
 def did_open_text_document_params(view: sublime.View, language_id: str) -> Dict[str, Any]:

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -270,6 +270,8 @@ def versioned_text_document_identifier(view: sublime.View, version: int) -> Dict
 def text_document_position_params(view: sublime.View, location: int) -> TextDocumentPositionParams:
     return {"textDocument": text_document_identifier(view), "position": position(view, location)}
 
+def text_document_range_params(view: sublime.View, region: sublime.Region) -> Dict[str, Any]:
+    return {"textDocument": text_document_identifier(view), "range": region_to_range(view, region).to_lsp()}
 
 def did_open_text_document_params(view: sublime.View, language_id: str) -> Dict[str, Any]:
     return {"textDocument": text_document_item(view, language_id)}
@@ -404,6 +406,8 @@ def text_document_code_action_params(
 # Workaround for a limited margin-collapsing capabilities of the minihtml.
 LSP_POPUP_SPACER_HTML = '<div class="lsp_popup--spacer"></div>'
 
+def hide_lsp_popup(view: sublime.View) -> None:
+    mdpopups.hide_popup(view)
 
 def show_lsp_popup(view: sublime.View, contents: str, location: int = -1, md: bool = False, flags: int = 0,
                    css: Optional[str] = None, wrapper_class: Optional[str] = None,

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -406,9 +406,6 @@ def text_document_code_action_params(
 # Workaround for a limited margin-collapsing capabilities of the minihtml.
 LSP_POPUP_SPACER_HTML = '<div class="lsp_popup--spacer"></div>'
 
-def hide_lsp_popup(view: sublime.View) -> None:
-    mdpopups.hide_popup(view)
-
 def show_lsp_popup(view: sublime.View, contents: str, location: int = -1, md: bool = False, flags: int = 0,
                    css: Optional[str] = None, wrapper_class: Optional[str] = None,
                    on_navigate: Optional[Callable] = None, on_hide: Optional[Callable] = None) -> None:

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -270,8 +270,10 @@ def versioned_text_document_identifier(view: sublime.View, version: int) -> Dict
 def text_document_position_params(view: sublime.View, location: int) -> TextDocumentPositionParams:
     return {"textDocument": text_document_identifier(view), "position": position(view, location)}
 
+
 def text_document_range_params(view: sublime.View, region: sublime.Region) -> Dict[str, Any]:
     return {"textDocument": text_document_identifier(view), "range": region_to_range(view, region).to_lsp()}
+
 
 def did_open_text_document_params(view: sublime.View, language_id: str) -> Dict[str, Any]:
     return {"textDocument": text_document_item(view, language_id)}
@@ -405,6 +407,7 @@ def text_document_code_action_params(
 
 # Workaround for a limited margin-collapsing capabilities of the minihtml.
 LSP_POPUP_SPACER_HTML = '<div class="lsp_popup--spacer"></div>'
+
 
 def show_lsp_popup(view: sublime.View, contents: str, location: int = -1, md: bool = False, flags: int = 0,
                    css: Optional[str] = None, wrapper_class: Optional[str] = None,

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -271,10 +271,6 @@ def text_document_position_params(view: sublime.View, location: int) -> TextDocu
     return {"textDocument": text_document_identifier(view), "position": position(view, location)}
 
 
-def text_document_range_params(view: sublime.View, region: sublime.Region) -> Dict[str, Any]:
-    return {"textDocument": text_document_identifier(view), "range": region_to_range(view, region).to_lsp()}
-
-
 def did_open_text_document_params(view: sublime.View, language_id: str) -> Dict[str, Any]:
     return {"textDocument": text_document_item(view, language_id)}
 

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -5,6 +5,7 @@ from .protocol import Diagnostic
 from .protocol import DiagnosticRelatedInformation
 from .protocol import DiagnosticSeverity
 from .protocol import DocumentUri
+from .protocol import ExperimentalTextDocumentRangeParams
 from .protocol import Location
 from .protocol import LocationLink
 from .protocol import MarkedString
@@ -269,6 +270,10 @@ def versioned_text_document_identifier(view: sublime.View, version: int) -> Dict
 
 def text_document_position_params(view: sublime.View, location: int) -> TextDocumentPositionParams:
     return {"textDocument": text_document_identifier(view), "position": position(view, location)}
+
+
+def text_document_range_params(view: sublime.View, region: sublime.Region) -> ExperimentalTextDocumentRangeParams:
+    return {"textDocument": text_document_identifier(view), "range": region_to_range(view, region).to_lsp()}
 
 
 def did_open_text_document_params(view: sublime.View, language_id: str) -> Dict[str, Any]:

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -93,9 +93,6 @@ class LspHoverCommand(LspTextCommand):
         if not window:
             return
         hover_point = temp_point
-        window = self.view.window()
-        if not window:
-            return
         wm = windows.lookup(window)
         self._base_dir = wm.get_project_path(self.view.file_name() or "")
         self._hover_responses = []  # type: List[Hover]

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -20,9 +20,9 @@ from .core.views import FORMAT_MARKED_STRING, FORMAT_MARKUP_CONTENT, minihtml
 from .core.views import is_location_href
 from .core.views import make_command_link
 from .core.views import make_link
+from .core.views import region_to_range
 from .core.views import show_lsp_popup
 from .core.views import text_document_position_params
-from .core.views import text_document_range_params
 from .core.views import unpack_href_location
 from .core.views import update_lsp_popup
 from .core.windows import AbstractViewListener
@@ -129,7 +129,8 @@ class LspHoverCommand(LspTextCommand):
                 if region is not None:
                     if region.contains(point):
                         # hovering selection or only text was selected
-                        document_position = text_document_range_params(self.view, region)
+                        document_position.pop('position', None)
+                        document_position['range'] = region_to_range(self.view, region).to_lsp()
             hover_promises.append(session.send_request_task(
                 Request("textDocument/hover", document_position, self.view)
             ))

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -121,8 +121,8 @@ class LspHoverCommand(LspTextCommand):
 
     def request_symbol_hover_async(self, listener: AbstractViewListener, point: int) -> None:
         hover_promises = []  # type: List[Promise[ResolvedHover]]
-        document_position = text_document_position_params(self.view, point)
         for session in listener.sessions_async('hoverProvider'):
+            document_position = text_document_position_params(self.view, point)
             range_hover_provider = session.get_capability('experimental.rangeHoverProvider')
             if range_hover_provider:
                 region = first_selection_region(self.view)

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -37,6 +37,7 @@ SUBLIME_WORD_MASK = 515
 SessionName = str
 ResolvedHover = Union[Hover, Error]
 
+
 _test_contents = []  # type: List[str]
 
 

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -128,11 +128,11 @@ class LspHoverCommand(LspTextCommand):
             if range_hover_provider:
                 region = first_selection_region(self.view)
                 if region is not None:
-                    if region.contains(point): # when hovering selection send the selection as range
+                    if region.contains(point):  # when hovering selection send the selection as range
                         document_position = text_document_range_params(self.view, region)
-                    else: # there is selection but ignored
+                    else:  # there is selection but ignored
                         document_position = text_document_range_params(self.view, region)
-                else: # nothing selected
+                else:  # nothing selected
                     document_position = text_document_position_params(self.view, point)
             else:
                 document_position = text_document_position_params(self.view, point)

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -138,7 +138,7 @@ class LspHoverCommand(LspTextCommand):
                     else:
                         document_position = text_document_position_params(self.view, point_or_region)
             else:
-                document_position = text_document_range_params(self.view, PointOrRegion)
+                document_position = text_document_range_params(self.view, point_or_region)
             hover_promises.append(session.send_request_task(
                 Request("textDocument/hover", document_position, self.view)
             ))

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -220,7 +220,6 @@ class LspHoverCommand(LspTextCommand):
         _test_contents.append(contents)  # for testing only
 
         if contents:
-            # The previous popup could be in a different location from the next one
             if self.view.is_popup_visible():
                 update_lsp_popup(self.view, contents)
             else:

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -138,7 +138,7 @@ class LspHoverCommand(LspTextCommand):
         if session.get_capability('experimental.rangeHoverProvider'):
             region = first_selection_region(self.view)
             if region is not None and region.contains(point):
-                return text_document_range_params(self.view, region)
+                return text_document_range_params(self.view, point, region)
         return text_document_position_params(self.view, point)
 
     def _on_all_settled(self, responses: List[ResolvedHover], listener: AbstractViewListener, point: int) -> None:

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -111,9 +111,13 @@ class LspHoverCommand(LspTextCommand):
             if not only_diagnostics:
                 self.request_symbol_hover_async(listener, point_or_region)
             if isinstance(point_or_region, int):
-                hover_point = point_or_region
                 self._diagnostics_by_config, covering = listener.diagnostics_touching_point_async(
-                    hover_point, userprefs().show_diagnostics_severity_level)
+                    point_or_region, userprefs().show_diagnostics_severity_level)
+            else:
+                self._diagnostics_by_config, covering = listener.diagnostics_intersecting_region_async(
+                    point_or_region)
+            if isinstance(point_or_region, int):
+                hover_point = point_or_region
                 if self._diagnostics_by_config:
                     self.show_hover(listener, hover_point, only_diagnostics)
                 if not only_diagnostics and userprefs().show_code_actions_in_hover:
@@ -137,7 +141,6 @@ class LspHoverCommand(LspTextCommand):
                 document_position = text_document_range_params(self.view, point_or_region)
             else:
                 document_position = text_document_position_params(self.view, point_or_region)
-
             hover_promises.append(session.send_request_task(
                 Request("textDocument/hover", document_position, self.view)
             ))

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -121,19 +121,15 @@ class LspHoverCommand(LspTextCommand):
 
     def request_symbol_hover_async(self, listener: AbstractViewListener, point: int) -> None:
         hover_promises = []  # type: List[Promise[ResolvedHover]]
+        document_position = text_document_position_params(self.view, point)
         for session in listener.sessions_async('hoverProvider'):
             range_hover_provider = session.get_capability('experimental.rangeHoverProvider')
             if range_hover_provider:
                 region = first_selection_region(self.view)
                 if region is not None:
-                    if region.contains(point):  # when hovering selection send the selection as range
+                    if region.contains(point):
+                        # hovering selection or only text was selected
                         document_position = text_document_range_params(self.view, region)
-                    else:  # there is selection but ignored
-                        document_position = text_document_range_params(self.view, region)
-                else:  # nothing selected
-                    document_position = text_document_position_params(self.view, point)
-            else:
-                document_position = text_document_position_params(self.view, point)
             hover_promises.append(session.send_request_task(
                 Request("textDocument/hover", document_position, self.view)
             ))

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -122,15 +122,6 @@ class LspHoverCommand(LspTextCommand):
 
         sublime.set_timeout_async(run_async)
 
-    def _create_hover_request(
-        self, session: Session, point: int
-    ) -> Union[TextDocumentPositionParams, ExperimentalTextDocumentRangeParams]:
-        if session.get_capability('experimental.rangeHoverProvider'):
-            region = first_selection_region(self.view)
-            if region is not None and region.contains(point):
-                return text_document_range_params(self.view, region)
-        return text_document_position_params(self.view, point)
-
     def request_symbol_hover_async(self, listener: AbstractViewListener, point: int) -> None:
         hover_promises = []  # type: List[Promise[ResolvedHover]]
         for session in listener.sessions_async('hoverProvider'):
@@ -140,6 +131,15 @@ class LspHoverCommand(LspTextCommand):
             ))
 
         Promise.all(hover_promises).then(lambda responses: self._on_all_settled(responses, listener, point))
+
+    def _create_hover_request(
+        self, session: Session, point: int
+    ) -> Union[TextDocumentPositionParams, ExperimentalTextDocumentRangeParams]:
+        if session.get_capability('experimental.rangeHoverProvider'):
+            region = first_selection_region(self.view)
+            if region is not None and region.contains(point):
+                return text_document_range_params(self.view, region)
+        return text_document_position_params(self.view, point)
 
     def _on_all_settled(self, responses: List[ResolvedHover], listener: AbstractViewListener, point: int) -> None:
         hovers = []  # type: List[Hover]

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -20,7 +20,6 @@ from .core.views import FORMAT_MARKED_STRING, FORMAT_MARKUP_CONTENT, minihtml
 from .core.views import is_location_href
 from .core.views import make_command_link
 from .core.views import make_link
-from .core.views import hide_lsp_popup
 from .core.views import show_lsp_popup
 from .core.views import text_document_position_params
 from .core.views import text_document_range_params
@@ -231,13 +230,14 @@ class LspHoverCommand(LspTextCommand):
         if contents:
             # The previous popup could be in a different location from the next one
             if self.view.is_popup_visible():
-                hide_lsp_popup(self.view)
-            show_lsp_popup(
-                self.view,
-                contents,
-                flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY,
-                location=point,
-                on_navigate=lambda href: self._on_navigate(href, point))
+                update_lsp_popup(self.view, contents)
+            else:
+                show_lsp_popup(
+                    self.view,
+                    contents,
+                    flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY,
+                    location=point,
+                    on_navigate=lambda href: self._on_navigate(href, point))
 
     def _on_navigate(self, href: str, point: int) -> None:
         if href.startswith("subl:"):

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -130,15 +130,18 @@ class LspHoverCommand(LspTextCommand):
         point = point_or_region if isinstance(point_or_region, int) else point_or_region.begin()
         for session in listener.sessions_async('hoverProvider'):
             range_hover_provider = session.get_capability('experimental.rangeHoverProvider')
-            if range_hover_provider and isinstance(point_or_region, int):
-                for region in self.view.sel():
-                    if region.contains(point):
-                        # when hovering selection send it as range
-                        document_position = text_document_range_params(self.view, region)
-                    else:
-                        document_position = text_document_position_params(self.view, point_or_region)
+            if range_hover_provider:
+                if isinstance(point_or_region, int):
+                    for region in self.view.sel():
+                        if region.contains(point):
+                            # when hovering selection send it as range
+                            document_position = text_document_range_params(self.view, region)
+                        else:
+                            document_position = text_document_position_params(self.view, point_or_region)
+                else:
+                    document_position = text_document_range_params(self.view, point_or_region)
             else:
-                document_position = text_document_range_params(self.view, point_or_region)
+                document_position = text_document_position_params(self.view, point)
             hover_promises.append(session.send_request_task(
                 Request("textDocument/hover", document_position, self.view)
             ))


### PR DESCRIPTION
This relies on `experimental.rangeHoverProvider` which so far only Metals implement. But this workaround would be removed once https://github.com/microsoft/language-server-protocol/issues/377 is part of the LSP specification.

![Peek 2021-11-18 14-42](https://user-images.githubusercontent.com/1632384/142426666-5aa5a8a2-1c97-4a19-9d32-4de43738057c.gif)

Fixes https://github.com/scalameta/metals-sublime/issues/44