### PR TITLE
Fix LSP status field missing randomly

### DIFF
--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -225,7 +225,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
     def on_session_shutdown_async(self, session: Session) -> None:
         removed_session = self._session_views.pop(session.config.name, None)
         if removed_session:
-            removed_session.on_before_destroy()
+            removed_session.on_before_remove()
             if not self._session_views:
                 self.view.settings().erase("lsp_active")
                 self._registered = False
@@ -774,7 +774,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
     def _clear_session_views_async(self) -> None:
         session_views = self._session_views
         for session_view in session_views.values():
-            session_view.on_before_destroy()
+            session_view.on_before_remove()
 
         def clear_async() -> None:
             nonlocal session_views

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -773,11 +773,11 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
 
     def _clear_session_views_async(self) -> None:
         session_views = self._session_views
-        for session_view in session_views.values():
-            session_view.on_before_remove()
 
         def clear_async() -> None:
             nonlocal session_views
+            for session_view in session_views.values():
+                session_view.on_before_remove()
             session_views.clear()
 
         sublime.set_timeout_async(clear_async)

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -225,6 +225,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
     def on_session_shutdown_async(self, session: Session) -> None:
         removed_session = self._session_views.pop(session.config.name, None)
         if removed_session:
+            removed_session.on_before_destroy()
             if not self._session_views:
                 self.view.settings().erase("lsp_active")
                 self._registered = False
@@ -772,6 +773,8 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
 
     def _clear_session_views_async(self) -> None:
         session_views = self._session_views
+        for session_view in session_views.values():
+            session_view.on_before_destroy()
 
         def clear_async() -> None:
             nonlocal session_views

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -152,7 +152,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             if this is not None:
                 this._on_settings_object_changed()
 
-        self._current_syntax = None
+        self._current_syntax = self.view.settings().get("syntax")
         existing_uri = view.settings().get("lsp_uri")
         if isinstance(existing_uri, str):
             self._uri = existing_uri

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -143,6 +143,9 @@ class SessionBuffer:
     def add_session_view(self, sv: SessionViewProtocol) -> None:
         self.session_views.add(sv)
 
+    def remove_session_view(self, sv: SessionViewProtocol) -> None:
+        self.session_views.remove(sv)
+
     def register_capability_async(
         self,
         registration_id: str,

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -60,7 +60,7 @@ class SessionView:
         self._clear_auto_complete_triggers(settings)
         self._setup_auto_complete_triggers(settings)
 
-    def __del__(self) -> None:
+    def on_before_remove(self) -> None:
         settings = self.view.settings()  # type: sublime.Settings
         self._clear_auto_complete_triggers(settings)
         self._code_lenses.clear_view()
@@ -77,6 +77,7 @@ class SessionView:
         for severity in reversed(range(1, len(DIAGNOSTIC_SEVERITY) + 1)):
             self.view.erase_regions(self.diagnostics_key(severity, False))
             self.view.erase_regions(self.diagnostics_key(severity, True))
+        self.session_buffer.remove_session_view(self)
 
     def _is_listener_alive(self) -> bool:
         return bool(self.listener())


### PR DESCRIPTION
The status fields for indicating that the server is running would sometimes not be shown. This has happened randomly when sessions were initializing.

The issue was that the [view settings listener](https://github.com/sublimelsp/LSP/blob/a8e67857126b2c9914d556850ebfc32526f650c6/plugin/documents.py#L161-L161) set up in `DocumentViewListener` would always trigger initially since we didn't initialize `self._current_syntax` from `__init__` so the [check if something has changed](https://github.com/sublimelsp/LSP/blob/a8e67857126b2c9914d556850ebfc32526f650c6/plugin/documents.py#L786-L788) would evaluate to `True` and call `self._reset()`.

At the point the `self._reset()` is called the `SessionViews` might already have been created (and in fact almost always are since the settings change is triggered by us adding new keys on starting the session) and the reset call will result in [those being destroyed](https://github.com/sublimelsp/LSP/blob/a8e67857126b2c9914d556850ebfc32526f650c6/plugin/documents.py#L773-L780) and new `SessionViews` created.

Now, this doesn't fix the root issue. I think the root issue is the fact that the `SessionView.__del__` of those cleared instances can get called after the new `SessionView`s are created thus resulting in the old one erasing the view status set by the new one.

As nice as relying on `__del__` might seem, I think it would be better to have explicit public methods for clearing the state and not relying on `__del__` in general since it's not really guaranteed when those will run.

The fix ensures that we don't unnecessarily reset the sessions and trigger this issue on start.