### PR TITLE
fix types for protocols to add type safety

### DIFF
--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -1,8 +1,8 @@
 from .configurations import ConfigManager
+from .sessions import AbstractViewListener
 from .sessions import Session
 from .settings import client_configs
 from .typing import Optional, Any, Generator, Iterable
-from .windows import AbstractViewListener
 from .windows import WindowRegistry
 import sublime
 import sublime_plugin

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -55,9 +55,11 @@ from .views import get_storage_path
 from .views import get_uri_and_range_from_location
 from .views import SYMBOL_KINDS
 from .views import to_encoded_filename
+from .windows import AbstractViewListener
 from .workspace import is_subpath_of
 from abc import ABCMeta
 from abc import abstractmethod
+from weakref import ref
 from weakref import WeakSet
 import functools
 import mdpopups
@@ -340,10 +342,21 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
 
 class SessionViewProtocol(Protocol):
 
-    session = None  # type: Session
-    view = None  # type: sublime.View
-    listener = None  # type: Any
-    session_buffer = None  # type: Any
+    @property
+    def session(self) -> 'Session':
+        ...
+
+    @property
+    def view(self) -> sublime.View:
+        ...
+
+    @property
+    def listener(self) -> ref[AbstractViewListener]:
+        ...
+
+    @property
+    def session_buffer(self) -> 'SessionBufferProtocol':
+        ...
 
     def get_uri(self) -> Optional[str]:
         ...
@@ -384,8 +397,13 @@ class SessionViewProtocol(Protocol):
 
 class SessionBufferProtocol(Protocol):
 
-    session = None  # type: Session
-    session_views = None  # type: WeakSet[SessionViewProtocol]
+    @property
+    def session(self) -> 'Session':
+        ...
+
+    @property
+    def session_views(self) -> 'WeakSet[SessionViewProtocol]':
+        ...
 
     def get_uri(self) -> Optional[str]:
         ...

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -59,7 +59,6 @@ from .views import to_encoded_filename
 from .workspace import is_subpath_of
 from abc import ABCMeta
 from abc import abstractmethod
-from weakref import ref
 from weakref import WeakSet
 import functools
 import mdpopups

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -339,93 +339,6 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
     }
 
 
-class AbstractViewListener(metaclass=ABCMeta):
-
-    TOTAL_ERRORS_AND_WARNINGS_STATUS_KEY = "lsp_total_errors_and_warnings"
-
-    view = None  # type: sublime.View
-
-    @abstractmethod
-    def session_async(self, capability_path: str, point: Optional[int] = None) -> Optional['Session']:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def sessions_async(self, capability_path: Optional[str] = None) -> Generator['Session', None, None]:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def session_views_async(self) -> Iterable['SessionViewProtocol']:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def on_session_initialized_async(self, session: 'Session') -> None:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def on_session_shutdown_async(self, session: 'Session') -> None:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def diagnostics_async(
-        self
-    ) -> Iterable[Tuple['SessionBufferProtocol', Sequence[Tuple[Diagnostic, sublime.Region]]]]:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def diagnostics_intersecting_region_async(
-        self,
-        region: sublime.Region
-    ) -> Tuple[Sequence[Tuple['SessionBufferProtocol', Sequence[Diagnostic]]], sublime.Region]:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def diagnostics_touching_point_async(
-        self,
-        pt: int,
-        max_diagnostic_severity_level: int = DiagnosticSeverity.Hint
-    ) -> Tuple[Sequence[Tuple['SessionBufferProtocol', Sequence[Diagnostic]]], sublime.Region]:
-        raise NotImplementedError()
-
-    def diagnostics_intersecting_async(
-        self,
-        region_or_point: Union[sublime.Region, int]
-    ) -> Tuple[Sequence[Tuple['SessionBufferProtocol', Sequence[Diagnostic]]], sublime.Region]:
-        if isinstance(region_or_point, int):
-            return self.diagnostics_touching_point_async(region_or_point)
-        elif region_or_point.empty():
-            return self.diagnostics_touching_point_async(region_or_point.a)
-        else:
-            return self.diagnostics_intersecting_region_async(region_or_point)
-
-    @abstractmethod
-    def on_diagnostics_updated_async(self) -> None:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def on_code_lens_capability_registered_async(self) -> None:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def get_language_id(self) -> str:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def get_uri(self) -> str:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def do_signature_help_async(self, manual: bool) -> None:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def navigate_signature_help(self, forward: bool) -> None:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def on_post_move_window_async(self) -> None:
-        raise NotImplementedError()
-
-
 class SessionViewProtocol(Protocol):
 
     @property
@@ -519,6 +432,93 @@ class SessionBufferProtocol(Protocol):
 
     def on_diagnostics_async(self, raw_diagnostics: List[Diagnostic], version: Optional[int]) -> None:
         ...
+
+
+class AbstractViewListener(metaclass=ABCMeta):
+
+    TOTAL_ERRORS_AND_WARNINGS_STATUS_KEY = "lsp_total_errors_and_warnings"
+
+    view = None  # type: sublime.View
+
+    @abstractmethod
+    def session_async(self, capability_path: str, point: Optional[int] = None) -> Optional['Session']:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def sessions_async(self, capability_path: Optional[str] = None) -> Generator['Session', None, None]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def session_views_async(self) -> Iterable['SessionViewProtocol']:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def on_session_initialized_async(self, session: 'Session') -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def on_session_shutdown_async(self, session: 'Session') -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def diagnostics_async(
+        self
+    ) -> Iterable[Tuple['SessionBufferProtocol', Sequence[Tuple[Diagnostic, sublime.Region]]]]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def diagnostics_intersecting_region_async(
+        self,
+        region: sublime.Region
+    ) -> Tuple[Sequence[Tuple['SessionBufferProtocol', Sequence[Diagnostic]]], sublime.Region]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def diagnostics_touching_point_async(
+        self,
+        pt: int,
+        max_diagnostic_severity_level: int = DiagnosticSeverity.Hint
+    ) -> Tuple[Sequence[Tuple['SessionBufferProtocol', Sequence[Diagnostic]]], sublime.Region]:
+        raise NotImplementedError()
+
+    def diagnostics_intersecting_async(
+        self,
+        region_or_point: Union[sublime.Region, int]
+    ) -> Tuple[Sequence[Tuple['SessionBufferProtocol', Sequence[Diagnostic]]], sublime.Region]:
+        if isinstance(region_or_point, int):
+            return self.diagnostics_touching_point_async(region_or_point)
+        elif region_or_point.empty():
+            return self.diagnostics_touching_point_async(region_or_point.a)
+        else:
+            return self.diagnostics_intersecting_region_async(region_or_point)
+
+    @abstractmethod
+    def on_diagnostics_updated_async(self) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def on_code_lens_capability_registered_async(self) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_language_id(self) -> str:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_uri(self) -> str:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def do_signature_help_async(self, manual: bool) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def navigate_signature_help(self, forward: bool) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def on_post_move_window_async(self) -> None:
+        raise NotImplementedError()
 
 
 class AbstractPlugin(metaclass=ABCMeta):

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -13,6 +13,7 @@ from .protocol import DiagnosticSeverity
 from .protocol import DocumentUri
 from .protocol import Error
 from .protocol import Location
+from .sessions import AbstractViewListener
 from .sessions import get_plugin
 from .sessions import Logger
 from .sessions import Manager
@@ -30,8 +31,6 @@ from .views import format_diagnostic_for_panel
 from .views import make_link
 from .workspace import ProjectFolders
 from .workspace import sorted_workspace_folders
-from abc import ABCMeta
-from abc import abstractmethod
 from collections import OrderedDict
 from collections import deque
 from subprocess import CalledProcessError
@@ -46,91 +45,6 @@ import urllib.parse
 
 
 _NO_DIAGNOSTICS_PLACEHOLDER = "  No diagnostics. Well done!"
-
-
-class AbstractViewListener(metaclass=ABCMeta):
-
-    TOTAL_ERRORS_AND_WARNINGS_STATUS_KEY = "lsp_total_errors_and_warnings"
-
-    view = None  # type: sublime.View
-
-    @abstractmethod
-    def session_async(self, capability_path: str, point: Optional[int] = None) -> Optional[Session]:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def sessions_async(self, capability_path: Optional[str] = None) -> Generator[Session, None, None]:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def session_views_async(self) -> Iterable[SessionViewProtocol]:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def on_session_initialized_async(self, session: Session) -> None:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def on_session_shutdown_async(self, session: Session) -> None:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def diagnostics_async(self) -> Iterable[Tuple[SessionBufferProtocol, Sequence[Tuple[Diagnostic, sublime.Region]]]]:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def diagnostics_intersecting_region_async(
-        self,
-        region: sublime.Region
-    ) -> Tuple[Sequence[Tuple[SessionBufferProtocol, Sequence[Diagnostic]]], sublime.Region]:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def diagnostics_touching_point_async(
-        self,
-        pt: int,
-        max_diagnostic_severity_level: int = DiagnosticSeverity.Hint
-    ) -> Tuple[Sequence[Tuple[SessionBufferProtocol, Sequence[Diagnostic]]], sublime.Region]:
-        raise NotImplementedError()
-
-    def diagnostics_intersecting_async(
-        self,
-        region_or_point: Union[sublime.Region, int]
-    ) -> Tuple[Sequence[Tuple[SessionBufferProtocol, Sequence[Diagnostic]]], sublime.Region]:
-        if isinstance(region_or_point, int):
-            return self.diagnostics_touching_point_async(region_or_point)
-        elif region_or_point.empty():
-            return self.diagnostics_touching_point_async(region_or_point.a)
-        else:
-            return self.diagnostics_intersecting_region_async(region_or_point)
-
-    @abstractmethod
-    def on_diagnostics_updated_async(self) -> None:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def on_code_lens_capability_registered_async(self) -> None:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def get_language_id(self) -> str:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def get_uri(self) -> str:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def do_signature_help_async(self, manual: bool) -> None:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def navigate_signature_help(self, forward: bool) -> None:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def on_post_move_window_async(self) -> None:
-        raise NotImplementedError()
 
 
 def extract_message(params: Any) -> str:

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -8,8 +8,6 @@ from .logging import exception_log
 from .message_request_handler import MessageRequestHandler
 from .panels import log_server_message
 from .promise import Promise
-from .protocol import Diagnostic
-from .protocol import DiagnosticSeverity
 from .protocol import DocumentUri
 from .protocol import Error
 from .protocol import Location
@@ -18,13 +16,11 @@ from .sessions import get_plugin
 from .sessions import Logger
 from .sessions import Manager
 from .sessions import Session
-from .sessions import SessionBufferProtocol
-from .sessions import SessionViewProtocol
 from .settings import userprefs
 from .transports import create_transport
 from .types import ClientConfig
 from .types import matches_pattern
-from .typing import Optional, Any, Dict, Deque, List, Generator, Tuple, Iterable, Sequence, Union
+from .typing import Optional, Any, Dict, Deque, List, Generator, Tuple
 from .url import parse_uri
 from .views import extract_variables
 from .views import format_diagnostic_for_panel

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -14,6 +14,7 @@ from .core.protocol import Request
 from .core.protocol import SignatureHelp
 from .core.registry import best_session
 from .core.registry import windows
+from .core.sessions import AbstractViewListener
 from .core.sessions import Session
 from .core.settings import userprefs
 from .core.signature_help import SigHelp
@@ -32,7 +33,6 @@ from .core.views import range_to_region
 from .core.views import show_lsp_popup
 from .core.views import text_document_position_params
 from .core.views import update_lsp_popup
-from .core.windows import AbstractViewListener
 from .core.windows import WindowManager
 from .session_buffer import SessionBuffer
 from .session_view import SessionView

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -136,8 +136,6 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
     highlights_debounce_time = FEATURES_TIMEOUT
     code_lenses_debounce_time = FEATURES_TIMEOUT
 
-    _uri = None  # type: str
-
     @classmethod
     def applies_to_primary_view_only(cls) -> bool:
         return False
@@ -152,6 +150,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             if this is not None:
                 this._on_settings_object_changed()
 
+        self._uri = ''  # assumed to never be falsey
         self._current_syntax = self.view.settings().get("syntax")
         existing_uri = view.settings().get("lsp_uri")
         if isinstance(existing_uri, str):

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -10,6 +10,7 @@ from .core.protocol import RangeLsp
 from .core.protocol import Request
 from .core.registry import LspTextCommand
 from .core.registry import windows
+from .core.sessions import AbstractViewListener
 from .core.sessions import SessionBufferProtocol
 from .core.settings import userprefs
 from .core.typing import List, Optional, Dict, Tuple, Sequence, Union
@@ -24,7 +25,6 @@ from .core.views import show_lsp_popup
 from .core.views import text_document_position_params
 from .core.views import unpack_href_location
 from .core.views import update_lsp_popup
-from .core.windows import AbstractViewListener
 from urllib.parse import unquote, urlparse
 import functools
 import re

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -106,7 +106,7 @@ class SessionBuffer:
         return self._session
 
     @property
-    def session_views(self) -> WeakSet[SessionViewProtocol]:
+    def session_views(self) -> 'WeakSet[SessionViewProtocol]':
         return self._session_views
 
     def _check_did_open(self, view: sublime.View) -> None:

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -5,6 +5,7 @@ from .core.protocol import Range
 from .core.protocol import Request
 from .core.protocol import TextDocumentSyncKindFull
 from .core.protocol import TextDocumentSyncKindNone
+from .core.sessions import Session
 from .core.sessions import SessionViewProtocol
 from .core.settings import userprefs
 from .core.types import Capabilities
@@ -68,9 +69,9 @@ class SessionBuffer:
         self.opened = False
         # Every SessionBuffer has its own personal capabilities due to "dynamic registration".
         self.capabilities = Capabilities()
-        self.session = session_view.session
-        self.session_views = WeakSet()  # type: WeakSet[SessionViewProtocol]
-        self.session_views.add(session_view)
+        self._session = session_view.session
+        self._session_views = WeakSet()  # type: WeakSet[SessionViewProtocol]
+        self._session_views.add(session_view)
         self.last_known_uri = uri
         self.id = buffer_id
         self.pending_changes = None  # type: Optional[PendingChanges]
@@ -86,7 +87,7 @@ class SessionBuffer:
         self.diagnostics_debouncer = Debouncer()
         self.color_phantoms = sublime.PhantomSet(view, "lsp_color")
         self._check_did_open(view)
-        self.session.register_session_buffer_async(self)
+        self._session.register_session_buffer_async(self)
 
     def __del__(self) -> None:
         mgr = self.session.manager()
@@ -99,6 +100,14 @@ class SessionBuffer:
             # Only send textDocument/didClose when we are the only view left (i.e. there are no other clones).
             self._check_did_close()
             self.session.unregister_session_buffer_async(self)
+
+    @property
+    def session(self) -> Session:
+        return self._session
+
+    @property
+    def session_views(self) -> WeakSet[SessionViewProtocol]:
+        return self._session_views
 
     def _check_did_open(self, view: sublime.View) -> None:
         if not self.opened and self.should_notify_did_open():

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -6,13 +6,13 @@ from .core.protocol import DiagnosticTag
 from .core.protocol import DocumentUri
 from .core.protocol import Notification
 from .core.protocol import Request
+from .core.sessions import AbstractViewListener
 from .core.sessions import Session
 from .core.settings import userprefs
 from .core.types import debounced
 from .core.typing import Any, Iterable, List, Tuple, Optional, Dict, Generator
 from .core.views import DIAGNOSTIC_SEVERITY
 from .core.views import text_document_identifier
-from .core.windows import AbstractViewListener
 from .session_buffer import SessionBuffer
 from weakref import ref
 from weakref import WeakValueDictionary
@@ -88,7 +88,7 @@ class SessionView:
         return self._view
 
     @property
-    def listener(self) -> ref[AbstractViewListener]:
+    def listener(self) -> 'ref[AbstractViewListener]':
         return self._listener
 
     @property

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -61,23 +61,23 @@ class SessionView:
         self._setup_auto_complete_triggers(settings)
 
     def on_before_remove(self) -> None:
-        settings = self._view.settings()  # type: sublime.Settings
+        settings = self.view.settings()  # type: sublime.Settings
         self._clear_auto_complete_triggers(settings)
         self._code_lenses.clear_view()
-        if self._session.has_capability(self.HOVER_PROVIDER_KEY):
+        if self.session.has_capability(self.HOVER_PROVIDER_KEY):
             self._decrement_hover_count()
         # If the session is exiting then there's no point in sending textDocument/didClose and there's also no point
         # in unregistering ourselves from the session.
-        if not self._session.exiting:
+        if not self.session.exiting:
             for request_id, request in self.active_requests.items():
-                if request.view and request.view.id() == self._view.id():
-                    self._session.send_notification(Notification("$/cancelRequest", {"id": request_id}))
-            self._session.unregister_session_view_async(self)
-        self._session.config.erase_view_status(self._view)
+                if request.view and request.view.id() == self.view.id():
+                    self.session.send_notification(Notification("$/cancelRequest", {"id": request_id}))
+            self.session.unregister_session_view_async(self)
+        self.session.config.erase_view_status(self.view)
         for severity in reversed(range(1, len(DIAGNOSTIC_SEVERITY) + 1)):
-            self._view.erase_regions(self.diagnostics_key(severity, False))
-            self._view.erase_regions(self.diagnostics_key(severity, True))
-        self._session_buffer.remove_session_view(self)
+            self.view.erase_regions(self.diagnostics_key(severity, False))
+            self.view.erase_regions(self.diagnostics_key(severity, True))
+        self.session_buffer.remove_session_view(self)
 
     @property
     def session(self) -> Session:

--- a/plugin/tooling.py
+++ b/plugin/tooling.py
@@ -7,10 +7,11 @@ from .core.transports import Transport
 from .core.transports import TransportCallbacks
 from .core.types import Capabilities
 from .core.types import ClientConfig
-from .core.typing import Any, Callable, Dict, List, Optional, Tuple
+from .core.typing import Any, Callable, cast, Dict, List, Optional, Tuple
 from .core.version import __version__
 from .core.views import extract_variables
 from .core.views import make_command_link
+from .session_buffer import SessionBuffer
 from base64 import b64decode
 from base64 import b64encode
 from subprocess import list2cmdline
@@ -457,7 +458,7 @@ class LspDumpBufferCapabilities(sublime_plugin.TextCommand):
             p("## Global capabilities\n")
             p(print_capabilities(sv.session.capabilities) + "\n")
             p("## View-specific capabilities\n")
-            p(print_capabilities(sv.session_buffer.capabilities) + "\n")
+            p(print_capabilities(cast(SessionBuffer, sv.session_buffer).capabilities) + "\n")
 
 
 class ServerTestRunner(TransportCallbacks):


### PR DESCRIPTION
Fixes types for pyright in cases like below where we've blatantly lied about types.

![Screenshot 2021-11-23 at 10 41 10](https://user-images.githubusercontent.com/153197/143001503-c10171aa-190d-4eb8-9419-9aa487d854e1.png)

The way it was done before, apart from causing type issues with Pyright, allowed users to just access `session_view.session_buffer` from `Session`, for example, and get away with accessing anything on `SessionBuffer` because the type was `Any`.

@jwortmann sorry to cause troubles for you again. I don't mean bad. :)