### PR TITLE
POC: Fix LSP-pyright code highlighting

### DIFF
--- a/Syntaxes/Popups-Python.sublime-syntax
+++ b/Syntaxes/Popups-Python.sublime-syntax
@@ -1,0 +1,29 @@
+%YAML 1.2
+---
+name: Python (for LSP)
+scope: source.python.lsp
+hidden: true
+
+extends: Packages/Python/Python.sublime-syntax
+
+contexts:
+  main:
+    - meta_include_prototype: false
+    - match: ''
+      push: [statements, lsp-type]
+
+  lsp-type:
+    - meta_include_prototype: false
+    - match: \(
+      scope: punctuation.section.parens.begin.python
+      set: lsp-type-body
+    - match: (?=\S)
+      pop: true
+
+  lsp-type-body:
+    - meta_scope: meta.parens.python
+    - meta_content_scope: storage.type.python
+    - match: \)
+      scope: punctuation.section.parens.end.python
+      pop: true
+

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -521,6 +521,9 @@ def minihtml(
     else:
         frontmatter = {
             "allow_code_wrap": True,
+            "language_map": {
+                "python": (("python", "py"), ("LSP/Syntaxes/Popups-Python",))
+            },
             "markdown_extensions": [
                 {
                     "pymdownx.escapeall": {


### PR DESCRIPTION
This commit ...

1. adds a Popups-Python.sublime-syntax and
2. assigns it to mdpopups using `language_map` in frontmatter.

The goal is to fix the highlighting issue of the leading `(type)` parentheses in code fences returned by LSP-pyright.

This is a proof of concept.

Maybe a support plugin such as LSP-pyright should be able to register a syntax definition.

Without this commit

![grafik](https://user-images.githubusercontent.com/16542113/143781961-5bc40561-eb41-4e65-9c13-20ddd1ce52ef.png)

With this commit

![grafik](https://user-images.githubusercontent.com/16542113/143781929-164381b3-7131-43e4-b304-efe12583f3dc.png)
