### PR TITLE
Don't call the callback if the transport was closed

### DIFF
--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -142,6 +142,8 @@ class ProcessTransport(Transport[T]):
                     continue
 
                 def invoke(p: T) -> None:
+                    if self._closed:
+                        return
                     callback_object = self._callback_object()
                     if callback_object:
                         callback_object.on_payload(p)


### PR DESCRIPTION
When saving an LSP package's `plugin.py`, the plugin would unload and the chokidar file watcher would be destroyed but the callback would still be attempted. The weak reference is not gone because it's referenced by the `ProcessTransport` itself.