### PR TITLE
Add `confirm_global_rename` option to ease rename confirmation prompt

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -10,6 +10,10 @@
   // "settings" section of project files.
   "lsp_format_on_save": false,
 
+  // Display a confirmation prompt before performing global rename operations
+  // that will modify more than one file.
+  "confirm_global_rename": true,
+
   // A dictionary of code action identifiers that should be triggered on save.
   //
   // Code action identifiers are not officially standardized so refer to specific

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -184,6 +184,7 @@ def read_list_setting(settings_obj: sublime.Settings, key: str, default: list) -
 class Settings:
 
     # This is only for mypy
+    confirm_global_rename = None # type: bool
     diagnostics_additional_delay_auto_complete_ms = None  # type: int
     diagnostics_delay_ms = None  # type: int
     diagnostics_gutter_marker = None  # type: str
@@ -197,7 +198,7 @@ class Settings:
     log_max_size = None  # type: int
     log_server = None  # type: List[str]
     lsp_code_actions_on_save = None  # type: Dict[str, bool]
-    lsp_format_on_save = None  # type: bool
+    lsp_format_on_save = None  # type: bool    
     on_save_task_timeout_ms = None  # type: int
     only_show_lsp_completions = None  # type: bool
     popup_max_characters_height = None  # type: int
@@ -223,6 +224,7 @@ class Settings:
             val = s.get(name)
             setattr(self, name, val if isinstance(val, default.__class__) else default)
 
+        r("confirm_global_rename", True)
         r("diagnostics_additional_delay_auto_complete_ms", 0)
         r("diagnostics_delay_ms", 0)
         r("diagnostics_gutter_marker", "dot")
@@ -232,7 +234,7 @@ class Settings:
         r("log_debug", False)
         r("log_max_size", 8 * 1024)
         r("lsp_code_actions_on_save", {})
-        r("lsp_format_on_save", False)
+        r("lsp_format_on_save", False)        
         r("on_save_task_timeout_ms", 2000)
         r("only_show_lsp_completions", False)
         r("popup_max_characters_height", 1000)

--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -8,6 +8,7 @@ from .core.protocol import Request
 from .core.registry import get_position
 from .core.registry import LspTextCommand
 from .core.registry import windows
+from .core.settings import userprefs
 from .core.types import PANEL_FILE_REGEX, PANEL_LINE_REGEX
 from .core.typing import Any, Optional, Dict, List
 from .core.views import first_selection_region, range_to_region, get_line
@@ -126,7 +127,7 @@ class LspSymbolRenameCommand(LspTextCommand):
             if response:
                 changes = parse_workspace_edit(response)
                 file_count = len(changes.keys())
-                if file_count > 1:
+                if file_count > 1 and userprefs().confirm_global_rename:
                     total_changes = sum(map(len, changes.values()))
                     message = "Replace {} occurrences across {} files?".format(total_changes, file_count)
                     choice = sublime.yes_no_cancel_dialog(message, "Replace", "Dry Run")

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -280,6 +280,11 @@
             "lsp_code_actions_on_save": {
               "$ref": "sublime://settings/LSP#/definitions/lsp_code_actions_on_save",
             },
+            "confirm_global_rename": {
+              "type": "boolean",
+              "default": true,
+              "markdownDescription": "Display a confirmation prompt before performing global rename operations that will modify more than one file."
+            },
             "show_diagnostics_in_view_status": {
               "type": "boolean",
               "default": true,


### PR DESCRIPTION
This PR resolves my recently-created issue: https://github.com/sublimelsp/LSP/issues/1922

This worked in my own testing and I believe I followed all the appropriate conventions. Please let me know if I missed anything.