### PR TITLE
Fix lsp_show_scope_name command not working if view was dragged to a new window

### DIFF
--- a/plugin/semantic_highlighting.py
+++ b/plugin/semantic_highlighting.py
@@ -1,5 +1,5 @@
 from .core.registry import LspTextCommand
-from .core.typing import List
+from .core.typing import List, Optional
 import sublime
 
 
@@ -20,6 +20,9 @@ class LspShowScopeNameCommand(LspTextCommand):
     """
 
     capability = 'semanticTokensProvider'
+
+    def is_enabled(self, event: Optional[dict] = None, point: Optional[int] = None) -> bool:
+        return True
 
     def run(self, edit: sublime.Edit) -> None:
         point = self.view.sel()[-1].b


### PR DESCRIPTION
It is the same bug and fix as #1852.

I think the actual underlying bug is in the ST API, because https://github.com/sublimelsp/LSP/blob/f1e96dcc67b1351c409e145dcb338c458977db02/boot.py#L202 is only called when a view is dragged between two existing windows (or inside a single window), but not when it is dragged to a *new* window. I've tested and verified this with a few print statements.

With this API bug, the WindowRegistry doesn't get to know the new window ID, and therefore https://github.com/sublimelsp/LSP/blob/f1e96dcc67b1351c409e145dcb338c458977db02/plugin/core/registry.py#L76 doesn't work, which is called by `LspTextCommand.is_enabled()`, which then will return `False`.