### PR TITLE
Ensure view gets registered when tab is moved to create new window

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -199,13 +199,18 @@ class Listener(sublime_plugin.EventListener):
     def on_pre_close_window(self, w: sublime.Window) -> None:
         windows.discard(w)
 
-    def on_post_move_async(self, view: sublime.View) -> None:
+    # Note: EventListener.on_post_move_async does not fire when a tab is moved out of the current window in such a way
+    # that a new window is created: https://github.com/sublimehq/sublime_text/issues/4630
+    # Hence, as a workaround we use on_pre_move, which still works in that case.
+    def on_pre_move(self, view: sublime.View) -> None:
         listeners = sublime_plugin.view_event_listeners.get(view.id())
         if not isinstance(listeners, list):
             return
         for listener in listeners:
             if isinstance(listener, DocumentSyncListener):
-                return listener.on_post_move_window_async()
+                # we need a small delay here, so that the DocumentSyncListener will recognize a possible new window
+                sublime.set_timeout_async(listener.on_post_move_window_async, timeout_ms=1)
+                return
 
     def on_load(self, view: sublime.View) -> None:
         file_name = view.file_name()

--- a/plugin/save_command.py
+++ b/plugin/save_command.py
@@ -1,6 +1,6 @@
 from .core.registry import LspTextCommand
 from .core.settings import userprefs
-from .core.typing import Callable, List, Optional, Type
+from .core.typing import Callable, List, Type
 from abc import ABCMeta, abstractmethod
 import sublime
 import sublime_plugin

--- a/plugin/save_command.py
+++ b/plugin/save_command.py
@@ -90,15 +90,6 @@ class LspSaveCommand(LspTextCommand):
         else:
             self._trigger_native_save()
 
-    def is_enabled(self, event: Optional[dict] = None, point: Optional[int] = None) -> bool:
-        # Workaround to ensure that the command will run, even if a view was dragged out to a new window,
-        # see https://github.com/sublimelsp/LSP/issues/1791.
-        # The check to determine whether the keybinding for lsp_save is applicable already happens in
-        # DocumentSyncListener.on_query_context and should not be required here, if lsp_save is only used for the
-        # keybinding. A proper fix should ensure that LspTextCommand.is_enabled returns the correct value even for
-        # dragged out views and that LSP keeps working as expected.
-        return True
-
     def _trigger_on_pre_save_async(self) -> None:
         # Supermassive hack that will go away later.
         listeners = sublime_plugin.view_event_listeners.get(self.view.id(), [])

--- a/plugin/semantic_highlighting.py
+++ b/plugin/semantic_highlighting.py
@@ -1,5 +1,5 @@
 from .core.registry import LspTextCommand
-from .core.typing import List, Optional
+from .core.typing import List
 import sublime
 
 

--- a/plugin/semantic_highlighting.py
+++ b/plugin/semantic_highlighting.py
@@ -21,9 +21,6 @@ class LspShowScopeNameCommand(LspTextCommand):
 
     capability = 'semanticTokensProvider'
 
-    def is_enabled(self, event: Optional[dict] = None, point: Optional[int] = None) -> bool:
-        return True
-
     def run(self, edit: sublime.Edit) -> None:
         point = self.view.sel()[-1].b
 


### PR DESCRIPTION
This is a workaround for the following ST bug: https://github.com/sublimehq/sublime_text/issues/4630

With this change, LspTextCommands still work after a tab is dragged out of a window to create a new window. For example lsp_hover will work again in such a case :)

The 1ms delay appears to be sufficient, so that this check still works:
https://github.com/sublimelsp/LSP/blob/19a01aa045de04bcc805e56043923656548050e0/plugin/documents.py#L205