### PR TITLE
Ensure code actions lightbulb icon is on top

### DIFF
--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -130,7 +130,6 @@ class TextChangeListener(sublime_plugin.TextChangeListener):
 
 class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListener):
 
-    CODE_ACTIONS_KEY = "lsp_code_action"
     ACTIVE_DIAGNOSTIC = "lsp_active_diagnostic"
     code_actions_debounce_time = FEATURES_TIMEOUT
     color_boxes_debounce_time = FEATURES_TIMEOUT
@@ -550,10 +549,10 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             code_actions_link = make_command_link('lsp_code_actions', title, {"commands_by_config": responses})
             annotations = ["<div class=\"actions\" style=\"font-family:system\">{}</div>".format(code_actions_link)]
             annotation_color = self.view.style_for_scope("region.bluish markup.accent.codeaction.lsp")["foreground"]
-        self.view.add_regions(self.CODE_ACTIONS_KEY, regions, scope, icon, flags, annotations, annotation_color)
+        self.view.add_regions(SessionView.CODE_ACTIONS_KEY, regions, scope, icon, flags, annotations, annotation_color)
 
     def _clear_code_actions_annotation(self) -> None:
-        self.view.erase_regions(self.CODE_ACTIONS_KEY)
+        self.view.erase_regions(SessionView.CODE_ACTIONS_KEY)
 
     # --- textDocument/codeLens ----------------------------------------------------------------------------------------
 

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -33,6 +33,7 @@ class SessionView:
     AC_TRIGGERS_KEY = "auto_complete_triggers"
     COMPLETION_PROVIDER_KEY = "completionProvider"
     TRIGGER_CHARACTERS_KEY = "completionProvider.triggerCharacters"
+    CODE_ACTIONS_KEY = "lsp_code_action"
 
     _session_buffers = WeakValueDictionary()  # type: WeakValueDictionary[Tuple[int, int], SessionBuffer]
 
@@ -114,6 +115,7 @@ class SessionView:
             for kind in document_highlight_kinds:
                 for mode in line_modes:
                     self.view.add_regions("lsp_highlight_{}{}".format(kind, mode), r)
+        self.view.add_regions(self.CODE_ACTIONS_KEY, r)
         for severity in range(1, 5):
             for mode in line_modes:
                 self.view.add_regions("lsp{}d{}{}".format(self.session.config.name, mode, severity), r)

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -103,19 +103,23 @@ class SessionView:
     def _initialize_region_keys(self) -> None:
         """
         Initialize all region keys for the View.add_regions method to enforce a certain draw order for overlapping
-        diagnostics, semantic tokens and document highlights, see https://github.com/sublimelsp/LSP/issues/1593.
+        diagnostics, semantic tokens, document highlights, and gutter icons. The draw order seems to follow the
+        following rules:
+          - inline decorations (underline & background) from region keys which were initialized _last_ are drawn on top
+          - gutter icons from region keys which were initialized _first_ are drawn
+        For more context, see https://github.com/sublimelsp/LSP/issues/1593.
         """
         r = [sublime.Region(0, 0)]
         document_highlight_style = userprefs().document_highlight_style
         document_highlight_kinds = ["text", "read", "write"]
         line_modes = ["m", "s"]
+        self.view.add_regions(self.CODE_ACTIONS_KEY, r)  # code actions lightbulb icon should always be on top
         for key, scope in self.session.semantic_tokens_map:
             self.view.add_regions("lsp_{} meta.semantic-token.{}.lsp".format(scope, key), r)
         if document_highlight_style == "fill":
             for kind in document_highlight_kinds:
                 for mode in line_modes:
                     self.view.add_regions("lsp_highlight_{}{}".format(kind, mode), r)
-        self.view.add_regions(self.CODE_ACTIONS_KEY, r)
         for severity in range(1, 5):
             for mode in line_modes:
                 self.view.add_regions("lsp{}d{}{}".format(self.session.config.name, mode, severity), r)

--- a/tests/test_code_actions.py
+++ b/tests/test_code_actions.py
@@ -5,6 +5,7 @@ from LSP.plugin.core.typing import Any, Dict, Generator, List, Tuple, Optional
 from LSP.plugin.core.url import filename_to_uri
 from LSP.plugin.core.views import entire_content
 from LSP.plugin.documents import DocumentSyncListener
+from LSP.plugin.session_view import SessionView
 from LSP.plugin.core.views import versioned_text_document_identifier
 from setup import TextDocumentTestCase
 from test_single_document import TEST_FILE_PATH
@@ -271,7 +272,7 @@ class CodeActionsListenerTestCase(TextDocumentTestCase):
         self.assertEquals(params['range']['end']['line'], 1)
         self.assertEquals(params['range']['end']['character'], 1)
         self.assertEquals(len(params['context']['diagnostics']), 2)
-        annotations_range = self.view.get_regions(DocumentSyncListener.CODE_ACTIONS_KEY)
+        annotations_range = self.view.get_regions(SessionView.CODE_ACTIONS_KEY)
         self.assertEquals(len(annotations_range), 1)
         self.assertEquals(annotations_range[0].a, 3)
         self.assertEquals(annotations_range[0].b, 0)
@@ -293,7 +294,7 @@ class CodeActionsListenerTestCase(TextDocumentTestCase):
         self.assertEquals(params['range']['end']['line'], 1)
         self.assertEquals(params['range']['end']['character'], 1)
         self.assertEquals(len(params['context']['diagnostics']), 0)
-        annotations_range = self.view.get_regions(DocumentSyncListener.CODE_ACTIONS_KEY)
+        annotations_range = self.view.get_regions(SessionView.CODE_ACTIONS_KEY)
         self.assertEquals(len(annotations_range), 1)
         self.assertEquals(annotations_range[0].a, 3)
         self.assertEquals(annotations_range[0].b, 0)


### PR DESCRIPTION
I must say I can't make any sense of the logic behind ST's region draw priority. For the inline decorations (underline, background), the regions which were initialized *last* end up on top, while the displayed icon is chosen from the regions, which were initialized *first*.

Whatever, this seems to work reliably for me now.