### PR TITLE
Announce in initialize request that we augment syntax tokens

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -350,7 +350,8 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
                 "relative"
             ],
             "overlappingTokenSupport": False,
-            "multilineTokenSupport": True
+            "multilineTokenSupport": True,
+            "augmentsSyntaxTokens": True
         }
     }
     workspace_capabilites = {


### PR DESCRIPTION
There was a new field in the client capabilities for semantic tokens added to the upcoming 3.17 version of the LSP spec:

```typescript
	/**
	 * Whether the client uses semantic tokens to augment existing
	 * syntax tokens. If set to `true` client side created syntax
	 * tokens and semantic tokens are both used for colorization. If
	 * set to `false` the client only uses the returned semantic tokens
	 * for colorization.
	 *
	 * If the value is `undefined` then the client behavior is not
	 * specified.
	 *
	 * @since 3.17.0
	 */
	augmentsSyntaxTokens?: boolean;
```

I could imagine / hope that servers like rust-analyzer will use that field in the future, to decide whether to emit tokens to just enhance the existing syntax highlighting (with things which are not possible with a static regex-based highlighting engine), or to take over all highlighting and emit tokens for everything in the file.