### PR TITLE
Prevent semantic tokens delta request after previous error response

### DIFF
--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -495,6 +495,7 @@ class SessionBuffer:
 
     def _on_semantic_tokens_error_async(self, error: dict) -> None:
         self.semantic_tokens.pending_response = None
+        self.semantic_tokens.result_id = None
 
     def _draw_semantic_tokens_async(self) -> None:
         view = self.some_view()


### PR DESCRIPTION
I have not observed it in practice, but there is a situation where the current logic for semantic token requests could fail in theory:

1. We have some semantic tokens data stored from a full or delta request, with a `resultId` given from the server
2. After typing in the buffer, we send a delta request (`textDocument/semanticTokens/full/delta`) for the stored data with the `resultId`
3. There are more changes in the buffer before the response arrived, so we send a cancel notification for the request, and a new delta request (still with the same `resultId`)
4. The server ignores the cancel notification for the first request (this is allowed per LSP spec) and responds with semantic tokens delta to our first request (from 2.) and a new `resultId`
5. We ignore the response to the cancelled request, because the buffer is in a different state in the meanwhile
6. The server has internally only stored the token data with the new `resultId` (from 4.) now, and deleted/overwritten its token data corresponding to the first `resultId`. Therefore it can only respond with an error response to our last request (from 3.)
7. For every new change in the buffer, we still send delta requests with the outdated `resultId`, and will always get error responses from now on

Solution: after receiving an error response, we reset the `resultId`, so that the next request will definitely be a request for full tokens (`textDocument/semanticTokens/full`).