### PR TITLE
Lowercase keys for initializing semantic token regions

### DIFF
--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -115,7 +115,7 @@ class SessionView:
         line_modes = ["m", "s"]
         self.view.add_regions(self.CODE_ACTIONS_KEY, r)  # code actions lightbulb icon should always be on top
         for key, scope in self.session.semantic_tokens_map:
-            self.view.add_regions("lsp_{} meta.semantic-token.{}.lsp".format(scope, key), r)
+            self.view.add_regions("lsp_{} meta.semantic-token.{}.lsp".format(scope, key.lower()), r)
         if document_highlight_style == "fill":
             for kind in document_highlight_kinds:
                 for mode in line_modes:


### PR DESCRIPTION
A small bug which prevented the region keys to match what will actually be used when drawing semantic tokens in a few cases.