### PR TITLE
Document the command for showing signature help

### DIFF
--- a/docs/src/keyboard_shortcuts.md
+++ b/docs/src/keyboard_shortcuts.md
@@ -28,7 +28,7 @@ Refer to the [Customization section](customization.md#keyboard-shortcuts-key-bin
 | Run Code Action | unbound | `lsp_code_actions`
 | Run Source Action | unbound | `lsp_code_actions` (with args: `{"only_kinds": ["source"]}`)
 | Run Code Lens | unbound | `lsp_code_lens`
-| Signature Help | <kbd>ctrl</kbd> <kbd>alt</kbd> <kbd>space</kbd> | -
+| Signature Help | <kbd>ctrl</kbd> <kbd>alt</kbd> <kbd>space</kbd> | `lsp_signature_help_show`
 | Hover Popup | unbound | `lsp_hover`
 | Toggle Diagnostics Panel | <kbd>ctrl</kbd> <kbd>alt</kbd> <kbd>m</kbd> | `lsp_show_diagnostics_panel`
 | Toggle Log Panel | unbound | `lsp_toggle_server_panel`


### PR DESCRIPTION
`lsp_signature_help_show` is now a thing and docs should reflect. I figured it out by reading the source and then testing it - seems to work :)