### PR TITLE
Reorganize documentation for JavaScript/TypeScript

### DIFF
--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -112,10 +112,6 @@ Follow installation instructions on [LSP-elm](https://github.com/sublimelsp/LSP-
     }
     ```
 
-## ESLint
-
-Follow installation instructions on [LSP-eslint](https://github.com/sublimelsp/LSP-eslint).
-
 ## F\#
 
 1. Install the [F#](https://packagecontrol.io/packages/F%23) package from Package Control for syntax highlighting.
@@ -142,10 +138,6 @@ Follow installation instructions on [LSP-eslint](https://github.com/sublimelsp/L
         }
     }
     ```
-
-## Flow
-
-Follow installation instructions on [LSP-flow](https://github.com/sublimelsp/LSP-flow).
 
 ## Fortran
 
@@ -220,6 +212,28 @@ Follow installation instructions on [LSP-html](https://github.com/sublimelsp/LSP
 ## Java
 
 Follow installation instructions on [LSP-jdtls](https://github.com/sublimelsp/LSP-jdtls).
+
+## JavaScript/TypeScript
+
+See also [Vue](#vue).
+
+There are multiple options:
+
+### Deno
+
+Follow installation instructions on [LSP-Deno](https://github.com/sublimelsp/LSP-Deno).
+
+### ESLint
+
+Follow installation instructions on [LSP-eslint](https://github.com/sublimelsp/LSP-eslint).
+
+### Flow
+
+Follow installation instructions on [LSP-flow](https://github.com/sublimelsp/LSP-flow).
+
+### TypeScript
+
+Follow installation instructions on [LSP-typescript](https://github.com/sublimelsp/LSP-typescript).
 
 ## JSON
 
@@ -523,12 +537,6 @@ Follow installation instructions on [LSP-tailwindcss](https://github.com/sublime
         }
     }
     ```
-
-## TypeScript / JavaScript
-
-Follow installation instructions on [LSP-typescript](https://github.com/sublimelsp/LSP-typescript).
-
-For development using the Deno framework follow installation instructions on [LSP-Deno](https://github.com/sublimelsp/LSP-Deno).
 
 ## Vue
 


### PR DESCRIPTION
The language servers for JavaScript are scattered throughout the
documentation. Most other language servers are grouped by programming
language. Reorganize the documentation for JavaScript language servers
so it's easy to see what options are available for JS developers.