### PR TITLE
Guard for overflow of the column offset when applying edits

### DIFF
--- a/plugin/core/edit.py
+++ b/plugin/core/edit.py
@@ -1,7 +1,7 @@
 from .logging import debug
 from .open import open_file
 from .promise import Promise
-from .protocol import TextEdit as LspTextEdit, Position
+from .protocol import UINT_MAX, TextEdit as LspTextEdit, Position
 from .typing import List, Dict, Any, Optional, Tuple
 from functools import partial
 import sublime
@@ -34,7 +34,7 @@ def parse_workspace_edit(workspace_edit: Dict[str, Any]) -> Dict[str, List[TextE
 
 
 def parse_range(range: Position) -> Tuple[int, int]:
-    return range['line'], range['character']
+    return range['line'], min(UINT_MAX, range['character'])
 
 
 def parse_text_edit(text_edit: LspTextEdit, version: int = None) -> TextEditTuple:

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -3,6 +3,8 @@ from .url import filename_to_uri
 import os
 import sublime
 
+INT_MAX = 2**31 - 1
+UINT_MAX = 2**32 - 1
 
 TextDocumentSyncKindNone = 0
 TextDocumentSyncKindFull = 1

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -4,7 +4,7 @@ import os
 import sublime
 
 INT_MAX = 2**31 - 1
-UINT_MAX = 2**32 - 1
+UINT_MAX = INT_MAX
 
 TextDocumentSyncKindNone = 0
 TextDocumentSyncKindFull = 1

--- a/plugin/edit.py
+++ b/plugin/edit.py
@@ -1,6 +1,5 @@
 from .core.edit import TextEditTuple
 from .core.logging import debug
-from .core.protocol import UINT_MAX
 from .core.typing import List, Optional, Any, Generator, Iterable
 from contextlib import contextmanager
 import operator
@@ -36,8 +35,8 @@ class LspApplyDocumentEditCommand(sublime_plugin.TextCommand):
                     debug('ignoring edit due to non-matching document version')
                     continue
                 region = sublime.Region(
-                    self.view.text_point_utf16(start[0], min(UINT_MAX, start[1]), clamp_column=True),
-                    self.view.text_point_utf16(end[0], min(UINT_MAX, end[1]), clamp_column=True)
+                    self.view.text_point_utf16(*start, clamp_column=True),
+                    self.view.text_point_utf16(*end, clamp_column=True)
                 )
                 if start[0] > last_row and replacement[0] != '\n':
                     # Handle when a language server (eg gopls) inserts at a row beyond the document

--- a/plugin/edit.py
+++ b/plugin/edit.py
@@ -1,5 +1,6 @@
 from .core.edit import TextEditTuple
 from .core.logging import debug
+from .core.protocol import UINT_MAX
 from .core.typing import List, Optional, Any, Generator, Iterable
 from contextlib import contextmanager
 import operator
@@ -35,8 +36,8 @@ class LspApplyDocumentEditCommand(sublime_plugin.TextCommand):
                     debug('ignoring edit due to non-matching document version')
                     continue
                 region = sublime.Region(
-                    self.view.text_point_utf16(*start, clamp_column=True),
-                    self.view.text_point_utf16(*end, clamp_column=True)
+                    self.view.text_point_utf16(start[0], min(UINT_MAX, start[1]), clamp_column=True),
+                    self.view.text_point_utf16(end[0], min(UINT_MAX, end[1]), clamp_column=True)
                 )
                 if start[0] > last_row and replacement[0] != '\n':
                     # Handle when a language server (eg gopls) inserts at a row beyond the document

--- a/tests/test_single_document.py
+++ b/tests/test_single_document.py
@@ -323,8 +323,12 @@ class SingleDocumentTestCase(TextDocumentTestCase):
                             'newText': 'bar'
                         },
                         {
-                            # Check that lsp_apply_document_edit guards for overflow by using sys.maxsize + 1
-                            'range': {'start': {'character': 0, 'line': 2}, 'end': {'character': sys.maxsize + 1, 'line': 2}},
+                            'range':
+                            {
+                                'start': {'character': 0, 'line': 2},
+                                # Check that lsp_apply_document_edit guards for overflow by using sys.maxsize + 1
+                                'end': {'character': sys.maxsize + 1, 'line': 2}
+                            },
                             'newText': 'bar'
                         }
                     ]

--- a/tests/test_single_document.py
+++ b/tests/test_single_document.py
@@ -8,6 +8,8 @@ from setup import TIMEOUT_TIME
 from setup import YieldPromise
 import os
 import sublime
+import sys
+
 
 try:
     from typing import Generator, Optional, Iterable, Tuple, List
@@ -321,7 +323,8 @@ class SingleDocumentTestCase(TextDocumentTestCase):
                             'newText': 'bar'
                         },
                         {
-                            'range': {'start': {'character': 0, 'line': 2}, 'end': {'character': 3, 'line': 2}},
+                            # Check that lsp_apply_document_edit guards for overflow by using sys.maxsize + 1
+                            'range': {'start': {'character': 0, 'line': 2}, 'end': {'character': sys.maxsize + 1, 'line': 2}},
                             'newText': 'bar'
                         }
                     ]


### PR DESCRIPTION
We could also guard for overflow from the client side. This is all totally hypothetical and I haven't actually tried using LSP-Prisma yet.

Related: #1951 