### PR TITLE
Check for `:` and `/` while updating nested dict structures in DottedDict

### DIFF
--- a/plugin/core/collections.py
+++ b/plugin/core/collections.py
@@ -113,7 +113,9 @@ class DottedDict:
         """
         return bool(self._d)
 
-    def __contains__(self, path: str) -> bool:
+    def __contains__(self, path: object) -> bool:
+        if not isinstance(path, str):
+            return False
         value = self.get(path)
         return value is not None and value is not False
 

--- a/plugin/core/collections.py
+++ b/plugin/core/collections.py
@@ -154,7 +154,7 @@ class DottedDict:
         return sublime.expand_variables(self._d, variables)
 
     def _update_recursive(self, current: Dict[str, Any], prefix: str) -> None:
-        if not current:
+        if not current or any(filter(lambda key: isinstance(key, str) and (":" in key or "/" in key), current.keys())):
             return self.set(prefix, current)
         for key, value in current.items():
             path = "{}.{}".format(prefix, key)

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -137,3 +137,45 @@ class DottedDictTests(TestCase):
         self.assertEqual(d.get(), {"a": {}})
         d.update({"a": {"b": {}}})
         self.assertEqual(d.get(), {"a": {"b": {}}})
+
+    def test_from_base_and_override(self) -> None:
+        base = DottedDict({
+            "yaml.schemas": {}
+        })
+        override = {
+            "yaml.schemas": {
+                "http://foo.com/bar.json": "**/*.json"
+            }
+        }
+        result = DottedDict.from_base_and_override(base, override)
+        self.assertEqual(
+            result.get(None),
+            {
+                "yaml": {
+                    "schemas": {
+                        "http://foo.com/bar.json": "**/*.json"
+                    }
+                }
+            }
+        )
+
+    def test_update_with_dicts(self) -> None:
+        base = {
+            "settings": {
+                "yaml.schemas": {}
+            }
+        }
+        overrides = {
+            "yaml.schemas": {
+                "http://foo.com/bar.json": "**/*.json"
+            }
+        }
+        settings = DottedDict(base.get("settings", {}))
+        settings.update(overrides)
+        self.assertEqual(settings.get(), {
+            "yaml": {
+                "schemas": {
+                    "http://foo.com/bar.json": "**/*.json"
+                }
+            }
+        })


### PR DESCRIPTION
This is another attempt at fixing #1858. This time we keep the old behavior of
merging dicts only for the custom client dicts.

Fixes #1858