### PR TITLE
Just skip empty stderr messages, don't break on them

### DIFF
--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -206,7 +206,7 @@ class ProcessTransport(Transport[T]):
                     return
                 message = self._stderr.readline().decode('utf-8', 'replace')
                 if message == '':
-                    break
+                    continue
                 callback_object = self._callback_object()
                 if callback_object:
                     callback_object.on_stderr_message(message.rstrip())


### PR DESCRIPTION
Hello! I'm working on an non-proprietary implementation of [VS Code's Development Container](https://code.visualstudio.com/docs/remote/create-dev-container) protocol, [Open Devcontainer](https://gitlab.com/smoores/open-devcontainer). While testing for compatibility with Sublime Text and Sublime LSP, I found what I _think_ is an issue with the ProcessTransport implementation: Sublime LSP considers an empty message in stderr to be a justification for closing the pipe. Unfortunately, it seems that `docker exec` (which `odc` uses for running language servers in containers) emits such an empty message immediately on startup, so all processes are immediately disconnected.

This has come up before, and I'm certain I don't have the whole story, so please let me know if this won't work! It looks like it was initially brought up in [this issue](https://github.com/sublimelsp/LSP/issues/1237), and a [PR](https://github.com/sublimelsp/LSP/pull/1242) was opened to address it, but that PR was later [reverted](https://github.com/sublimelsp/LSP/commit/708655d9c79a90dc82324968e8d74cf6925d6c16) and the issue was left closed. There was a [follow up PR](https://github.com/sublimelsp/LSP/pull/1256) a few days later to specifically close the stream when an empty message is sent, and I'm not sure why, but I would love the context!

I've tested this PR with both `gopls` and `pyright` running inside Docker containers, and with `gopls` running locally via the provided `gopls` config in Sublime LSP, and everything _seems_ to work correctly. All code actions and lookups seem to be working, and if I manually kill the language server, Sublime LSP starts a new one for the next request (which I believe to be the correct behavior).