### PR TITLE
Fix WSL path URI decoding under Windows

### DIFF
--- a/plugin/core/url.py
+++ b/plugin/core/url.py
@@ -49,8 +49,8 @@ def parse_uri(uri: str) -> Tuple[str, str]:
     parsed = urlparse(uri)
     if parsed.scheme == "file":
         path = url2pathname(parsed.path)
-        netloc = url2pathname(parsed.netloc)
         if os.name == 'nt':
+            netloc = url2pathname(parsed.netloc)
             path = path.lstrip("\\")
             path = re.sub(r"^([a-z]):", _uppercase_driveletter, path)
             if netloc:

--- a/plugin/core/url.py
+++ b/plugin/core/url.py
@@ -49,12 +49,13 @@ def parse_uri(uri: str) -> Tuple[str, str]:
     parsed = urlparse(uri)
     if parsed.scheme == "file":
         path = url2pathname(parsed.path)
+        netloc = url2pathname(parsed.netloc)
         if os.name == 'nt':
             path = path.lstrip("\\")
             path = re.sub(r"^([a-z]):", _uppercase_driveletter, path)
-            if parsed.netloc:
+            if netloc:
                 # Convert to UNC path
-                return parsed.scheme, "\\\\{}\\{}".format(parsed.netloc, path)
+                return parsed.scheme, "\\\\{}\\{}".format(netloc, path)
             else:
                 return parsed.scheme, path
         return parsed.scheme, path

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -35,6 +35,11 @@ class WindowsTests(unittest.TestCase):
         self.assertEqual(scheme, "file")
         self.assertEqual(path, R'\\192.168.80.2\D$\www\File.php')
 
+    def test_wsl_path(self):
+        scheme, path = parse_uri('file://wsl%24/Ubuntu-20.04/File.php')
+        self.assertEqual(scheme, "file")
+        self.assertEqual(path, R'\\wsl$\Ubuntu-20.04\File.php')
+
 
 @unittest.skipIf(sys.platform.startswith("win"), "requires non-Windows")
 class NixTests(unittest.TestCase):


### PR DESCRIPTION
```
Python 3.3>>> from LSP.plugin.core.url import filename_to_uri, parse_uri, urlparse

Python 3.3>>> filename_to_uri('\\\\wsl$\\Ubuntu-20.04\\home\\jfcherng\\Desktop\\docs\\a.py')
'file://wsl%24/Ubuntu-20.04/home/jfcherng/Desktop/docs/a.py'
           
Python 3.3>>> parse_uri('file://wsl%24/Ubuntu-20.04/home/jfcherng/Desktop/docs/a.py')
('file', '\\\\wsl%24\\Ubuntu-20.04\\home\\jfcherng\\Desktop\\docs\\a.py')
                 ^^^ this is wrong. should be $

Python 3.3>>> urlparse('file://wsl%24/Ubuntu-20.04/home/jfcherng/Desktop/docs/a.py')
ParseResult(scheme='file', netloc='wsl%24', path='/Ubuntu-20.04/home/jfcherng/Desktop/docs/a.py', params='', query='', fragment='')
                                      ^^^ this is wrong. should be $
```

Notice that `netloc` is `wsl%24` after `urlparse()`. We need to decoding that before doing `"\\\\{}\\{}".format(netloc, path)` just like what we do for `path`.

Related issue: https://discord.com/channels/280102180189634562/280157083356233728/963549081886666784