### PR TITLE
Follow global setting whether to show snippet completions

### DIFF
--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -23,6 +23,34 @@ class DiagnosticTag:
     Deprecated = 2
 
 
+class CompletionItemKind:
+    Text = 1
+    Method = 2
+    Function = 3
+    Constructor = 4
+    Field = 5
+    Variable = 6
+    Class = 7
+    Interface = 8
+    Module = 9
+    Property = 10
+    Unit = 11
+    Value = 12
+    Enum = 13
+    Keyword = 14
+    Snippet = 15
+    Color = 16
+    File = 17
+    Reference = 18
+    Folder = 19
+    EnumMember = 20
+    Constant = 21
+    Struct = 22
+    Event = 23
+    Operator = 24
+    TypeParameter = 25
+
+
 class CompletionItemTag:
     Deprecated = 1
 

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -5,6 +5,7 @@ from .completion import LspResolveDocsCommand
 from .core.logging import debug
 from .core.promise import Promise
 from .core.protocol import CompletionItem
+from .core.protocol import CompletionItemKind
 from .core.protocol import CompletionList
 from .core.protocol import Diagnostic
 from .core.protocol import DiagnosticSeverity
@@ -702,6 +703,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             flags |= sublime.INHIBIT_EXPLICIT_COMPLETIONS
         if prefs.inhibit_word_completions:
             flags |= sublime.INHIBIT_WORD_COMPLETIONS
+        include_snippets = self.view.settings().get("auto_complete_include_snippets")
         for response, session_name in responses:
             if isinstance(response, Error):
                 errors.append(response)
@@ -721,7 +723,8 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             can_resolve_completion_items = session.has_capability('completionProvider.resolveProvider')
             items.extend(
                 format_completion(response_item, index, can_resolve_completion_items, session.config.name)
-                for index, response_item in enumerate(response_items))
+                for index, response_item in enumerate(response_items)
+                if include_snippets or response_item.get("kind") != CompletionItemKind.Snippet)
         if items:
             flags |= sublime.INHIBIT_REORDER
         if errors:


### PR DESCRIPTION
Closes #1939 by using the *"auto_complete_include_snippets"* setting from ST to decide whether completions with the "snippet" kind should be included.

Addendum to what I wrote in https://github.com/sublimelsp/LSP/issues/1939#issuecomment-1109749912:

As far as I understand, the "snippet" *kind* should more or less represent the same as what a snippet is in ST, and whether a CompletionItem includes "snippet syntax" with `$0`, etc. tab stops & placeholders is designated by the "insertTextFormat" field (even though this distinction isn't described clearly in the LSP specs and they probably overlap in most cases):

```ts
/**
 * Defines whether the insert text in a completion item should be interpreted as
 * plain text or a snippet.
 */
export namespace [InsertTextFormat](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#insertTextFormat) {
	/**
	 * The primary text to be inserted is treated as a plain string.
	 */
	export const PlainText = 1;

	/**
	 * The primary text to be inserted is treated as a snippet.
	 *
	 * A snippet can define tab stops and placeholders with `$1`, `$2`
	 * and `${3:foo}`. `$0` defines the final tab stop, it defaults to
	 * the end of the snippet. Placeholders with equal identifiers are linked,
	 * that is typing in one will update others too.
	 */
	export const Snippet = 2;
}
```