### PR TITLE
Initialize diagnostic's tagged regions before non-tagged ones

### DIFF
--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -122,9 +122,11 @@ class SessionView:
                     self.view.add_regions("lsp_highlight_{}{}".format(kind, mode), r)
         for severity in range(1, 5):
             for mode in line_modes:
-                self.view.add_regions("lsp{}d{}{}".format(self.session.config.name, mode, severity), r)
                 for tag in range(1, 3):
                     self.view.add_regions("lsp{}d{}{}_tags_{}".format(self.session.config.name, mode, severity, tag), r)
+        for severity in range(1, 5):
+            for mode in line_modes:
+                self.view.add_regions("lsp{}d{}{}".format(self.session.config.name, mode, severity), r)
         if document_highlight_style != "fill":
             for kind in document_highlight_kinds:
                 for mode in line_modes:


### PR DESCRIPTION
This fixes an issue that I have, where due to me having a custom style for `unnecessary` diagnostic, those hide the normal diagnostic underlines in case the same region also has normal diagnostic region.

Initializing "normal" diagnostic regions after "tagged" ones solves this issue by assuming that "normal" diagnostics are more important to show than the "tagged" ones so should be initialized later.

So the old code initialized in the following order:

 - lspLSP-typescriptdm1
 - lspLSP-typescriptdm1_tags_1
 - lspLSP-typescriptdm1_tags_2
 - lspLSP-typescriptds1
 - lspLSP-typescriptds1_tags_1
 - lspLSP-typescriptds1_tags_2
 - lspLSP-typescriptdm2
 - lspLSP-typescriptdm2_tags_1
 - lspLSP-typescriptdm2_tags_2
 - lspLSP-typescriptds2
 - lspLSP-typescriptds2_tags_1
 - lspLSP-typescriptds2_tags_2
 - lspLSP-typescriptdm3
 - lspLSP-typescriptdm3_tags_1
 - lspLSP-typescriptdm3_tags_2
 - lspLSP-typescriptds3
 - lspLSP-typescriptds3_tags_1
 - lspLSP-typescriptds3_tags_2
 - lspLSP-typescriptdm4
 - lspLSP-typescriptdm4_tags_1
 - lspLSP-typescriptdm4_tags_2
 - lspLSP-typescriptds4
 - lspLSP-typescriptds4_tags_1
 - lspLSP-typescriptds4_tags_2

While the new code initializes "tagged" first to ensure that "normal" will have priority when being shown.

 - lspLSP-typescriptdm1_tags_1
 - lspLSP-typescriptdm1_tags_2
 - lspLSP-typescriptds1_tags_1
 - lspLSP-typescriptds1_tags_2
 - lspLSP-typescriptdm2_tags_1
 - lspLSP-typescriptdm2_tags_2
 - lspLSP-typescriptds2_tags_1
 - lspLSP-typescriptds2_tags_2
 - lspLSP-typescriptdm3_tags_1
 - lspLSP-typescriptdm3_tags_2
 - lspLSP-typescriptds3_tags_1
 - lspLSP-typescriptds3_tags_2
 - lspLSP-typescriptdm4_tags_1
 - lspLSP-typescriptdm4_tags_2
 - lspLSP-typescriptds4_tags_1
 - lspLSP-typescriptds4_tags_2
 - lspLSP-typescriptdm1
 - lspLSP-typescriptds1
 - lspLSP-typescriptdm2
 - lspLSP-typescriptds2
 - lspLSP-typescriptdm3
 - lspLSP-typescriptds3
 - lspLSP-typescriptdm4
 - lspLSP-typescriptds4

Related a bit to #1934 although not really semantic-highlighting specific.