### PR TITLE
Fix diagnostic regions being hidden by semantic regions

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1083,7 +1083,7 @@ class Session(TransportCallbacks):
         self._plugin = None  # type: Optional[AbstractPlugin]
         self._status_messages = {}  # type: Dict[str, str]
         self.diagnostics_manager = DiagnosticsManager()
-        self.semantic_tokens_map = get_semantic_tokens_map(config.semantic_tokens)
+        self._semantic_tokens_map = get_semantic_tokens_map(config.semantic_tokens)
 
     def __getattr__(self, name: str) -> Any:
         """
@@ -1532,7 +1532,7 @@ class Session(TransportCallbacks):
         types_legend = tuple(cast(List[str], self.get_capability('semanticTokensProvider.legend.tokenTypes')))
         modifiers_legend = tuple(cast(List[str], self.get_capability('semanticTokensProvider.legend.tokenModifiers')))
         return decode_semantic_token(
-            types_legend, modifiers_legend, self.semantic_tokens_map, token_type_encoded, token_modifiers_encoded)
+            types_legend, modifiers_legend, self._semantic_tokens_map, token_type_encoded, token_modifiers_encoded)
 
     # --- server request handlers --------------------------------------------------------------------------------------
 

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -528,7 +528,6 @@ class SessionBuffer:
                 # This logic should not be cached (in the decode_semantic_token method) because otherwise new user
                 # customizations in the color scheme for the scopes of custom token types would require a restart of
                 # Sublime Text to take effect.
-                # Note that the region keys for these scopes are not initialized in SessionView._initialize_region_keys.
                 token_general_style = view.style_for_scope("meta.semantic-token")
                 token_type_style = view.style_for_scope("meta.semantic-token.{}".format(token_type.lower()))
                 if token_general_style["source_line"] != token_type_style["source_line"] or \

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -61,12 +61,12 @@ class DiagnosticSeverityData:
 class SemanticTokensData:
 
     __slots__ = (
-        'data', 'result_id', 'active_scopes', 'tokens', 'view_change_count', 'needs_refresh', 'pending_response')
+        'data', 'result_id', 'active_region_keys', 'tokens', 'view_change_count', 'needs_refresh', 'pending_response')
 
     def __init__(self) -> None:
         self.data = []  # type: List[int]
         self.result_id = None  # type: Optional[str]
-        self.active_scopes = []  # type: List[str]
+        self.active_region_keys = []  # type: List[int]
         self.tokens = []  # type: List[SemanticToken]
         self.view_change_count = 0
         self.needs_refresh = False
@@ -105,6 +105,8 @@ class SessionBuffer:
         self.diagnostics_debouncer = Debouncer()
         self.color_phantoms = sublime.PhantomSet(view, "lsp_color")
         self.semantic_tokens = SemanticTokensData()
+        self._semantic_region_keys = {}  # type: Dict[str, int]
+        self._last_semantic_region_key = 0
         self._check_did_open(view)
         self._session.register_session_buffer_async(self)
 
@@ -502,7 +504,7 @@ class SessionBuffer:
         if view is None:
             return
         self.semantic_tokens.tokens.clear()
-        scope_regions = dict()  # type: Dict[str, List[sublime.Region]]
+        scope_regions = dict()  # type: Dict[int, Tuple[str, List[sublime.Region]]]
         prev_line = 0
         prev_col_utf16 = 0
         for idx in range(0, len(self.semantic_tokens.data), 5):
@@ -537,24 +539,30 @@ class SessionBuffer:
                         scope = "meta.semantic-token.{}.lsp".format(token_type.lower())
             self.semantic_tokens.tokens.append(SemanticToken(r, token_type, token_modifiers))
             if scope:
-                scope_regions.setdefault(scope, []).append(r)
+                scope_regions.setdefault(self._get_region_key_for_scope(scope), (scope, []))[1].append(r)
         # don't update regions if there were additional changes to the buffer in the meantime
         if self.semantic_tokens.view_change_count != view.change_count():
             return
-        for scope in self.semantic_tokens.active_scopes.copy():
-            if scope not in scope_regions.keys():
-                self.semantic_tokens.active_scopes.remove(scope)
+        for region_key in self.semantic_tokens.active_region_keys.copy():
+            if region_key not in scope_regions.keys():
+                self.semantic_tokens.active_region_keys.remove(region_key)
                 for sv in self.session_views:
-                    sv.view.erase_regions("lsp_{}".format(scope))
-        for scope, regions in scope_regions.items():
-            if scope not in self.semantic_tokens.active_scopes:
-                self.semantic_tokens.active_scopes.append(scope)
+                    sv.view.erase_regions("lsp_semantic_{}".format(region_key))
+        for region_key, (scope, regions) in scope_regions.items():
+            if region_key not in self.semantic_tokens.active_region_keys:
+                self.semantic_tokens.active_region_keys.append(region_key)
             for sv in self.session_views:
-                sv.view.add_regions("lsp_{}".format(scope), regions, scope, flags=sublime.DRAW_NO_OUTLINE)
+                sv.view.add_regions("lsp_semantic_{}".format(region_key), regions, scope, flags=sublime.DRAW_NO_OUTLINE)
+
+    def _get_region_key_for_scope(self, scope: str) -> int:
+        if scope not in self._semantic_region_keys:
+            self._last_semantic_region_key += 1
+            self._semantic_region_keys[scope] = self._last_semantic_region_key
+        return self._semantic_region_keys[scope]
 
     def _clear_semantic_token_regions(self, view: sublime.View) -> None:
-        for scope in self.semantic_tokens.active_scopes:
-            view.erase_regions("lsp_{}".format(scope))
+        for region_key in self.semantic_tokens.active_region_keys:
+            view.erase_regions("lsp_semantic_{}".format(region_key))
 
     def set_semantic_tokens_pending_refresh(self, needs_refresh: bool = True) -> None:
         self.semantic_tokens.needs_refresh = needs_refresh

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -538,7 +538,7 @@ class SessionBuffer:
                         scope = "meta.semantic-token.{}.lsp".format(token_type.lower())
             self.semantic_tokens.tokens.append(SemanticToken(r, token_type, token_modifiers))
             if scope:
-                scope_regions.setdefault(self._get_region_key_for_scope(scope), (scope, []))[1].append(r)
+                scope_regions.setdefault(self._get_semantic_region_key_for_scope(scope), (scope, []))[1].append(r)
         # don't update regions if there were additional changes to the buffer in the meantime
         if self.semantic_tokens.view_change_count != view.change_count():
             return
@@ -553,7 +553,7 @@ class SessionBuffer:
             for sv in self.session_views:
                 sv.view.add_regions("lsp_semantic_{}".format(region_key), regions, scope, flags=sublime.DRAW_NO_OUTLINE)
 
-    def _get_region_key_for_scope(self, scope: str) -> int:
+    def _get_semantic_region_key_for_scope(self, scope: str) -> int:
         if scope not in self._semantic_region_keys:
             self._last_semantic_region_key += 1
             self._semantic_region_keys[scope] = self._last_semantic_region_key

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -12,7 +12,7 @@ from .core.types import Capabilities
 from .core.types import debounced
 from .core.types import Debouncer
 from .core.types import FEATURES_TIMEOUT
-from .core.typing import Any, Callable, Iterable, Optional, List, Dict, Tuple
+from .core.typing import Any, Callable, Iterable, Optional, List, Set, Dict, Tuple
 from .core.views import DIAGNOSTIC_SEVERITY
 from .core.views import diagnostic_severity
 from .core.views import did_change
@@ -66,7 +66,7 @@ class SemanticTokensData:
     def __init__(self) -> None:
         self.data = []  # type: List[int]
         self.result_id = None  # type: Optional[str]
-        self.active_region_keys = []  # type: List[int]
+        self.active_region_keys = set()  # type: Set[int]
         self.tokens = []  # type: List[SemanticToken]
         self.view_change_count = 0
         self.needs_refresh = False
@@ -549,7 +549,7 @@ class SessionBuffer:
                     sv.view.erase_regions("lsp_semantic_{}".format(region_key))
         for region_key, (scope, regions) in scope_regions.items():
             if region_key not in self.semantic_tokens.active_region_keys:
-                self.semantic_tokens.active_region_keys.append(region_key)
+                self.semantic_tokens.active_region_keys.add(region_key)
             for sv in self.session_views:
                 sv.view.add_regions("lsp_semantic_{}".format(region_key), regions, scope, flags=sublime.DRAW_NO_OUTLINE)
 

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -114,7 +114,7 @@ class SessionView:
         document_highlight_kinds = ["text", "read", "write"]
         line_modes = ["m", "s"]
         self.view.add_regions(self.CODE_ACTIONS_KEY, r)  # code actions lightbulb icon should always be on top
-        for key in range(0, 100):
+        for key in range(1, 100):
             self.view.add_regions("lsp_semantic_{}".format(key), r)
         if document_highlight_style == "fill":
             for kind in document_highlight_kinds:

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -114,8 +114,8 @@ class SessionView:
         document_highlight_kinds = ["text", "read", "write"]
         line_modes = ["m", "s"]
         self.view.add_regions(self.CODE_ACTIONS_KEY, r)  # code actions lightbulb icon should always be on top
-        for key, scope in self.session.semantic_tokens_map:
-            self.view.add_regions("lsp_{} meta.semantic-token.{}.lsp".format(scope, key.lower()), r)
+        for key in range(0, 100):
+            self.view.add_regions("lsp_semantic_{}".format(key), r)
         if document_highlight_style == "fill":
             for kind in document_highlight_kinds:
                 for mode in line_modes:


### PR DESCRIPTION
This attempts to fix the issue where semantic regions are being added after diagnostic regions, causing the latter to become invisible.

[As explained by @jwortmann](https://github.com/sublimelsp/LSP/issues/1934#issuecomment-1013964009) this is because we don't initialize all combinations of semantic token region keys in `SessionView._initialize_region_keys`. We could attempt to do that but I figured we could just create a pool of region keys `lsp_semantic_<number>` where the number monotonically increases each time new region is seen. This way we can just initialize regions within certain range (I've picked 0-100 in this PR) and ensure that all semantic regions are drawn in specific order relative to other types of regions. At least as long as the server doesn't use more than 100 combinations of tokens.

This approach would not work properly if using more than one server that provides semantic highlighting for the same file but that had issues also previously and it's not a sensible use case anyway.

Fixes #1934