### PR TITLE
Fix type of Request params

### DIFF
--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -479,7 +479,7 @@ class Notification:
 
     __slots__ = ('method', 'params')
 
-    def __init__(self, method: str, params: Optional[Mapping[str, Any]] = None) -> None:
+    def __init__(self, method: str, params: Any = None) -> None:
         self.method = method
         self.params = params
 

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -343,7 +343,7 @@ class Request:
     def __init__(
         self,
         method: str,
-        params: Optional[Mapping[str, Any]] = None,
+        params: Any = None,
         view: Optional[sublime.View] = None,
         progress: bool = False
     ) -> None:


### PR DESCRIPTION
`Request` or `Notification` params are not required to be of any specific type. It's up to the server.