### PR TITLE
docs: add info about enabling clangd server

### DIFF
--- a/docs/src/guides/cplusplus.md
+++ b/docs/src/guides/cplusplus.md
@@ -78,3 +78,18 @@ Another way to let your language server know what the include dirs are is by han
 your source root. Each line is one flag. This can be useful for projects that e.g. only have a Visual Studio solution
 file. For more information, see [these instructions](https://releases.llvm.org/8.0.0/tools/clang/tools/extra/docs/clangd/Installation.html#compile-flags-txt). Creating this file by hand is a reasonable place to start if your project is quite
 simple.
+
+### Enable clangd server
+
+After setup enable clangd server manually in `Preferences - Package Settings - LSP - Settings`:
+
+```jsonc
+{
+    // ...
+    "clients": {
+        "clangd": {
+            "enabled": true
+        }
+    }
+}
+```


### PR DESCRIPTION
First of all, I'm not sure of the wording. Also, I'm not sure if this information is really needed, but I'm having trouble finding information about activation of the server. And also, maybe it's better to write about this after

> You will thus have to adjust your `"clients"` dictionary in your user preferences.

and not at the end of page.