### PR TITLE
Add support for textDocument/documentLink request

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -353,6 +353,20 @@
     //         }
     //     ]
     // },
+    // Follow Link
+    // {
+    //     "command": "lsp_open_link",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "context": [
+    //         {
+    //             "key": "lsp.session_with_capability",
+    //             "operator": "equal",
+    //             "operand": "documentLinkProvider"
+    //         }
+    //     ]
+    // },
     // Expand Selection (a replacement for ST's "Expand Selection")
     // {
     //     "command": "lsp_expand_selection",

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -105,6 +105,16 @@
   // Valid values are "dot", "circle", "bookmark", "sign" or ""
   "diagnostics_gutter_marker": "dot",
 
+  // Highlight style of links to internal or external resources, like another text document
+  // or a web site. Link navigation is implemented via the popup on mouse hover.
+  // Valid values are:
+  // "underline"
+  // "none" - disables special highlighting, but still displays links in the hover popup
+  // "off" - disables special highlighting and the hover popup for links
+  // Note that depending on support in the syntax and color scheme, some internet URLs may
+  // still be underlined via regular syntax highlighting.
+  "link_highlight_style": "underline",
+
   // Enable semantic highlighting in addition to standard syntax highlighting (experimental!).
   // Note: Must be supported by the language server and also requires a special rule in the
   // color scheme to work. If you use none of the built-in color schemes from Sublime Text,

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -109,10 +109,10 @@
   // or a web site. Link navigation is implemented via the popup on mouse hover.
   // Valid values are:
   // "underline"
-  // "none" - disables special highlighting, but still displays links in the hover popup
-  // "off" - disables special highlighting and the hover popup for links
-  // Note that depending on support in the syntax and color scheme, some internet URLs may
-  // still be underlined via regular syntax highlighting.
+  // "none" - disables special highlighting, but still allows to navigate links in the hover popup
+  // "disabled" - disables highlighting and the hover popup for links
+  // Note that depending on the syntax and color scheme, some internet URLs may still be
+  // underlined via regular syntax highlighting.
   "link_highlight_style": "underline",
 
   // Enable semantic highlighting in addition to standard syntax highlighting (experimental!).

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -72,6 +72,10 @@
       {
         "caption": "LSP: Find References",
         "command": "lsp_symbol_references"
+      },
+      {
+        "caption": "LSP: Follow Link",
+        "command": "lsp_open_link"
       }
     ]
   },

--- a/boot.py
+++ b/boot.py
@@ -35,6 +35,7 @@ from .plugin.core.transports import kill_all_subprocesses
 from .plugin.core.typing import Any, Optional, List, Type, Dict
 from .plugin.core.views import get_uri_and_position_from_location
 from .plugin.core.views import LspRunTextCommandHelperCommand
+from .plugin.document_link import LspOpenLinkCommand
 from .plugin.documents import DocumentSyncListener
 from .plugin.documents import TextChangeListener
 from .plugin.edit import LspApplyDocumentEditCommand

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -295,6 +295,13 @@ CompletionList = TypedDict('CompletionList', {
     'items': List[CompletionItem],
 }, total=True)
 
+DocumentLink = TypedDict('DocumentLink', {
+    'range': RangeLsp,
+    'target': DocumentUri,
+    'tooltip': str,
+    'data': Any
+}, total=False)
+
 MarkedString = Union[str, Dict[str, str]]
 
 MarkupContent = Dict[str, str]
@@ -385,6 +392,10 @@ class Request:
         return Request("textDocument/documentHighlight", params, view)
 
     @classmethod
+    def documentLink(cls, params: Mapping[str, Any], view: sublime.View) -> 'Request':
+        return Request("textDocument/documentLink", params, view)
+
+    @classmethod
     def semanticTokensFull(cls, params: Mapping[str, Any], view: sublime.View) -> 'Request':
         return Request("textDocument/semanticTokens/full", params, view)
 
@@ -399,6 +410,10 @@ class Request:
     @classmethod
     def resolveCompletionItem(cls, params: CompletionItem, view: sublime.View) -> 'Request':
         return Request("completionItem/resolve", params, view)
+
+    @classmethod
+    def resolveDocumentLink(cls, params: DocumentLink, view: sublime.View) -> 'Request':
+        return Request("documentLink/resolve", params, view)
 
     @classmethod
     def shutdown(cls) -> 'Request':

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -531,6 +531,9 @@ class SessionBufferProtocol(Protocol):
     def get_document_link_at_point(self, view: sublime.View, point: int) -> Optional[DocumentLink]:
         ...
 
+    def update_document_link(self, link: DocumentLink) -> bool:
+        ...
+
     def do_semantic_tokens_async(self, view: sublime.View) -> None:
         ...
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -531,7 +531,7 @@ class SessionBufferProtocol(Protocol):
     def get_document_link_at_point(self, view: sublime.View, point: int) -> Optional[DocumentLink]:
         ...
 
-    def update_document_link(self, link: DocumentLink) -> bool:
+    def update_document_link(self, link: DocumentLink) -> None:
         ...
 
     def do_semantic_tokens_async(self, view: sublime.View) -> None:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -24,6 +24,7 @@ from .protocol import Diagnostic
 from .protocol import DiagnosticSeverity
 from .protocol import DiagnosticTag
 from .protocol import DidChangeWatchedFilesRegistrationOptions
+from .protocol import DocumentLink
 from .protocol import DocumentUri
 from .protocol import Error
 from .protocol import ErrorCode
@@ -527,7 +528,7 @@ class SessionBufferProtocol(Protocol):
     def on_diagnostics_async(self, raw_diagnostics: List[Diagnostic], version: Optional[int]) -> None:
         ...
 
-    def get_document_links(self) -> List[Any]:
+    def get_document_link_at_point(self, view: sublime.View, point: int) -> Optional[DocumentLink]:
         ...
 
     def do_semantic_tokens_async(self, view: sublime.View) -> None:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -280,6 +280,10 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
                 "valueSet": symbol_tag_value_set
             }
         },
+        "documentLink": {
+            "dynamicRegistration": True,
+            "tooltipSupport": True
+        },
         "formatting": {
             "dynamicRegistration": True  # exceptional
         },
@@ -521,6 +525,9 @@ class SessionBufferProtocol(Protocol):
         ...
 
     def on_diagnostics_async(self, raw_diagnostics: List[Diagnostic], version: Optional[int]) -> None:
+        ...
+
+    def get_document_links(self) -> List[Any]:
         ...
 
     def do_semantic_tokens_async(self, view: sublime.View) -> None:

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -193,6 +193,7 @@ class Settings:
     document_highlight_style = None  # type: str
     inhibit_snippet_completions = None  # type: bool
     inhibit_word_completions = None  # type: bool
+    link_highlight_style = None  # type: str
     log_debug = None  # type: bool
     log_max_size = None  # type: int
     log_server = None  # type: List[str]
@@ -230,6 +231,7 @@ class Settings:
         r("diagnostics_panel_include_severity_level", 4)
         r("disabled_capabilities", [])
         r("document_highlight_style", "underline")
+        r("link_highlight_style", "underline")
         r("log_debug", False)
         r("log_max_size", 8 * 1024)
         r("lsp_code_actions_on_save", {})

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -35,6 +35,8 @@ import tempfile
 
 MarkdownLangMap = Dict[str, Tuple[Tuple[str, ...], Tuple[str, ...]]]
 
+DOCUMENT_LINK_FLAGS = sublime.HIDE_ON_MINIMAP | sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE | sublime.DRAW_SOLID_UNDERLINE  # noqa: E501
+
 _baseflags = sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE | sublime.DRAW_EMPTY_AS_OVERWRITE
 
 DIAGNOSTIC_SEVERITY = [

--- a/plugin/document_link.py
+++ b/plugin/document_link.py
@@ -12,23 +12,6 @@ import webbrowser
 class LspOpenLinkCommand(LspTextCommand):
     capability = 'documentLinkProvider'
 
-    def open_target(self, target: str) -> None:
-        if target.startswith("file:"):
-            window = self.view.window()
-            if window:
-                decoded = unquote(target)  # decode percent-encoded characters
-                parsed = urlparse(decoded)
-                filepath = parsed.path
-                if sublime.platform() == "windows":
-                    filepath = re.sub(r"^/([a-zA-Z]:)", r"\1", filepath)  # remove slash preceding drive letter
-                fn = "{}:{}".format(filepath, parsed.fragment) if parsed.fragment else filepath
-                window.open_file(fn, flags=sublime.ENCODED_POSITION)
-        else:
-            if not (target.lower().startswith("http://") or target.lower().startswith("https://")):
-                target = "http://" + target
-            if not webbrowser.open(target):
-                sublime.status_message("failed to open: " + target)
-
     def is_enabled(self, event: Optional[dict] = None, point: Optional[int] = None) -> bool:
         if not super().is_enabled(event, point):
             return False
@@ -69,3 +52,20 @@ class LspOpenLinkCommand(LspTextCommand):
 
     def _on_resolved_async(self, response: DocumentLink) -> None:
         self.open_target(response["target"])
+
+    def open_target(self, target: str) -> None:
+        if target.startswith("file:"):
+            window = self.view.window()
+            if window:
+                decoded = unquote(target)  # decode percent-encoded characters
+                parsed = urlparse(decoded)
+                filepath = parsed.path
+                if sublime.platform() == "windows":
+                    filepath = re.sub(r"^/([a-zA-Z]:)", r"\1", filepath)  # remove slash preceding drive letter
+                fn = "{}:{}".format(filepath, parsed.fragment) if parsed.fragment else filepath
+                window.open_file(fn, flags=sublime.ENCODED_POSITION)
+        else:
+            if not (target.lower().startswith("http://") or target.lower().startswith("https://")):
+                target = "http://" + target
+            if not webbrowser.open(target):
+                sublime.status_message("failed to open: " + target)

--- a/plugin/document_link.py
+++ b/plugin/document_link.py
@@ -1,0 +1,63 @@
+from .core.registry import get_position
+from .core.registry import LspTextCommand
+from .core.typing import Optional
+from urllib.parse import unquote, urlparse
+import re
+import sublime
+import webbrowser
+
+
+class LspOpenLinkCommand(LspTextCommand):
+    capability = 'documentLinkProvider'
+
+    def is_enabled(self, event: Optional[dict] = None) -> bool:
+        point = get_position(self.view, event)
+        if not point:
+            return False
+        session = self.best_session(self.capability, point)
+        if not session:
+            return False
+        sv = session.session_view_for_view_async(self.view)
+        if not sv:
+            return False
+        link = sv.session_buffer.get_document_link_at_point(self.view, point)
+        return link is not None
+
+    def run(self, edit: sublime.Edit, event: Optional[dict] = None) -> None:
+
+        def open_target(target: str) -> None:
+            if target.startswith("file:"):
+                window = self.view.window()
+                if window:
+                    decoded = unquote(target)  # decode percent-encoded characters
+                    parsed = urlparse(decoded)
+                    filepath = parsed.path
+                    if sublime.platform() == "windows":
+                        filepath = re.sub(r"^/([a-zA-Z]:)", r"\1", filepath)  # remove slash preceding drive letter
+                    fn = "{}:{}".format(filepath, parsed.fragment) if parsed.fragment else filepath
+                    window.open_file(fn, flags=sublime.ENCODED_POSITION)
+            else:
+                if not (target.lower().startswith("http://") or target.lower().startswith("https://")):
+                    target = "http://" + target
+                if not webbrowser.open(target):
+                    sublime.status_message("failed to open: " + target)
+
+        point = get_position(self.view, event)
+        if not point:
+            return
+        session = self.best_session(self.capability, point)
+        if not session:
+            return
+        sv = session.session_view_for_view_async(self.view)
+        if not sv:
+            return
+        link = sv.session_buffer.get_document_link_at_point(self.view, point)
+        if not link:
+            return
+        target = link.get("target")
+
+        if target is not None:
+            open_target(target)
+        else:
+            # TODO send documentLink/resolve request
+            sublime.status_message("Links with unresolved target are currently not supported")

--- a/plugin/document_link.py
+++ b/plugin/document_link.py
@@ -10,17 +10,19 @@ import webbrowser
 class LspOpenLinkCommand(LspTextCommand):
     capability = 'documentLinkProvider'
 
-    def is_enabled(self, event: Optional[dict] = None) -> bool:
-        point = get_position(self.view, event)
-        if not point:
+    def is_enabled(self, event: Optional[dict] = None, point: Optional[int] = None) -> bool:
+        if not super().is_enabled(event, point):
             return False
-        session = self.best_session(self.capability, point)
+        position = get_position(self.view, event)
+        if not position:
+            return False
+        session = self.best_session(self.capability, position)
         if not session:
             return False
         sv = session.session_view_for_view_async(self.view)
         if not sv:
             return False
-        link = sv.session_buffer.get_document_link_at_point(self.view, point)
+        link = sv.session_buffer.get_document_link_at_point(self.view, position)
         return link is not None
 
     def run(self, edit: sublime.Edit, event: Optional[dict] = None) -> None:

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -261,7 +261,7 @@ class LspHoverCommand(LspTextCommand):
         contents = self.diagnostics_content() + hover_content + code_actions_content(self._actions_by_config)
         link_content, link_has_standard_tooltip = self.document_link_content(listener, point)
         if userprefs().show_symbol_action_links and contents and not only_diagnostics and hover_content:
-            symbol_actions_content =  self.symbol_actions_content(listener, point)
+            symbol_actions_content = self.symbol_actions_content(listener, point)
             if link_content and link_has_standard_tooltip:
                 symbol_actions_content += ' | ' + link_content
             elif link_content:

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -216,21 +216,21 @@ class LspHoverCommand(LspTextCommand):
         return "".join(formatted)
 
     def document_link_content(self, listener: AbstractViewListener, point: int) -> str:
-        if userprefs().link_highlight_style in ("underline", "none"):
-            for sv in listener.session_views_async():
-                if sv.view == self.view and sv.has_capability_async("documentLinkProvider"):
-                    sb = sv.session_buffer
-                    for link in sb.get_document_links():
-                        if link.contains(point):
-                            title = link.tooltip or "Follow link"
-                            if link.target is not None:
-                                return '<div class="link"><a href="{}">{}</a></div>'.format(link.target, title)
-                            else:
-                                # TODO send documentLink/resolve request
-                                # TODO maybe figure out how "Promise" works and if it could help here
-                                return ""
-                    break
-        return ""
+        if userprefs().link_highlight_style not in ("underline", "none"):
+            return ""
+        contents = []
+        for sv in listener.session_views_async():
+            if sv.has_capability_async("documentLinkProvider"):
+                for link in sv.session_buffer.get_document_links():
+                    if link.contains(point):
+                        title = link.tooltip or "Follow link"
+                        if link.target is not None:
+                            contents.append('<a href="{}">{}</a>'.format(link.target, title))
+                        else:
+                            # TODO send documentLink/resolve request
+                            # TODO maybe figure out how "Promise" works and if it could help here
+                            pass
+        return '<div class="link">' + '<br>'.join(contents) + '</div>' if contents else ''
 
     def hover_content(self) -> str:
         contents = []

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -197,8 +197,7 @@ class LspHoverCommand(LspTextCommand):
                 continue
             target = link.get("target")
             if target:
-                resolved_link = link
-                link_promises.append(Promise(lambda resolve: resolve(resolved_link)))
+                link_promises.append(Promise.resolve(link))
             elif sv.has_capability_async("documentLinkProvider.resolveProvider"):
                 link_promises.append(sv.session.send_request_task(Request.resolveDocumentLink(link, sv.view)).then(
                     lambda link: self._on_resolved_link(sv.session_buffer, link)))

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -221,15 +221,16 @@ class LspHoverCommand(LspTextCommand):
         contents = []
         for sv in listener.session_views_async():
             if sv.has_capability_async("documentLinkProvider"):
-                for link in sv.session_buffer.get_document_links():
-                    if link.contains(point):
-                        title = link.tooltip or "Follow link"
-                        if link.target is not None:
-                            contents.append('<a href="{}">{}</a>'.format(link.target, title))
-                        else:
-                            # TODO send documentLink/resolve request
-                            # TODO maybe figure out how "Promise" works and if it could help here
-                            pass
+                link = sv.session_buffer.get_document_link_at_point(sv.view, point)
+                if link is not None:
+                    title = link.get("tooltip") or "Follow link"
+                    target = link.get("target")
+                    if target is not None:
+                        contents.append('<a href="{}">{}</a>'.format(target, title))
+                    else:
+                        # TODO send documentLink/resolve request
+                        # TODO maybe figure out how "Promise" works and if it could help here
+                        pass
         return '<div class="link">' + '<br>'.join(contents) + '</div>' if contents else ''
 
     def hover_content(self) -> str:

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -367,14 +367,12 @@ class SessionBuffer:
         else:
             return None
 
-    def update_document_link(self, new_link: DocumentLink) -> bool:
+    def update_document_link(self, new_link: DocumentLink) -> None:
         new_link_range = Range.from_lsp(new_link["range"])
         for link in self.document_links:
             if Range.from_lsp(link["range"]) == new_link_range:
                 self.document_links.remove(link)
                 self.document_links.append(new_link)
-                return True
-        return False
 
     # --- textDocument/publishDiagnostics ------------------------------------------------------------------------------
 

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -367,6 +367,15 @@ class SessionBuffer:
         else:
             return None
 
+    def update_document_link(self, new_link: DocumentLink) -> bool:
+        new_link_range = Range.from_lsp(new_link["range"])
+        for link in self.document_links:
+            if Range.from_lsp(link["range"]) == new_link_range:
+                self.document_links.remove(link)
+                self.document_links.append(new_link)
+                return True
+        return False
+
     # --- textDocument/publishDiagnostics ------------------------------------------------------------------------------
 
     def on_diagnostics_async(self, raw_diagnostics: List[Diagnostic], version: Optional[int]) -> None:

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -364,6 +364,8 @@ class SessionBuffer:
         for link in self.document_links:
             if range_to_region(Range.from_lsp(link["range"]), view).contains(point):
                 return link
+        else:
+            return None
 
     # --- textDocument/publishDiagnostics ------------------------------------------------------------------------------
 

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -373,6 +373,7 @@ class SessionBuffer:
             if Range.from_lsp(link["range"]) == new_link_range:
                 self.document_links.remove(link)
                 self.document_links.append(new_link)
+                break
 
     # --- textDocument/publishDiagnostics ------------------------------------------------------------------------------
 

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -79,6 +79,7 @@ class SessionView:
         for severity in reversed(range(1, len(DIAGNOSTIC_SEVERITY) + 1)):
             self.view.erase_regions(self.diagnostics_key(severity, False))
             self.view.erase_regions(self.diagnostics_key(severity, True))
+        self.view.erase_regions("lsp_document_link")
         self.session_buffer.remove_session_view(self)
 
     @property
@@ -124,6 +125,7 @@ class SessionView:
             for mode in line_modes:
                 for tag in range(1, 3):
                     self.view.add_regions("lsp{}d{}{}_tags_{}".format(self.session.config.name, mode, severity, tag), r)
+        self.view.add_regions("lsp_document_link", r)
         for severity in range(1, 5):
             for mode in line_modes:
                 self.view.add_regions("lsp{}d{}{}".format(self.session.config.name, mode, severity), r)

--- a/popups.css
+++ b/popups.css
@@ -60,6 +60,9 @@
 .actions a.icon {
     text-decoration: none;
 }
+.link.with-padding {
+    padding: 0.5rem;
+}
 pre.related_info {
     border-top: 1px solid color(var(--background) alpha(0.25));
     margin-top: 0.7rem;

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -372,7 +372,7 @@
               "enum": [
                 "underline",
                 "none",
-                "off"
+                "disabled"
               ],
               "default": "underline",
               "markdownDescription": "Highlight style of links to internal or external resources, like another text document or a web site."

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -368,6 +368,15 @@
               "default": "dot",
               "markdownDescription": "Gutter marker for code diagnostics."
             },
+            "link_highlight_style": {
+              "enum": [
+                "underline",
+                "none",
+                "off"
+              ],
+              "default": "underline",
+              "markdownDescription": "Highlight style of links to internal or external resources, like another text document or a web site."
+            },
             "semantic_highlighting": {
               "type": "boolean",
               "default": false,


### PR DESCRIPTION
Is this useful? Tested with LSP-TexLab:

![lsp](https://user-images.githubusercontent.com/6579999/172652831-17d3810b-3e01-4824-850a-f1ee413930a9.gif)

A strange (or maybe just inaccurate) thing in the LSP specs is that a "document link"
> links to an internal or external resource, like another text document or a web site

but the type for `DocumentLink.target` is `DocumentUri`, and not the more general `URI` (they both are defined as `string` though).

---

Initially I figured it might be good to make the links available in the right click context menu, similar to what `Default/open_context_url.py` does for website links, and to run the request only on demand when you open the context menu. But then we can't show the underlines for the links, and it would probably make the context menu very slow (I don't know if it would even be possible to run the request from the `sublime_plugin.TextCommand.is_enabled()` and wait for a response). So I guess to run the request in the background after text changed and show the link in a hover popup (like what VS Code does) is better and looks nicer.

---

### TODO

- [x] Add support for `documentLink/resolve` (when the "target" is not provided in the initial response)
- [ ] Maybe add some tests

### Questions

- Are the style options useful? Is the default value good?
- Do we need an additional mouse binding (Alt + click) like in VS Code to directly open the link?
