### PR TITLE
Don't expose disabled code actions

### DIFF
--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -56,8 +56,11 @@ class CodeActionsCollector:
 
     def _collect_response(self, config_name: str, actions: CodeActionsResponse) -> None:
         self._response_count += 1
-        self._commands_by_config[config_name] = actions or []
+        self._commands_by_config[config_name] = self._get_enabled_actions(actions or [])
         self._notify_if_all_finished()
+
+    def _get_enabled_actions(self, actions: List[CodeActionOrCommand]) -> List[CodeActionOrCommand]:
+        return [action for action in actions if not action.get('disabled')]
 
     def _notify_if_all_finished(self) -> None:
         if self._all_requested and self._request_count == self._response_count:

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -164,11 +164,17 @@ Command = TypedDict('Command', {
 }, total=True)
 
 
+CodeActionDisabledInformation = TypedDict('CodeActionDisabledInformation', {
+    'reason': str
+}, total=True)
+
+
 CodeAction = TypedDict('CodeAction', {
     'title': str,
     'kind': Optional[str],
     'diagnostics': Optional[List[Any]],
     'isPreferred': Optional[bool],
+    'disabled': Optional[CodeActionDisabledInformation],
     'edit': Optional[dict],
     'command': Optional[Command],
 }, total=True)

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -317,6 +317,7 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
                 }
             },
             "dataSupport": True,
+            "disabledSupport": True,
             "resolveSupport": {
                 "properties": [
                     "edit"


### PR DESCRIPTION
Specification says this about `disabled` property:

```
Marks that the code action cannot currently be applied.
Clients should follow the following guidelines regarding disabled code
actions:
- Disabled code actions are not shown in automatic lightbulbs code
  action menus.
- Disabled actions are shown as faded out in the code action menu when
  the user request a more specific type of code action, such as
  refactorings.
- If the user has a keybinding that auto applies a code action and only
  a disabled code actions are returned, the client should show the user
  an error message with `reason` in the editor.
@since 3.16.0
```

We can't quite follow the second point as we have no way of creating disabled menu items.
As for the third point, we don't provide a way to run specific code actions so that doesn't apply either.
We are just filtering out disabled code actions in general.

Fixes https://github.com/sublimelsp/LSP-volar/issues/94