### PR TITLE
Enable admonition extension for mdpopups

### DIFF
--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -578,6 +578,7 @@ def minihtml(
         frontmatter = {
             "allow_code_wrap": True,
             "markdown_extensions": [
+                "markdown.extensions.admonition",
                 {
                     "pymdownx.escapeall": {
                         "hardbreak": True,


### PR DESCRIPTION
This would be cool for language servers which use a certain convention for admonitions in the hover popups.

Before:

![before](https://user-images.githubusercontent.com/6579999/177095857-95fe5283-f992-477c-9b24-021192fe6e2b.png)

After:

![after](https://user-images.githubusercontent.com/6579999/177095717-f5024bcf-d8a2-4f43-8a1f-f197242e0735.png)