### PR TITLE
Optionally fallback to goto_definition in lsp_symbol_definition

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -171,7 +171,8 @@
     // {
     //     "command": "lsp_symbol_definition",
     //     "args": {
-    //         "side_by_side": false
+    //         "side_by_side": false,
+    //         "fallback": false
     //     },
     //     "keys": [
     //         "f12"

--- a/docs/src/features.md
+++ b/docs/src/features.md
@@ -31,6 +31,9 @@ In addition to the basic "Goto Definition", the protocol also provides further r
 - Goto Declaration
 - Goto Implementation
 
+Additionally, the LSP's "Goto Definition" command can fall back to the built-in Sublime's "Goto Definition" if the `fallback` argument is set to `true`.
+This way, when there are no results found the built-in "Goto Definition" command will be triggered.
+
 ## Find References
 
 [Example GIF 1](https://user-images.githubusercontent.com/6579999/128551752-b37fe407-148c-41cf-b1e4-6fe96ed0f77c.gif)

--- a/plugin/goto.py
+++ b/plugin/goto.py
@@ -65,7 +65,7 @@ class LspGotoCommand(LspTextCommand):
         else:
             self._handle_no_results(fallback, side_by_side)
 
-    def _handle_no_results(self, fallback: bool = False, side_by_side: bool = False):
+    def _handle_no_results(self, fallback: bool = False, side_by_side: bool = False) -> None:
         window = self.view.window()
 
         if not window:

--- a/plugin/goto.py
+++ b/plugin/goto.py
@@ -24,7 +24,7 @@ class LspGotoCommand(LspTextCommand):
         side_by_side: bool = False,
         fallback: bool = False
     ) -> bool:
-        return super().is_enabled(event, point)
+        return fallback or super().is_enabled(event, point)
 
     def run(
         self,
@@ -42,6 +42,8 @@ class LspGotoCommand(LspTextCommand):
             session.send_request(
                 request, functools.partial(self._handle_response_async, session, side_by_side, fallback)
             )
+        else:
+            self._handle_no_results(fallback, side_by_side)
 
     def _handle_response_async(
         self,

--- a/plugin/goto.py
+++ b/plugin/goto.py
@@ -55,7 +55,7 @@ class LspGotoCommand(LspTextCommand):
             open_location_async(session, response, side_by_side)
         elif isinstance(response, list):
             if len(response) == 0:
-                self._handle_no_results(fallback=fallback, side_by_side=side_by_side)
+                self._handle_no_results(fallback, side_by_side)
             elif len(response) == 1:
                 self.view.run_command("add_jump_record", {"selection": [(r.a, r.b) for r in self.view.sel()]})
                 open_location_async(session, response[0], side_by_side)
@@ -63,7 +63,7 @@ class LspGotoCommand(LspTextCommand):
                 self.view.run_command("add_jump_record", {"selection": [(r.a, r.b) for r in self.view.sel()]})
                 sublime.set_timeout(functools.partial(LocationPicker, self.view, session, response, side_by_side))
         else:
-            self._handle_no_results(fallback=fallback, side_by_side=side_by_side)
+            self._handle_no_results(fallback, side_by_side)
 
     def _handle_no_results(self, fallback: bool = False, side_by_side: bool = False):
         window = self.view.window()


### PR DESCRIPTION
Unfortunatelly not all LSPs have good symbol definition support. For example, `solargraph`(ruby) has limited support and quite offten returns `No results found`, so you have to keep and remember the built-in Sublime `goto_definition` key bining to be able to jump to at least something.  
It becomes especially inconvenient when you switch between different programming langages where one has a better symbol defition support than another so you always have to keep in mind what exact key to use.

This PR adds an optional `fallback` parameter to the `lsp_symbol_definition` command that allows to fallback to the built-in `goto_definition` command in case no results were found.  

```JSON
{ "keys": ["super+alt+down"], "command": "goto_definition" },
{
  "keys": ["super+alt+down"],
  "command": "lsp_symbol_definition",
  "args": { "side_by_side": false, "fallback": true },
  "context": [
    {
      "key": "lsp.session_with_capability",
      "operator": "equal",
      "operand": "definitionProvider"
    },
    {
      "key": "auto_complete_visible",
      "operator": "equal",
      "operand": false
    }
  ]
},
```
This option allows you to have more consistant key bining and better integration with Sublime, because you don't need to worry if LSP is enable or no, as every time it would try to find at least something.