### PR TITLE
Don't use actual linebreaks in log panel if payload is string literal

### DIFF
--- a/Syntaxes/ServerLog.sublime-syntax
+++ b/Syntaxes/ServerLog.sublime-syntax
@@ -83,6 +83,7 @@ contexts:
         - match: $
           pop: true
         - include: scope:source.python#constants  # e.g. shutdown request
+        - include: scope:source.python#strings
         - include: scope:source.python#lists
         - include: scope:source.python#dictionaries-and-sets
     - match: ''

--- a/Syntaxes/ServerLog.sublime-syntax
+++ b/Syntaxes/ServerLog.sublime-syntax
@@ -84,6 +84,7 @@ contexts:
           pop: true
         - include: scope:source.python#constants  # e.g. shutdown request
         - include: scope:source.python#strings
+        - include: scope:source.python#numbers
         - include: scope:source.python#lists
         - include: scope:source.python#dictionaries-and-sets
     - match: ''

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -506,8 +506,7 @@ class PanelLogger(Logger):
 
         def run_on_async_worker_thread() -> None:
             nonlocal message
-            params_str = "'{}'".format(params.replace("\n", "\\n").replace("'", "\\'")) if isinstance(params, str) \
-                         else str(params)
+            params_str = repr(params) if isinstance(params, str) else str(params)
             if 0 < userprefs().log_max_size <= len(params_str):
                 params_str = '<params with {} characters>'.format(len(params_str))
             message = "{}: {}".format(message, params_str)

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -506,7 +506,8 @@ class PanelLogger(Logger):
 
         def run_on_async_worker_thread() -> None:
             nonlocal message
-            params_str = str(params)
+            params_str = "'{}'".format(params.replace("\n", "\\n").replace("'", "\\'")) if isinstance(params, str) \
+                         else str(params)
             if 0 < userprefs().log_max_size <= len(params_str):
                 params_str = '<params with {} characters>'.format(len(params_str))
             message = "{}: {}".format(message, params_str)

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -506,7 +506,7 @@ class PanelLogger(Logger):
 
         def run_on_async_worker_thread() -> None:
             nonlocal message
-            params_str = repr(params) if isinstance(params, str) else str(params)
+            params_str = repr(params)
             if 0 < userprefs().log_max_size <= len(params_str):
                 params_str = '<params with {} characters>'.format(len(params_str))
             message = "{}: {}".format(message, params_str)


### PR DESCRIPTION
Before:

![before](https://user-images.githubusercontent.com/6579999/178109853-2fe3e161-7cb6-4f43-a973-62fb1b32b72d.png)

After:

![after](https://user-images.githubusercontent.com/6579999/178109911-dd523f74-941e-4e32-bb74-62c0f7e084b0.png)