### PR TITLE
Keep active group when using Goto commands

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -194,7 +194,8 @@
     // {
     //     "command": "lsp_symbol_type_definition",
     //     "args": {
-    //         "side_by_side": false
+    //         "side_by_side": false,
+    //         "force_group": true
     //     },
     //     "keys": [
     //         "UNBOUND"
@@ -216,7 +217,8 @@
     // {
     //     "command": "lsp_symbol_declaration",
     //     "args": {
-    //         "side_by_side": false
+    //         "side_by_side": false,
+    //         "force_group": true
     //     },
     //     "keys": [
     //         "UNBOUND"
@@ -238,7 +240,8 @@
     // {
     //     "command": "lsp_symbol_implementation",
     //     "args": {
-    //         "side_by_side": false
+    //         "side_by_side": false,
+    //         "force_group": true
     //     },
     //     "keys": [
     //         "UNBOUND"

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -171,7 +171,8 @@
     // {
     //     "command": "lsp_symbol_definition",
     //     "args": {
-    //         "side_by_side": false
+    //         "side_by_side": false,
+    //         "force_group": true
     //     },
     //     "keys": [
     //         "f12"

--- a/plugin/core/open.py
+++ b/plugin/core/open.py
@@ -28,10 +28,10 @@ def open_file(
     # to open as a separate view).
     view = window.find_open_file(file)
     if view:
-        view_group = window.get_view_index(view)[0]
-        opens_in_desired_group = not bool(flags & sublime.FORCE_GROUP) or view_group == window.active_group()
-        opens_as_new_selection = bool(flags & (sublime.ADD_TO_SELECTION | sublime.REPLACE_MRU))
-        return_existing_view = opens_in_desired_group and not opens_as_new_selection
+        opens_in_desired_group = not bool(flags & sublime.FORCE_GROUP) or \
+                                 window.get_view_index(view)[0] == window.active_group()
+        opens_in_side_by_side = bool(flags & (sublime.ADD_TO_SELECTION | sublime.REPLACE_MRU))
+        return_existing_view = opens_in_desired_group and not opens_in_side_by_side
         if return_existing_view:
             return Promise.resolve(view)
 

--- a/plugin/core/open.py
+++ b/plugin/core/open.py
@@ -29,9 +29,9 @@ def open_file(
     view = window.find_open_file(file)
     if view:
         view_group = window.get_view_index(view)[0]
-        opens_in_current_group = view_group == window.active_group() if group == -1 else view_group == group
+        opens_in_desired_group = view_group == window.active_group() if group == -1 else view_group == group
         opens_as_new_selection = (flags & (sublime.ADD_TO_SELECTION | sublime.REPLACE_MRU)) != 0
-        return_existing_view = opens_in_current_group and not opens_as_new_selection
+        return_existing_view = opens_in_desired_group and not opens_as_new_selection
         if return_existing_view:
             return Promise.resolve(view)
 

--- a/plugin/core/open.py
+++ b/plugin/core/open.py
@@ -29,8 +29,8 @@ def open_file(
     view = window.find_open_file(file)
     if view:
         view_group = window.get_view_index(view)[0]
-        opens_in_desired_group = view_group == window.active_group() if group == -1 else view_group == group
-        opens_as_new_selection = (flags & (sublime.ADD_TO_SELECTION | sublime.REPLACE_MRU)) != 0
+        opens_in_desired_group = not bool(flags & sublime.FORCE_GROUP) or view_group == window.active_group()
+        opens_as_new_selection = bool(flags & (sublime.ADD_TO_SELECTION | sublime.REPLACE_MRU))
         return_existing_view = opens_in_desired_group and not opens_as_new_selection
         if return_existing_view:
             return Promise.resolve(view)

--- a/plugin/core/open.py
+++ b/plugin/core/open.py
@@ -28,7 +28,8 @@ def open_file(
     # to open as a separate view).
     view = window.find_open_file(file)
     if view:
-        opens_in_current_group = group == -1 or window.active_group() == group
+        view_group = window.get_view_index(view)[0]
+        opens_in_current_group = view_group == window.active_group() if group == -1 else view_group == group
         opens_as_new_selection = (flags & (sublime.ADD_TO_SELECTION | sublime.REPLACE_MRU)) != 0
         return_existing_view = opens_in_current_group and not opens_as_new_selection
         if return_existing_view:

--- a/plugin/locationpicker.py
+++ b/plugin/locationpicker.py
@@ -11,8 +11,15 @@ import sublime
 import weakref
 
 
-def open_location_async(session: Session, location: Union[Location, LocationLink], side_by_side: bool) -> None:
-    flags = sublime.ENCODED_POSITION | sublime.FORCE_GROUP
+def open_location_async(
+    session: Session,
+    location: Union[Location, LocationLink],
+    side_by_side: bool,
+    force_group: bool
+) -> None:
+    flags = sublime.ENCODED_POSITION
+    if force_group:
+        flags |= sublime.FORCE_GROUP
     if side_by_side:
         flags |= sublime.ADD_TO_SELECTION | sublime.SEMI_TRANSIENT
 
@@ -80,7 +87,8 @@ class LocationPicker:
                 if not self._side_by_side:
                     open_basic_file(session, uri, position, flags)
             else:
-                sublime.set_timeout_async(functools.partial(open_location_async, session, location, self._side_by_side))
+                sublime.set_timeout_async(
+                    functools.partial(open_location_async, session, location, self._side_by_side, True))
         else:
             self._window.focus_view(self._view)
             # When in side-by-side mode close the current highlighted

--- a/plugin/locationpicker.py
+++ b/plugin/locationpicker.py
@@ -12,7 +12,7 @@ import weakref
 
 
 def open_location_async(session: Session, location: Union[Location, LocationLink], side_by_side: bool) -> None:
-    flags = sublime.ENCODED_POSITION
+    flags = sublime.ENCODED_POSITION | sublime.FORCE_GROUP
     if side_by_side:
         flags |= sublime.ADD_TO_SELECTION | sublime.SEMI_TRANSIENT
 


### PR DESCRIPTION
Fixes #1990

More general, this also aligns the behavior of LSP Goto commands with the behavior of the native commands in the following, related case: if the location is in another file, which is already opened in another group, then the LSP commands would focus the already opened tab. After this PR, it will instead create a new view for the file in the active group.

There was a logic bug in the open_file function, which caused the current behavior (assuming that the `group = -1` argument should have the same meaning as in all the Sublime API functions).