### PR TITLE
Refactor symbol and completion item kinds

### DIFF
--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -55,6 +55,35 @@ class CompletionItemTag:
     Deprecated = 1
 
 
+class SymbolKind:
+    File = 1
+    Module = 2
+    Namespace = 3
+    Package = 4
+    Class = 5
+    Method = 6
+    Property = 7
+    Field = 8
+    Constructor = 9
+    Enum = 10
+    Interface = 11
+    Function = 12
+    Variable = 13
+    Constant = 14
+    String = 15
+    Number = 16
+    Boolean = 17
+    Array = 18
+    Object = 19
+    Key = 20
+    Null = 21
+    EnumMember = 22
+    Struct = 23
+    Event = 24
+    Operator = 25
+    TypeParameter = 26
+
+
 class SymbolTag:
     Deprecated = 1
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -186,7 +186,7 @@ class Manager(metaclass=ABCMeta):
         pass
 
 
-def _enum_like_class_to_list(c: Type[object]) -> Union[List[int], List[str]]:
+def _enum_like_class_to_list(c: Type[object]) -> List[Union[int, str]]:
     return [v for k, v in c.__dict__.items() if not k.startswith('_')]
 
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -186,7 +186,7 @@ class Manager(metaclass=ABCMeta):
         pass
 
 
-def _enum_like_class_to_list(c: Type[object]) -> List[Union[int, str]]:
+def _enum_like_class_to_list(c: Type[object]) -> Union[List[int], List[str]]:
     return [v for k, v in c.__dict__.items() if not k.startswith('_')]
 
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -186,7 +186,7 @@ class Manager(metaclass=ABCMeta):
         pass
 
 
-def _enum_like_class_to_list(c: Type[object]) -> List[Union[int, str]]:
+def _enum_like_class_to_list(c: Type[object]) -> Union[List[int], List[str]]:
     return [v for k, v in c.__dict__.items() if not k.startswith('_')]
 
 
@@ -197,7 +197,7 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
     diagnostic_tag_value_set = _enum_like_class_to_list(DiagnosticTag)
     completion_tag_value_set = _enum_like_class_to_list(CompletionItemTag)
     symbol_tag_value_set = _enum_like_class_to_list(SymbolTag)
-    semantic_token_types = _enum_like_class_to_list(SemanticTokenTypes)
+    semantic_token_types = _enum_like_class_to_list(SemanticTokenTypes)  # type: List[str]
     if config.semantic_tokens is not None:
         for token_type in config.semantic_tokens.keys():
             if token_type not in semantic_token_types:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -186,7 +186,7 @@ class Manager(metaclass=ABCMeta):
         pass
 
 
-def _enum_like_class_to_list(c: Type[object]) -> Union[List[int], List[str]]:
+def _enum_like_class_to_list(c: Type[object]) -> List[Union[int, str]]:
     return [v for k, v in c.__dict__.items() if not k.startswith('_')]
 
 
@@ -197,7 +197,7 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
     diagnostic_tag_value_set = _enum_like_class_to_list(DiagnosticTag)
     completion_tag_value_set = _enum_like_class_to_list(CompletionItemTag)
     symbol_tag_value_set = _enum_like_class_to_list(SymbolTag)
-    semantic_token_types = _enum_like_class_to_list(SemanticTokenTypes)  # type: List[str]
+    semantic_token_types = _enum_like_class_to_list(SemanticTokenTypes)
     if config.semantic_tokens is not None:
         for token_type in config.semantic_tokens.keys():
             if token_type not in semantic_token_types:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -19,6 +19,7 @@ from .promise import PackagedTask
 from .promise import Promise
 from .protocol import CodeAction, CodeLens, InsertTextMode, Location, LocationLink
 from .protocol import Command
+from .protocol import CompletionItemKind
 from .protocol import CompletionItemTag
 from .protocol import Diagnostic
 from .protocol import DiagnosticSeverity
@@ -36,6 +37,7 @@ from .protocol import Request
 from .protocol import Response
 from .protocol import SemanticTokenModifiers
 from .protocol import SemanticTokenTypes
+from .protocol import SymbolKind
 from .protocol import SymbolTag
 from .protocol import WorkspaceFolder
 from .settings import client_configs
@@ -55,13 +57,11 @@ from .typing import Callable, cast, Dict, Any, Optional, List, Tuple, Generator,
 from .url import filename_to_uri
 from .url import parse_uri
 from .version import __version__
-from .views import COMPLETION_KINDS
 from .views import extract_variables
 from .views import get_storage_path
 from .views import get_uri_and_range_from_location
 from .views import MarkdownLangMap
 from .views import SEMANTIC_TOKENS_MAP
-from .views import SYMBOL_KINDS
 from .workspace import is_subpath_of
 from abc import ABCMeta
 from abc import abstractmethod
@@ -186,18 +186,14 @@ class Manager(metaclass=ABCMeta):
         pass
 
 
-def _sequence_to_lsp_indices(sequence: Sequence[Any]) -> List[int]:
-    return list(range(1, len(sequence) + 1))
-
-
-def _enum_like_class_to_list(c: Type[object]) -> List[str]:
+def _enum_like_class_to_list(c: Type[object]) -> List[Union[int, str]]:
     return [v for k, v in c.__dict__.items() if not k.startswith('_')]
 
 
 def get_initialize_params(variables: Dict[str, str], workspace_folders: List[WorkspaceFolder],
                           config: ClientConfig) -> dict:
-    completion_kinds = _sequence_to_lsp_indices(COMPLETION_KINDS)
-    symbol_kinds = _sequence_to_lsp_indices(SYMBOL_KINDS)
+    completion_kinds = _enum_like_class_to_list(CompletionItemKind)
+    symbol_kinds = _enum_like_class_to_list(SymbolKind)
     diagnostic_tag_value_set = _enum_like_class_to_list(DiagnosticTag)
     completion_tag_value_set = _enum_like_class_to_list(CompletionItemTag)
     symbol_tag_value_set = _enum_like_class_to_list(SymbolTag)

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -1,9 +1,11 @@
 from .css import css as lsp_css
 from .protocol import CompletionItem
+from .protocol import CompletionItemKind
 from .protocol import CompletionItemTag
 from .protocol import Diagnostic
 from .protocol import DiagnosticRelatedInformation
 from .protocol import DiagnosticSeverity
+from .protocol import DocumentHighlightKind
 from .protocol import DocumentUri
 from .protocol import ExperimentalTextDocumentRangeParams
 from .protocol import Location
@@ -16,6 +18,7 @@ from .protocol import Position
 from .protocol import Range
 from .protocol import RangeLsp
 from .protocol import Request
+from .protocol import SymbolKind
 from .protocol import TextDocumentIdentifier
 from .protocol import TextDocumentPositionParams
 from .settings import userprefs
@@ -47,65 +50,140 @@ DIAGNOSTIC_SEVERITY = [
     ("hint",    "hints",    "region.bluish markup.info.hint.lsp",  "Packages/LSP/icons/info.png",    _baseflags | sublime.DRAW_STIPPLED_UNDERLINE, sublime.DRAW_NO_FILL),  # noqa: E501
 ]  # type: List[Tuple[str, str, str, str, int, int]]
 
-# The scope names mainly come from http://www.sublimetext.com/docs/3/scope_naming.html
-SYMBOL_KINDS = [
-    # ST Kind                    Icon  Display Name      ST Scope
-    (sublime.KIND_ID_NAVIGATION, "f", "File",           "string"),
-    (sublime.KIND_ID_NAMESPACE,  "m", "Module",         "entity.name.namespace"),
-    (sublime.KIND_ID_NAMESPACE,  "n", "Namespace",      "entity.name.namespace"),
-    (sublime.KIND_ID_NAMESPACE,  "p", "Package",        "entity.name.namespace"),
-    (sublime.KIND_ID_TYPE,       "c", "Class",          "entity.name.class"),
-    (sublime.KIND_ID_FUNCTION,   "m", "Method",         "entity.name.function"),
-    (sublime.KIND_ID_VARIABLE,   "p", "Property",       "variable.other.member"),
-    (sublime.KIND_ID_VARIABLE,   "f", "Field",          "variable.other.member"),
-    (sublime.KIND_ID_FUNCTION,   "c", "Constructor",    "entity.name.function.constructor"),
-    (sublime.KIND_ID_TYPE,       "e", "Enum",           "entity.name.enum"),
-    (sublime.KIND_ID_VARIABLE,   "i", "Interface",      "entity.name.interface"),
-    (sublime.KIND_ID_FUNCTION,   "f", "Function",       "entity.name.function"),
-    (sublime.KIND_ID_VARIABLE,   "v", "Variable",       "variable.other.readwrite"),
-    (sublime.KIND_ID_VARIABLE,   "c", "Constant",       "variable.other.constant"),
-    (sublime.KIND_ID_MARKUP,     "s", "String",         "string"),
-    (sublime.KIND_ID_VARIABLE,   "n", "Number",         "constant.numeric"),
-    (sublime.KIND_ID_VARIABLE,   "b", "Boolean",        "constant.language"),
-    (sublime.KIND_ID_TYPE,       "a", "Array",          "meta.sequence"),  # [scope taken from JSON.sublime-syntax]
-    (sublime.KIND_ID_TYPE,       "o", "Object",         "meta.mapping"),  # [scope taken from JSON.sublime-syntax]
-    (sublime.KIND_ID_NAVIGATION, "k", "Key",            "meta.mapping.key string"),  # [from JSON.sublime-syntax]
-    (sublime.KIND_ID_VARIABLE,   "n", "Null",           "constant.language"),
-    (sublime.KIND_ID_VARIABLE,   "e", "Enum Member",    "constant.other.enum"),  # Based on {Java,C#}.sublime-syntax
-    (sublime.KIND_ID_TYPE,       "s", "Struct",         "entity.name.struct"),
-    (sublime.KIND_ID_TYPE,       "e", "Event",          "storage.modifier"),   # [scope taken from C#.sublime-syntax]
-    (sublime.KIND_ID_FUNCTION,   "o", "Operator",       "keyword.operator"),
-    (sublime.KIND_ID_TYPE,       "t", "Type Parameter", "storage.type"),
-]
+# sublime.Kind tuples for sublime.CompletionItem, sublime.QuickPanelItem, sublime.ListInputItem
+# https://www.sublimetext.com/docs/api_reference.html#sublime.Kind
+KIND_ARRAY = (sublime.KIND_ID_TYPE, "a", "Array")
+KIND_BOOLEAN = (sublime.KIND_ID_VARIABLE, "b", "Boolean")
+KIND_CLASS = (sublime.KIND_ID_TYPE, "c", "Class")
+KIND_COLOR = (sublime.KIND_ID_MARKUP, "c", "Color")
+KIND_CONSTANT = (sublime.KIND_ID_VARIABLE, "c", "Constant")
+KIND_CONSTRUCTOR = (sublime.KIND_ID_FUNCTION, "c", "Constructor")
+KIND_ENUM = (sublime.KIND_ID_TYPE, "e", "Enum")
+KIND_ENUMMEMBER = (sublime.KIND_ID_VARIABLE, "e", "Enum Member")
+KIND_EVENT = (sublime.KIND_ID_FUNCTION, "e", "Event")
+KIND_FIELD = (sublime.KIND_ID_VARIABLE, "f", "Field")
+KIND_FILE = (sublime.KIND_ID_NAVIGATION, "f", "File")
+KIND_FOLDER = (sublime.KIND_ID_NAVIGATION, "f", "Folder")
+KIND_FUNCTION = (sublime.KIND_ID_FUNCTION, "f", "Function")
+KIND_INTERFACE = (sublime.KIND_ID_TYPE, "i", "Interface")
+KIND_KEY = (sublime.KIND_ID_NAVIGATION, "k", "Key")
+KIND_KEYWORD = (sublime.KIND_ID_KEYWORD, "k", "Keyword")
+KIND_METHOD = (sublime.KIND_ID_FUNCTION, "m", "Method")
+KIND_MODULE = (sublime.KIND_ID_NAMESPACE, "m", "Module")
+KIND_NAMESPACE = (sublime.KIND_ID_NAMESPACE, "n", "Namespace")
+KIND_NULL = (sublime.KIND_ID_VARIABLE, "n", "Null")
+KIND_NUMBER = (sublime.KIND_ID_VARIABLE, "n", "Number")
+KIND_OBJECT = (sublime.KIND_ID_TYPE, "o", "Object")
+KIND_OPERATOR = (sublime.KIND_ID_KEYWORD, "o", "Operator")
+KIND_PACKAGE = (sublime.KIND_ID_NAMESPACE, "p", "Package")
+KIND_PROPERTY = (sublime.KIND_ID_VARIABLE, "p", "Property")
+KIND_REFERENCE = (sublime.KIND_ID_NAVIGATION, "r", "Reference")
+KIND_SNIPPET = (sublime.KIND_ID_SNIPPET, "s", "Snippet")
+KIND_STRING = (sublime.KIND_ID_VARIABLE, "s", "String")
+KIND_STRUCT = (sublime.KIND_ID_TYPE, "s", "Struct")
+KIND_TEXT = (sublime.KIND_ID_MARKUP, "t", "Text")
+KIND_TYPEPARAMETER = (sublime.KIND_ID_TYPE, "t", "Type Parameter")
+KIND_UNIT = (sublime.KIND_ID_VARIABLE, "u", "Unit")
+KIND_VALUE = (sublime.KIND_ID_VARIABLE, "v", "Value")
+KIND_VARIABLE = (sublime.KIND_ID_VARIABLE, "v", "Variable")
 
-COMPLETION_KINDS = [
-    # ST Kind                    Icon Display Name
-    (sublime.KIND_ID_MARKUP,     "t", "Text"),
-    (sublime.KIND_ID_FUNCTION,   "m", "Method"),
-    (sublime.KIND_ID_FUNCTION,   "f", "Function"),
-    (sublime.KIND_ID_FUNCTION,   "c", "Constructor"),
-    (sublime.KIND_ID_VARIABLE,   "f", "Field"),
-    (sublime.KIND_ID_VARIABLE,   "v", "Variable"),
-    (sublime.KIND_ID_TYPE,       "c", "Class"),
-    (sublime.KIND_ID_TYPE,       "i", "Interface"),
-    (sublime.KIND_ID_NAMESPACE,  "m", "Module"),
-    (sublime.KIND_ID_VARIABLE,   "p", "Property"),
-    (sublime.KIND_ID_VARIABLE,   "u", "Unit"),
-    (sublime.KIND_ID_VARIABLE,   "v", "Value"),
-    (sublime.KIND_ID_TYPE,       "e", "Enum"),
-    (sublime.KIND_ID_KEYWORD,    "k", "Keyword"),
-    (sublime.KIND_ID_SNIPPET,    "s", "Snippet"),
-    (sublime.KIND_ID_MARKUP,     "c", "Color"),
-    (sublime.KIND_ID_NAVIGATION, "f", "File"),
-    (sublime.KIND_ID_NAVIGATION, "r", "Reference"),
-    (sublime.KIND_ID_NAMESPACE,  "f", "Folder"),
-    (sublime.KIND_ID_VARIABLE,   "e", "Enum Member"),
-    (sublime.KIND_ID_VARIABLE,   "c", "Constant"),
-    (sublime.KIND_ID_TYPE,       "s", "Struct"),
-    (sublime.KIND_ID_TYPE,       "e", "Event"),
-    (sublime.KIND_ID_KEYWORD,    "o", "Operator"),
-    (sublime.KIND_ID_TYPE,       "t", "Type Parameter"),
-]
+COMPLETION_KINDS = {
+    CompletionItemKind.Text: KIND_TEXT,
+    CompletionItemKind.Method: KIND_METHOD,
+    CompletionItemKind.Function: KIND_FUNCTION,
+    CompletionItemKind.Constructor: KIND_CONSTRUCTOR,
+    CompletionItemKind.Field: KIND_FIELD,
+    CompletionItemKind.Variable: KIND_VARIABLE,
+    CompletionItemKind.Class: KIND_CLASS,
+    CompletionItemKind.Interface: KIND_INTERFACE,
+    CompletionItemKind.Module: KIND_MODULE,
+    CompletionItemKind.Property: KIND_PROPERTY,
+    CompletionItemKind.Unit: KIND_UNIT,
+    CompletionItemKind.Value: KIND_VALUE,
+    CompletionItemKind.Enum: KIND_ENUM,
+    CompletionItemKind.Keyword: KIND_KEYWORD,
+    CompletionItemKind.Snippet: KIND_SNIPPET,
+    CompletionItemKind.Color: KIND_COLOR,
+    CompletionItemKind.File: KIND_FILE,
+    CompletionItemKind.Reference: KIND_REFERENCE,
+    CompletionItemKind.Folder: KIND_FOLDER,
+    CompletionItemKind.EnumMember: KIND_ENUMMEMBER,
+    CompletionItemKind.Constant: KIND_CONSTANT,
+    CompletionItemKind.Struct: KIND_STRUCT,
+    CompletionItemKind.Event: KIND_EVENT,
+    CompletionItemKind.Operator: KIND_OPERATOR,
+    CompletionItemKind.TypeParameter: KIND_TYPEPARAMETER
+}
+
+SYMBOL_KINDS = {
+    SymbolKind.File: KIND_FILE,
+    SymbolKind.Module: KIND_MODULE,
+    SymbolKind.Namespace: KIND_NAMESPACE,
+    SymbolKind.Package: KIND_PACKAGE,
+    SymbolKind.Class: KIND_CLASS,
+    SymbolKind.Method: KIND_METHOD,
+    SymbolKind.Property: KIND_PROPERTY,
+    SymbolKind.Field: KIND_FIELD,
+    SymbolKind.Constructor: KIND_CONSTRUCTOR,
+    SymbolKind.Enum: KIND_ENUM,
+    SymbolKind.Interface: KIND_INTERFACE,
+    SymbolKind.Function: KIND_FUNCTION,
+    SymbolKind.Variable: KIND_VARIABLE,
+    SymbolKind.Constant: KIND_CONSTANT,
+    SymbolKind.String: KIND_STRING,
+    SymbolKind.Number: KIND_NUMBER,
+    SymbolKind.Boolean: KIND_BOOLEAN,
+    SymbolKind.Array: KIND_ARRAY,
+    SymbolKind.Object: KIND_OBJECT,
+    SymbolKind.Key: KIND_KEY,
+    SymbolKind.Null: KIND_NULL,
+    SymbolKind.EnumMember: KIND_ENUMMEMBER,
+    SymbolKind.Struct: KIND_STRUCT,
+    SymbolKind.Event: KIND_EVENT,
+    SymbolKind.Operator: KIND_OPERATOR,
+    SymbolKind.TypeParameter: KIND_TYPEPARAMETER
+}
+
+SYMBOL_KIND_SCOPES = {
+    SymbolKind.File: "string",
+    SymbolKind.Module: "entity.name.namespace",
+    SymbolKind.Namespace: "entity.name.namespace",
+    SymbolKind.Package: "entity.name.namespace",
+    SymbolKind.Class: "entity.name.class",
+    SymbolKind.Method: "entity.name.function",
+    SymbolKind.Property: "variable.other.member",
+    SymbolKind.Field: "variable.other.member",
+    SymbolKind.Constructor: "entity.name.function.constructor",
+    SymbolKind.Enum: "entity.name.enum",
+    SymbolKind.Interface: "entity.name.interface",
+    SymbolKind.Function: "entity.name.function",
+    SymbolKind.Variable: "variable.other",
+    SymbolKind.Constant: "variable.other.constant",
+    SymbolKind.String: "string",
+    SymbolKind.Number: "constant.numeric",
+    SymbolKind.Boolean: "constant.language.boolean",
+    SymbolKind.Array: "meta.sequence",
+    SymbolKind.Object: "meta.mapping",
+    SymbolKind.Key: "meta.mapping.key string",
+    SymbolKind.Null: "constant.language.null",
+    SymbolKind.EnumMember: "constant.other.enum",
+    SymbolKind.Struct: "entity.name.struct",
+    SymbolKind.Event: "entity.name.function",
+    SymbolKind.Operator: "keyword.operator",
+    SymbolKind.TypeParameter: "variable.parameter.type"
+}
+
+DOCUMENT_HIGHLIGHT_KINDS = {
+    DocumentHighlightKind.Text: "text",
+    DocumentHighlightKind.Read: "read",
+    DocumentHighlightKind.Write: "write"
+}
+
+DOCUMENT_HIGHLIGHT_KIND_SCOPES = {
+    DocumentHighlightKind.Text: "region.bluish markup.highlight.text.lsp",
+    DocumentHighlightKind.Read: "region.greenish markup.highlight.read.lsp",
+    DocumentHighlightKind.Write: "region.yellowish markup.highlight.write.lsp"
+}
 
 SEMANTIC_TOKENS_MAP = {
     "namespace": "variable.other.namespace.lsp",
@@ -874,10 +952,8 @@ def format_completion(
 ) -> sublime.CompletionItem:
     # This is a hot function. Don't do heavy computations or IO in this function.
     item_kind = item.get("kind")
-    if isinstance(item_kind, int) and 1 <= item_kind <= len(COMPLETION_KINDS):
-        kind = COMPLETION_KINDS[item_kind - 1]
-    else:
-        kind = sublime.KIND_AMBIGUOUS
+    kind = COMPLETION_KINDS[item_kind] if isinstance(item_kind, int) and item_kind in COMPLETION_KINDS \
+        else (sublime.KIND_ID_AMBIGUOUS, "?", "???")
 
     if _is_completion_item_deprecated(item):
         kind = (kind[0], '!', "⚠ {} - Deprecated".format(kind[2]))

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -87,6 +87,8 @@ KIND_UNIT = (sublime.KIND_ID_VARIABLE, "u", "Unit")
 KIND_VALUE = (sublime.KIND_ID_VARIABLE, "v", "Value")
 KIND_VARIABLE = (sublime.KIND_ID_VARIABLE, "v", "Variable")
 
+KIND_UNSPECIFIED = (sublime.KIND_ID_AMBIGUOUS, "?", "???")
+
 COMPLETION_KINDS = {
     CompletionItemKind.Text: KIND_TEXT,
     CompletionItemKind.Method: KIND_METHOD,
@@ -952,8 +954,7 @@ def format_completion(
 ) -> sublime.CompletionItem:
     # This is a hot function. Don't do heavy computations or IO in this function.
     item_kind = item.get("kind")
-    kind = COMPLETION_KINDS[item_kind] if isinstance(item_kind, int) and item_kind in COMPLETION_KINDS \
-        else (sublime.KIND_ID_AMBIGUOUS, "?", "???")
+    kind = COMPLETION_KINDS.get(item_kind, KIND_UNSPECIFIED) if item_kind else KIND_UNSPECIFIED
 
     if _is_completion_item_deprecated(item):
         kind = (kind[0], '!', "⚠ {} - Deprecated".format(kind[2]))

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -28,6 +28,8 @@ from .core.typing import Any, Callable, Optional, Dict, Generator, Iterable, Lis
 from .core.url import parse_uri
 from .core.url import view_to_uri
 from .core.views import diagnostic_severity
+from .core.views import DOCUMENT_HIGHLIGHT_KIND_SCOPES
+from .core.views import DOCUMENT_HIGHLIGHT_KINDS
 from .core.views import first_selection_region
 from .core.views import format_completion
 from .core.views import make_command_link
@@ -52,18 +54,6 @@ import webbrowser
 
 
 SUBLIME_WORD_MASK = 515
-
-_kind2name = {
-    DocumentHighlightKind.Text: "text",
-    DocumentHighlightKind.Read: "read",
-    DocumentHighlightKind.Write: "write"
-}
-
-_kind2scope = {
-    DocumentHighlightKind.Text: "region.bluish markup.highlight.text.lsp",
-    DocumentHighlightKind.Read: "region.greenish markup.highlight.read.lsp",
-    DocumentHighlightKind.Write: "region.yellowish markup.highlight.write.lsp"
-}
 
 Flags = int
 ResolveCompletionsFn = Callable[[List[sublime.CompletionItem], Flags], None]
@@ -617,7 +607,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
     # --- textDocument/documentHighlight -------------------------------------------------------------------------------
 
     def _highlights_key(self, kind: int, multiline: bool) -> str:
-        return "lsp_highlight_{}{}".format(_kind2name[kind], "m" if multiline else "s")
+        return "lsp_highlight_{}{}".format(DOCUMENT_HIGHLIGHT_KINDS[kind], "m" if multiline else "s")
 
     def _clear_highlight_regions(self) -> None:
         for kind in range(1, 4):
@@ -663,7 +653,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
                 kind, multiline = tup
                 key = self._highlights_key(kind, multiline)
                 flags = flags_multi if multiline else flags_single
-                self.view.add_regions(key, regions, scope=_kind2scope[kind], flags=flags)
+                self.view.add_regions(key, regions, scope=DOCUMENT_HIGHLIGHT_KIND_SCOPES[kind], flags=flags)
 
         sublime.set_timeout(render_highlights_on_main_thread)
 

--- a/plugin/symbols.py
+++ b/plugin/symbols.py
@@ -4,6 +4,7 @@ from .core.registry import LspTextCommand
 from .core.sessions import print_to_status_bar
 from .core.typing import Any, List, Optional, Tuple, Dict, Generator, Union, cast
 from .core.views import range_to_region
+from .core.views import SYMBOL_KIND_SCOPES
 from .core.views import SYMBOL_KINDS
 from .core.views import text_document_identifier
 from contextlib import contextmanager
@@ -15,29 +16,23 @@ import sublime_plugin
 SUPPRESS_INPUT_SETTING_KEY = 'lsp_suppress_input'
 
 
-def unpack_lsp_kind(kind: int) -> Tuple[int, str, str, str]:
-    if 1 <= kind <= len(SYMBOL_KINDS):
-        return SYMBOL_KINDS[kind - 1]
-    return sublime.KIND_ID_AMBIGUOUS, "?", "???", "comment"
+def unpack_lsp_kind(kind: int) -> Tuple[int, str, str]:
+    return SYMBOL_KINDS[kind] if kind in SYMBOL_KINDS else (sublime.KIND_ID_AMBIGUOUS, "?", "???")
 
 
 def format_symbol_kind(kind: int) -> str:
-    if 1 <= kind <= len(SYMBOL_KINDS):
-        return SYMBOL_KINDS[kind - 1][2]
-    return str(kind)
+    return SYMBOL_KINDS[kind][2] if kind in SYMBOL_KINDS else str(kind)
 
 
 def get_symbol_scope_from_lsp_kind(kind: int) -> str:
-    if 1 <= kind <= len(SYMBOL_KINDS):
-        return SYMBOL_KINDS[kind - 1][3]
-    return 'comment'
+    return SYMBOL_KIND_SCOPES[kind] if kind in SYMBOL_KIND_SCOPES else "comment"
 
 
 def symbol_information_to_quick_panel_item(
     item: SymbolInformation,
     show_file_name: bool = True
 ) -> sublime.QuickPanelItem:
-    st_kind, st_icon, st_display_type, _ = unpack_lsp_kind(item['kind'])
+    st_kind, st_icon, st_display_type = unpack_lsp_kind(item['kind'])
     tags = item.get("tags") or []
     if SymbolTag.Deprecated in tags:
         st_display_type = "⚠ {} - Deprecated".format(st_display_type)
@@ -191,7 +186,7 @@ class LspDocumentSymbolsCommand(LspTextCommand):
                              get_symbol_scope_from_lsp_kind(lsp_kind)))
         name = item['name']
         with _additional_name(names, name):
-            st_kind, st_icon, st_display_type, _ = unpack_lsp_kind(lsp_kind)
+            st_kind, st_icon, st_display_type = unpack_lsp_kind(lsp_kind)
             formatted_names = " > ".join(names)
             st_details = item.get("detail") or ""
             if st_details:

--- a/plugin/symbols.py
+++ b/plugin/symbols.py
@@ -3,6 +3,7 @@ from .core.protocol import Request, Range, DocumentSymbol, SymbolInformation, Sy
 from .core.registry import LspTextCommand
 from .core.sessions import print_to_status_bar
 from .core.typing import Any, List, Optional, Tuple, Dict, Generator, Union, cast
+from .core.views import KIND_UNSPECIFIED
 from .core.views import range_to_region
 from .core.views import SYMBOL_KIND_SCOPES
 from .core.views import SYMBOL_KINDS
@@ -17,15 +18,15 @@ SUPPRESS_INPUT_SETTING_KEY = 'lsp_suppress_input'
 
 
 def unpack_lsp_kind(kind: int) -> Tuple[int, str, str]:
-    return SYMBOL_KINDS[kind] if kind in SYMBOL_KINDS else (sublime.KIND_ID_AMBIGUOUS, "?", "???")
+    return SYMBOL_KINDS.get(kind, KIND_UNSPECIFIED)
 
 
 def format_symbol_kind(kind: int) -> str:
-    return SYMBOL_KINDS[kind][2] if kind in SYMBOL_KINDS else str(kind)
+    return SYMBOL_KINDS.get(kind, (None, None, str(kind)))[2]
 
 
 def get_symbol_scope_from_lsp_kind(kind: int) -> str:
-    return SYMBOL_KIND_SCOPES[kind] if kind in SYMBOL_KIND_SCOPES else "comment"
+    return SYMBOL_KIND_SCOPES.get(kind, "comment")
 
 
 def symbol_information_to_quick_panel_item(


### PR DESCRIPTION
- This defines [sublime.Kind](https://www.sublimetext.com/docs/api_reference.html#sublime.Kind) tuples, so that they can be reused for LSP's `SymbolKind`s and `CompletionItemKind`s, which have a lot of overlap and even had a few inconsistencies before.
- Also they could easily be used for sublime.QuickPanelItem now.
- No more awkward indexing with `kind - 1`
- Moved the small lookup dicts for DocumentHighlightKind to core/views.py as well, because that seems to be the place where most of such things are defined.
- Fixes a bug in views.py#format_completion, which would use an `int` instead of a kind tuple for the kind in `sublime.CompletionItem.command_completion`, in case there is a kind id in the language server response, which is out of range for LSP's CompletionItemKind.

Changes:
- Removed "readwrite" from "variable.other.readwrite" scope of SymbolKind.Variable (dubious scope only used in JavaScript syntax - `https://github.com/sublimehq/Packages/issues/1336`).
- Adjusted scope of SymbolKind.Boolean from "constant.language" to "constant.language.boolean" (used in various syntaxes).
- Adjusted scope of SymbolKind.Null from "constant.language" to "constant.language.null" (used in various syntaxes).
- Changed scope of SymbolKind.Event from "storage.modifier" to "entity.name.function" and kind id from sublime.KIND_ID_TYPE to sublime.KIND_ID_FUNCTION (I'm not entirely sure, but I think "Event" is meant to be things like `onclick` or `onchange`).
- Changed scope of SymbolKind.TypeParameter from "storage.type" to "variable.parameter.type" (but keep the kind id as sublime.KIND_ID_TYPE). Ass far as I understand, the following is a type parameter (Java example):
    ```java
    class ClassWithGenericType<T> {}
    //                         ^ Type parameter
    ```
- Changed kind id of CompletionItemKind.Folder from sublime.KIND_ID_NAMESPACE to sublime.KIND_ID_NAVIGATION, so that it is consistent with CompletionItemKind.File
- Changed kind id of SymbolKind.Interface from sublime.KIND_ID_VARIABLE to sublime.KIND_ID_TYPE, so that it is consistent with CompletionItemKind.Interface.
- Changed kind id of SymbolKind.Operator from sublime.KIND_ID_FUNCTION to sublime.KIND_ID_KEYWORD, so that it is consistent with CompletionItemKind.Operator.
- Changed kind id of SymbolKind.String from sublime.KIND_ID_MARKUP to sublime.KIND_ID_VARIABLE, so that it is consistent with SymbolKind.Number, SymbolKind.Boolean, SymbolKind.Null.