### PR TITLE
Tweaks for signature help popup

### DIFF
--- a/docs/src/customization.md
+++ b/docs/src/customization.md
@@ -200,6 +200,7 @@ The color scheme rule only works if the "background" color is different from the
 | ----- | ----------- |
 | `entity.name.function.sighelp.lsp` | Function name in the signature help popup |
 | `variable.parameter.sighelp.lsp` | Function argument in the signature help popup |
+| `variable.parameter.sighelp.active.lsp` | Function argument which is currently highlighted in the signature help popup |
 
 ### Annotations
 

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -228,7 +228,8 @@ ParameterInformation = TypedDict('ParameterInformation', {
 SignatureInformation = TypedDict('SignatureInformation', {
     'label': str,
     'documentation': Union[str, Dict[str, str]],
-    'parameters': List[ParameterInformation]
+    'parameters': List[ParameterInformation],
+    'activeParameter': int
 }, total=False)
 
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -254,9 +254,9 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
         },
         "signatureHelp": {
             "dynamicRegistration": True,
-            "activeParameterSupport": True,
             "contextSupport": True,
             "signatureInformation": {
+                "activeParameterSupport": True,
                 "documentationFormat": ["markdown", "plaintext"],
                 "parameterInformation": {
                     "labelOffsetSupport": True

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -258,8 +258,10 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
                 "documentationFormat": ["markdown", "plaintext"],
                 "parameterInformation": {
                     "labelOffsetSupport": True
-                }
-            }
+                },
+                "activeParameterSupport": True
+            },
+            "contextSupport": True
         },
         "references": {
             "dynamicRegistration": True

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -254,14 +254,14 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
         },
         "signatureHelp": {
             "dynamicRegistration": True,
+            "activeParameterSupport": True,
+            "contextSupport": True,
             "signatureInformation": {
                 "documentationFormat": ["markdown", "plaintext"],
                 "parameterInformation": {
                     "labelOffsetSupport": True
-                },
-                "activeParameterSupport": True
-            },
-            "contextSupport": True
+                }
+            }
         },
         "references": {
             "dynamicRegistration": True

--- a/plugin/core/signature_help.py
+++ b/plugin/core/signature_help.py
@@ -87,9 +87,6 @@ class SigHelp:
         new_index = self._active_signature_index + (1 if forward else -1)
         self._active_signature_index = max(0, min(new_index, len(self._signatures) - 1))
 
-    def active_signature(self) -> SignatureInformation:
-        return self._signatures[self._active_signature_index]
-
     def _render_intro(self) -> str:
         fmt = '<p><div style="font-size: 0.9rem"><b>{}</b> of <b>{}</b> overloads ' + \
               "(use ↑ ↓ to navigate, press Esc to hide):</div></p>"

--- a/plugin/core/signature_help.py
+++ b/plugin/core/signature_help.py
@@ -44,8 +44,8 @@ class SigHelp:
         self._state = state
         self._language_map = language_map
         self._signatures = self._state["signatures"]
-        self._active_signature_index = self._state.get("activeSignature", 0)
-        self._active_parameter_index = self._state.get("activeParameter", 0)
+        self._active_signature_index = self._state.get("activeSignature") or 0
+        self._active_parameter_index = self._state.get("activeParameter") or 0
 
     @classmethod
     def from_lsp(

--- a/plugin/core/signature_help.py
+++ b/plugin/core/signature_help.py
@@ -1,6 +1,5 @@
 from .logging import debug
 from .protocol import SignatureHelp
-from .protocol import SignatureHelpContext
 from .protocol import SignatureInformation
 from .registry import LspTextCommand
 from .typing import Optional, List
@@ -45,8 +44,8 @@ class SigHelp:
         self._state = state
         self._language_map = language_map
         self._signatures = self._state["signatures"]
-        self._active_signature_index = self._state.get("activeSignature") or 0
-        self._active_parameter_index = self._state.get("activeParameter") or 0
+        self._active_signature_index = self._state.get("activeSignature", 0)
+        self._active_parameter_index = self._state.get("activeParameter", 0)
 
     @classmethod
     def from_lsp(
@@ -66,26 +65,18 @@ class SigHelp:
         except IndexError:
             return ""
         formatted = []  # type: List[str]
-        intro = self._render_intro()
-        if intro:
-            formatted.append(intro)
+        if self.has_multiple_signatures():
+            formatted.append(self._render_intro())
         formatted.extend(self._render_label(view, signature))
         formatted.extend(self._render_docs(view, signature))
         return "".join(formatted)
 
-    def context(self, trigger_kind: int, trigger_character: str, is_retrigger: bool) -> SignatureHelpContext:
+    def active_signature_help(self) -> SignatureHelp:
         """
         Extract the state out of this state machine to send back to the language server.
-
-        XXX: Currently unused. Revisit this some time in the future.
         """
         self._state["activeSignature"] = self._active_signature_index
-        return {
-            "triggerKind": trigger_kind,
-            "triggerCharacter": trigger_character,
-            "isRetrigger": is_retrigger,
-            "activeSignatureHelp": self._state
-        }
+        return self._state
 
     def has_multiple_signatures(self) -> bool:
         """Does the current signature help state contain more than one overload?"""
@@ -99,15 +90,13 @@ class SigHelp:
     def active_signature(self) -> SignatureInformation:
         return self._signatures[self._active_signature_index]
 
-    def _render_intro(self) -> Optional[str]:
-        if len(self._signatures) > 1:
-            fmt = '<p><div style="font-size: 0.9rem"><b>{}</b> of <b>{}</b> overloads ' + \
-                  "(use ↑ ↓ to navigate, press Esc to hide):</div></p>"
-            return fmt.format(
-                self._active_signature_index + 1,
-                len(self._signatures),
-            )
-        return None
+    def _render_intro(self) -> str:
+        fmt = '<p><div style="font-size: 0.9rem"><b>{}</b> of <b>{}</b> overloads ' + \
+              "(use ↑ ↓ to navigate, press Esc to hide):</div></p>"
+        return fmt.format(
+            self._active_signature_index + 1,
+            len(self._signatures),
+        )
 
     def _render_label(self, view: sublime.View, signature: SignatureInformation) -> List[str]:
         formatted = []  # type: List[str]
@@ -118,6 +107,7 @@ class SigHelp:
         parameters = signature.get("parameters")
         if parameters:
             prev, start, end = 0, 0, 0
+            active_parameter_index = signature.get("activeParameter", self._active_parameter_index)
             for i, param in enumerate(parameters):
                 rawlabel = param["label"]
                 if isinstance(rawlabel, list):
@@ -136,7 +126,7 @@ class SigHelp:
                     end = start + len(rawlabel)
                 if prev < start:
                     formatted.append(_function(view, label[prev:start]))
-                formatted.append(_parameter(view, label[start:end], i == self._active_parameter_index))
+                formatted.append(_parameter(view, label[start:end], i == active_parameter_index))
                 prev = end
             if end < len(label):
                 formatted.append(_function(view, label[end:]))
@@ -164,7 +154,7 @@ class SigHelp:
         if not parameters:
             return None
         try:
-            parameter = parameters[self._active_parameter_index]
+            parameter = parameters[signature.get("activeParameter", self._active_parameter_index)]
         except IndexError:
             return None
         documentation = parameter.get("documentation")
@@ -186,7 +176,8 @@ def _function(view: sublime.View, content: str) -> str:
 
 
 def _parameter(view: sublime.View, content: str, emphasize: bool) -> str:
-    return _wrap_with_scope_style(view, content, "variable.parameter.sighelp.lsp", emphasize)
+    scope = "variable.parameter.sighelp.active.lsp" if emphasize else "variable.parameter.sighelp.lsp"
+    return _wrap_with_scope_style(view, content, scope, emphasize)
 
 
 def _wrap_with_scope_style(view: sublime.View, content: str, scope: str, emphasize: bool) -> str:

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -470,9 +470,10 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             self.purge_changes_async()
             position_params = text_document_position_params(self.view, pos)
             context_params = {}  # type: SignatureHelpContext
-            context_params["triggerKind"] = SignatureHelpTriggerKind.Invoked if manual else \
-                SignatureHelpTriggerKind.TriggerCharacter
-            if not manual:
+            if manual:
+                context_params["triggerKind"] = SignatureHelpTriggerKind.Invoked
+            else:
+                context_params["triggerKind"] = SignatureHelpTriggerKind.TriggerCharacter
                 context_params["triggerCharacter"] = last_char
             context_params["isRetrigger"] = self._sighelp is not None
             if self._sighelp:

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -485,6 +485,10 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             language_map = session.markdown_language_id_to_st_syntax_map()
             request = Request.signatureHelp(params, self.view)
             session.send_request_async(request, lambda resp: self._on_signature_help(resp, pos, language_map))
+        elif self.view.match_selector(pos, "meta.function-call.arguments"):
+            # Don't force close the signature help popup while the user is typing the parameters.
+            # See also: https://github.com/sublimehq/sublime_text/issues/5518
+            pass
         else:
             # TODO: Refactor popup usage to a common class. We now have sigHelp, completionDocs, hover, and diags
             # all using a popup. Most of these systems assume they have exclusive access to a popup, while in


### PR DESCRIPTION
- Add contextSupport (see https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#signatureHelpContext). For now, "triggerKind" will always be SignatureHelpTriggerKind.Invoked in case of invoking via key binding, or otherwise SignatureHelpTriggerKind.TriggerCharacter. Maybe some more logic could be added in the future, to determine if the last pressed key was e.g. <kbd>Backspace</kbd>, for the third possible option of SignatureHelpTriggerKind.
- Add support for `activeParameter` property on `SignatureInformation` (since LSP 3.16 - see https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#signatureInformation)
- Allow color schemes to adjust color of currently highlighted parameter
- Small tweaks regarding code style

Also I believe ST has a bug with the `sublime.HIDE_ON_MOUSE_MOVE_AWAY` flag for popups, which would randomly hide the popup even when the cursor isn't moved (but only if the window is relatively small [sic!] :D - it doesn't happen for me in fullscreen or with a big window). This bug seems to happen more often on this branch, and I think HIDE_ON_MOUSE_MOVE_AWAY isn't useful anyway for the signature help popup, so I removed it.