### PR TITLE
Update F# guidance

### DIFF
--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -129,7 +129,7 @@ Follow installation instructions on [LSP-elm](https://github.com/sublimelsp/LSP-
         "clients": {
             "fsautocomplete": {
                 "enabled": true,
-                "command": ["dotnet", "fsautocomplete", "--background-service-enabled"],
+                "command": ["fsautocomplete", "--background-service-enabled"],
                 "selector": "source.fsharp",
                 "initializationOptions": {
                     "AutomaticWorkspaceInit": true
@@ -138,6 +138,9 @@ Follow installation instructions on [LSP-elm](https://github.com/sublimelsp/LSP-
         }
     }
     ```
+
+!!! info "A note about .NET Tools and $PATH"
+    If the `fsautocomplete` executable isn't on your $PATH after installing it globally, ensure the .NET global tools location (by default `$HOME/.dotnet/tools`) is on your $PATH.
 
 ## Fortran
 


### PR DESCRIPTION
The current docs install FSAC as a global tool, but invoke it as a local tool. Invoking it as a global tool means executing the globally-installed shim (which is installed to a global path by default).

These updates are based on getting @matthewcrews up and running, thanks Matthew!