### PR TITLE
Handle URLs in the location like URIs

### DIFF
--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -336,7 +336,7 @@ class LspHoverCommand(LspTextCommand):
                     sublime.set_timeout_async(functools.partial(session.open_uri_async, uri, r))
         else:
             # NOTE: Remove this check when on py3.8.
-            if not (href.lower().startswith("http://") or href.lower().startswith("https://")):
+            if not href.lower().startswith(("http://", "https://")):
                 href = "http://" + href
             if not webbrowser.open(href):
                 debug("failed to open:", href)

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -325,7 +325,7 @@ class LspHoverCommand(LspTextCommand):
         elif is_location_href(href):
             session_name, uri, row, col_utf16 = unpack_href_location(href)
 
-            if (uri.lower().startswith("http://") or uri.lower().startswith("https://")):
+            if uri.lower().startswith(("http://", "https://")):
                 if not webbrowser.open(uri):
                     debug("failed to open:", uri)
             else:

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -324,11 +324,16 @@ class LspHoverCommand(LspTextCommand):
                 self.handle_code_action_select(config_name, 0)
         elif is_location_href(href):
             session_name, uri, row, col_utf16 = unpack_href_location(href)
-            session = self.session_by_name(session_name)
-            if session:
-                position = {"line": row, "character": col_utf16}  # type: Position
-                r = {"start": position, "end": position}  # type: RangeLsp
-                sublime.set_timeout_async(functools.partial(session.open_uri_async, uri, r))
+
+            if (uri.lower().startswith("http://") or uri.lower().startswith("https://")):
+                if not webbrowser.open(uri):
+                    debug("failed to open:", uri)
+            else:
+                session = self.session_by_name(session_name)
+                if session:
+                    position = {"line": row, "character": col_utf16}  # type: Position
+                    r = {"start": position, "end": position}  # type: RangeLsp
+                    sublime.set_timeout_async(functools.partial(session.open_uri_async, uri, r))
         else:
             # NOTE: Remove this check when on py3.8.
             if not (href.lower().startswith("http://") or href.lower().startswith("https://")):


### PR DESCRIPTION
In [sorbet](https://sorbet.org), URLs in hovers are rendered as `location:sorbet@https://srb.help/7003#0,0` and as result, they are not handed with the `LspHoverCommand#_on_navigate` method, because it expects URLs to start with `http://` or `https://`.

I am not sure whether this is an issue with the LSP itself, but this PR handles this situation and opens URLs in the location like URIs with the `webbrowser`