### PR TITLE
Follow global settings more accurately whether to show snippet completions

### DIFF
--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -426,12 +426,12 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
                     on_navigate=lambda href: self._on_navigate(href, point))
 
     def on_text_command(self, command_name: str, args: Optional[dict]) -> Optional[Tuple[str, dict]]:
-        if command_name == "show_scope_name" and userprefs().semantic_highlighting:
+        if command_name == "auto_complete":
+            self._auto_complete_triggered_manually = True
+        elif command_name == "show_scope_name" and userprefs().semantic_highlighting:
             session = self.session_async("semanticTokensProvider")
             if session:
                 return ("lsp_show_scope_name", {})
-        elif command_name == "auto_complete":
-            self._auto_complete_triggered_manually = True
         return None
 
     def on_post_text_command(self, command_name: str, args: Optional[Dict[str, Any]]) -> None:

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -683,7 +683,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
     # --- textDocument/complete ----------------------------------------------------------------------------------------
 
     def _on_query_completions_async(self, resolve_completion_list: ResolveCompletionsFn, location: int) -> None:
-        triggerd_manually = self._auto_complete_triggered_manually
+        triggered_manually = self._auto_complete_triggered_manually
         self._auto_complete_triggered_manually = False  # reset state for next completion popup
         sessions = list(self.sessions_async('completionProvider'))
         if not sessions or not self.view.is_valid():
@@ -702,7 +702,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             completion_promises.append(completion_request())
 
         Promise.all(completion_promises).then(
-            lambda responses: self._on_all_settled(responses, resolve_completion_list, triggerd_manually))
+            lambda responses: self._on_all_settled(responses, resolve_completion_list, triggered_manually))
 
     def _on_all_settled(
         self,


### PR DESCRIPTION
This is part 2 of https://github.com/sublimelsp/LSP/commit/e14bf5de0cacabea9545cf88f27cea7fa8e4e840.

Now both of the builtin ST settings are respected. For example, I personally use
```jsonc
{
    "auto_complete_include_snippets": true,  // (default value)
    "auto_complete_include_snippets_when_typing": false,
}
```