### PR TITLE
Improve strategy for semantic highlighting requests

### DIFF
--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -22,6 +22,7 @@ from .core.views import did_open
 from .core.views import did_save
 from .core.views import document_color_params
 from .core.views import DOCUMENT_LINK_FLAGS
+from .core.views import entire_content_range
 from .core.views import lsp_color_to_phantom
 from .core.views import MissingUriError
 from .core.views import range_to_region
@@ -29,9 +30,15 @@ from .core.views import region_to_range
 from .core.views import text_document_identifier
 from .core.views import will_save
 from .semantic_highlighting import SemanticToken
+from functools import partial
 from weakref import WeakSet
 import sublime
 import time
+
+
+# If the total number of characters in the file exceeds this limit, try to send a semantic tokens request only for the
+# visible part first when the file was just opened
+HUGE_FILE_SIZE = 50000
 
 
 class PendingChanges:
@@ -142,7 +149,7 @@ class SessionBuffer:
             self.session.send_notification(did_open(view, language_id))
             self.opened = True
             self._do_color_boxes_async(view, view.change_count())
-            self.do_semantic_tokens_async(view)
+            self.do_semantic_tokens_async(view, view.size() > HUGE_FILE_SIZE)
             if userprefs().link_highlight_style in ("underline", "none"):
                 self._do_document_link_async(view, view.change_count())
             self.session.notify_plugin_on_session_buffer_change(self)
@@ -485,7 +492,7 @@ class SessionBuffer:
 
     # --- textDocument/semanticTokens ----------------------------------------------------------------------------------
 
-    def do_semantic_tokens_async(self, view: sublime.View) -> None:
+    def do_semantic_tokens_async(self, view: sublime.View, only_viewport: bool = False) -> None:
         if not userprefs().semantic_highlighting:
             return
         if not self.session.has_capability("semanticTokensProvider"):
@@ -497,7 +504,12 @@ class SessionBuffer:
             self.session.cancel_request(self.semantic_tokens.pending_response)
         self.semantic_tokens.view_change_count = view.change_count()
         params = {"textDocument": text_document_identifier(view)}  # type: Dict[str, Any]
-        if self.semantic_tokens.result_id and self.session.has_capability("semanticTokensProvider.full.delta"):
+        if only_viewport and self.session.has_capability("semanticTokensProvider.range"):
+            params["range"] = region_to_range(view, view.visible_region()).to_lsp()
+            request = Request.semanticTokensRange(params, view)
+            self.semantic_tokens.pending_response = self.session.send_request_async(
+                request, partial(self._on_semantic_tokens_viewport_async, view), self._on_semantic_tokens_error_async)
+        elif self.semantic_tokens.result_id and self.session.has_capability("semanticTokensProvider.full.delta"):
             params["previousResultId"] = self.semantic_tokens.result_id
             request = Request.semanticTokensFullDelta(params, view)
             self.semantic_tokens.pending_response = self.session.send_request_async(
@@ -507,21 +519,25 @@ class SessionBuffer:
             self.semantic_tokens.pending_response = self.session.send_request_async(
                 request, self._on_semantic_tokens_async, self._on_semantic_tokens_error_async)
         elif self.session.has_capability("semanticTokensProvider.range"):
-            params["range"] = region_to_range(view, view.visible_region()).to_lsp()
+            params["range"] = entire_content_range(view).to_lsp()
             request = Request.semanticTokensRange(params, view)
             self.semantic_tokens.pending_response = self.session.send_request_async(
                 request, self._on_semantic_tokens_async, self._on_semantic_tokens_error_async)
 
     def _on_semantic_tokens_async(self, response: Optional[Dict]) -> None:
+        self.semantic_tokens.pending_response = None
         if response:
-            self.semantic_tokens.pending_response = None
             self.semantic_tokens.result_id = response.get("resultId")
             self.semantic_tokens.data = response["data"]
             self._draw_semantic_tokens_async()
 
+    def _on_semantic_tokens_viewport_async(self, view: sublime.View, response: Optional[Dict]) -> None:
+        self._on_semantic_tokens_async(response)
+        self.do_semantic_tokens_async(view)  # now request semantic tokens for the full file
+
     def _on_semantic_tokens_delta_async(self, response: Optional[Dict]) -> None:
+        self.semantic_tokens.pending_response = None
         if response:
-            self.semantic_tokens.pending_response = None
             self.semantic_tokens.result_id = response.get("resultId")
             if "edits" in response:  # response is of type SemanticTokensDelta
                 for semantic_tokens_edit in response["edits"]:


### PR DESCRIPTION
This is a small optimization for semantic highlighting:

* If a very big file was just opened, initially request tokens only for
  the visible range (if the server supports it), and after the response
  arrives also request tokens for the rest of the file. This way
  semantic highlighting can be shown faster for the currently visible
  part of the file, and for the rest of the file it will be applied a
  little bit later.

* If the server supports only the semanticTokens/range request, use the
  entire file range for the requested content range while typing. By
  doing this, semantic highlighting is also visible after scrolling the
  file and it prevents unpleasant highlighting updates when typing after
  scrolling to another position.


With LSP-lua and a 165kb file:

**Before:**
<details>
  <summary>Click to show GIF</summary>
  
![full](https://user-images.githubusercontent.com/6579999/184934995-b7f153c5-26e3-45f4-b55e-3f5e84757b5b.gif)

</details>

Time between request send and response arrives (counted from screen record with 60Hz): 166 frames = 2.77 sec

**After:**
<details>
  <summary>Click to show GIF</summary>
  
![range](https://user-images.githubusercontent.com/6579999/184935451-bb973c9a-0d01-4e38-a83a-323dfca327ec.gif)

</details>

Time between request send and response arrives: 13 frames = 0.22 sec