### PR TITLE
Add overridable methods to LspExecuteCommand

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -20,6 +20,7 @@ from .plugin.core.panels import LspClearPanelCommand
 from .plugin.core.panels import LspUpdatePanelCommand
 from .plugin.core.panels import LspUpdateServerPanelCommand
 from .plugin.core.panels import WindowPanelListener
+from .plugin.core.protocol import Error
 from .plugin.core.protocol import Location
 from .plugin.core.registry import LspRecheckSessionsCommand
 from .plugin.core.registry import LspRestartServerCommand

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -37,16 +37,20 @@ class LspExecuteCommand(LspTextCommand):
             def handle_response(response: Any) -> None:
                 assert command_name
                 if isinstance(response, Error):
-                    sublime.message_dialog("command {} failed. Reason: {}".format(command_name, str(response)))
+                    self.handle_error_async(response, command_name)
                     return
-                msg = "command {} completed".format(command_name)
-                if response:
-                    msg += "with response: {}".format(response)
-                window = self.view.window()
-                if window:
-                    window.status_message(msg)
+                self.handle_success_async(response, command_name)
 
             session.execute_command(params, progress=True).then(handle_response)
+
+    def handle_success_async(self, result: Any, command_name: str) -> None:
+        msg = "command {} completed".format(command_name)
+        window = self.view.window()
+        if window:
+            window.status_message(msg)
+
+    def handle_error_async(self, error: Error, command_name: str) -> None:
+        sublime.message_dialog("command {} failed. Reason: {}".format(command_name, str(error)))
 
     def _expand_variables(self, command_args: List[Any]) -> List[Any]:
         view = self.view  # type: sublime.View

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -9,6 +9,9 @@ from .core.views import uri_from_view, offset_to_point, region_to_range, text_do
 
 
 class LspExecuteCommand(LspTextCommand):
+    """
+    Helper command for triggering workspace/executeCommand requests.
+    """
 
     def run(self,
             edit: sublime.Edit,
@@ -44,12 +47,24 @@ class LspExecuteCommand(LspTextCommand):
             session.execute_command(params, progress=True).then(handle_response)
 
     def handle_success_async(self, result: Any, command_name: str) -> None:
+        """
+        Override this method to handle successful response to workspace/executeCommand.
+
+        :param result: The result returned from the server.
+        :param command_name: The name of the command that was executed.
+        """
         msg = "command {} completed".format(command_name)
         window = self.view.window()
         if window:
             window.status_message(msg)
 
     def handle_error_async(self, error: Error, command_name: str) -> None:
+        """
+        Override this method to handle failed response to workspace/executeCommand.
+
+        :param error: The Error object.
+        :param command_name: The name of the command that was executed.
+        """
         sublime.message_dialog("command {} failed. Reason: {}".format(command_name, str(error)))
 
     def _expand_variables(self, command_args: List[Any]) -> List[Any]:


### PR DESCRIPTION
A simple addition to make it so that plugins can easily use it with custom response handlers without re-implementing the `run` method.

I've changed the default success handler to not stringify the response as the response can be anything, including a complex object, so it doesn't make sense to assume that it's something that can be presented in the status bar.

Resolves #1902