### PR TITLE
Delay re-calculation of currently not visible code lenses and inlay hints

### DIFF
--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -339,11 +339,17 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         if not self.view.is_loading() and is_regular_view(self.view):
             if not self._registered:
                 self._register_async()
+            for sv in self.session_views_async():
+                if sv.code_lenses_needs_refresh:
+                    sv.set_code_lenses_pending_refresh(False)
+                    sv.start_code_lenses_async()
             for sb in self.session_buffers_async():
                 if sb.semantic_tokens.needs_refresh:
-                    sb.semantic_tokens.needs_refresh = False
+                    sb.set_semantic_tokens_pending_refresh(False)
                     sb.do_semantic_tokens_async(self.view)
-                sb.do_inlay_hints_async(self.view)
+                if sb.inlay_hints_needs_refresh:
+                    sb.set_inlay_hints_pending_refresh(False)
+                    sb.do_inlay_hints_async(self.view)
 
     def on_selection_modified_async(self) -> None:
         different, current_region = self._update_stored_region_async()

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -121,6 +121,7 @@ class SessionBuffer:
         self._semantic_region_keys = {}  # type: Dict[str, int]
         self._last_semantic_region_key = 0
         self._inlay_hints_phantom_set = sublime.PhantomSet(view, "lsp_inlay_hints")
+        self.inlay_hints_needs_refresh = False
         self._check_did_open(view)
         self._session.register_session_buffer_async(self)
 
@@ -660,6 +661,9 @@ class SessionBuffer:
 
     def present_inlay_hints(self, phantoms: List[sublime.Phantom]) -> None:
         self._inlay_hints_phantom_set.update(phantoms)
+
+    def set_inlay_hints_pending_refresh(self, needs_refresh: bool = True) -> None:
+        self.inlay_hints_needs_refresh = needs_refresh
 
     def remove_inlay_hint_phantom(self, phantom_uuid: str) -> None:
         new_phantoms = list(filter(

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -45,6 +45,7 @@ class SessionView:
         self._listener = ref(listener)
         self.progress = {}  # type: Dict[int, ViewProgressReporter]
         self._code_lenses = CodeLensView(self._view)
+        self.code_lenses_needs_refresh = False
         settings = self._view.settings()
         buffer_id = self._view.buffer_id()
         key = (id(session), buffer_id)
@@ -375,6 +376,9 @@ class SessionView:
     def _on_code_lenses_resolved_async(self, mode: str) -> None:
         if self._is_listener_alive():
             sublime.set_timeout(lambda: self._code_lenses.render(mode))
+
+    def set_code_lenses_pending_refresh(self, needs_refresh: bool = True) -> None:
+        self.code_lenses_needs_refresh = needs_refresh
 
     def get_resolved_code_lenses_for_region(self, region: sublime.Region) -> Generator[CodeLens, None, None]:
         yield from self._code_lenses.get_resolved_code_lenses_for_region(region)


### PR DESCRIPTION
... after a "refresh" request from the server, which may be triggered by some servers after each document change.

I have not tested it for inlay hints because LSP-gopls doesn't seem to support inlayHint/refresh, but you can see the improvement to avoid unnecessary code lens requests for example with rust-analyzer.