### PR TITLE
Allow plugins to override name shown in the status field

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -683,6 +683,16 @@ class AbstractPlugin(metaclass=ABCMeta):
         raise NotImplementedError()
 
     @classmethod
+    def status_name(cls) -> str:
+        """
+        Overrides the name shown in the status field for a running server. Defaults to name().
+
+        The difference between overriding name() and this is that name() also affects the names of the configuration
+        keys, name shown in the error messages and other places.
+        """
+        return cls.name()
+
+    @classmethod
     def configuration(cls) -> Tuple[sublime.Settings, str]:
         """
         Return the Settings object that defines the "command", "languages", and optionally the "initializationOptions",

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -668,6 +668,7 @@ class ClientConfig:
         self.file_watcher = file_watcher
         self.path_maps = path_maps
         self.status_key = "lsp_{}".format(self.name)
+        self.status_name = self.name
         self.semantic_tokens = semantic_tokens
 
     @classmethod
@@ -793,9 +794,12 @@ class ClientConfig:
                 env[key] = sublime.expand_variables(value, variables)
         return TransportConfig(self.name, command, tcp_port, env, listener_socket)
 
+    def override_status_name(self, name: str) -> None:
+        self.status_name = name
+
     def set_view_status(self, view: sublime.View, message: str) -> None:
         if sublime.load_settings("LSP.sublime-settings").get("show_view_status"):
-            status = "{}: {}".format(self.name, message) if message else self.name
+            status = "{}: {}".format(self.status_name, message) if message else self.status_name
             view.set_status(self.status_key, status)
 
     def erase_view_status(self, view: sublime.View) -> None:

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -244,6 +244,7 @@ class WindowManager(Manager):
             variables = extract_variables(self._window)
             cwd = None  # type: Optional[str]
             if plugin_class is not None:
+                config.override_status_name(plugin_class.status_name())
                 if plugin_class.needs_update_or_installation():
                     config.set_view_status(initiating_view, "installing...")
                     plugin_class.install_or_update()


### PR DESCRIPTION
I'm fine with this not going in if there are objections.

On one hand I think it can create a bit of confusion as the name in the status won't match package name. On the other hand, this is already the case for packages overriding `AbstractPlugin.name()` and I'm very much against overriding `AbstractPlugin.name()` as that also affects configuration keys and I believe that configuration keys should match the package name.

The only point of using this would be to create a bit cleaner look in the status field.

![Screenshot 2022-08-21 at 23 26 12](https://user-images.githubusercontent.com/153197/185811583-9f9dc179-24c8-40ce-9dfd-db6bfa1a5b37.png)

vs.

![Screenshot 2022-08-21 at 23 26 38](https://user-images.githubusercontent.com/153197/185811604-4dcb765f-d0e7-45c3-b03d-6eebdebfd108.png)

