### PR TITLE
Optionally fallback to goto_reference in lsp_symbol_references

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -154,7 +154,8 @@
     {
         "command": "lsp_symbol_references",
         "args": {
-            "side_by_side": false
+            "side_by_side": false,
+            "fallback": false
         },
         "keys": [
             "shift+f12"

--- a/docs/src/features.md
+++ b/docs/src/features.md
@@ -44,6 +44,9 @@ By parsing and indexing a project with `.sublime-syntax` files, Sublime Text is 
 
 This package provides a replacement of that functionality if your language server has this capability.
 
+Additionally, the LSP's "Find References" command can fall back to the built-in Sublime's "Goto Reference" if the `fallback` argument is set to `true`.
+This way, when there are no results found the built-in "Goto Reference" command will be triggered.
+
 ## Highlights
 
 [Example GIF 1](https://user-images.githubusercontent.com/6579999/128552021-d9058c65-d6f6-48f5-b7aa-652eafe23247.gif)

--- a/plugin/references.py
+++ b/plugin/references.py
@@ -87,6 +87,15 @@ class LspSymbolReferencesCommand(LspTextCommand):
         else:
             self._handle_no_results(fallback, side_by_side)
 
+    def _handle_no_results(self, fallback: bool = False, side_by_side: bool = False) -> None:
+        window = self.view.window()
+        if not window:
+            return
+        if fallback:
+            window.run_command("goto_reference", {"side_by_side": side_by_side})
+        else:
+            window.status_message("No references found")
+
     def _show_references_in_quick_panel(self, session: Session, locations: List[Location], side_by_side: bool) -> None:
         self.view.run_command("add_jump_record", {"selection": [(r.a, r.b) for r in self.view.sel()]})
         LocationPicker(self.view, session, locations, side_by_side)
@@ -122,17 +131,6 @@ class LspSymbolReferencesCommand(LspTextCommand):
         # highlight all word occurrences
         regions = panel.find_all(r"\b{}\b".format(word))
         panel.add_regions('ReferenceHighlight', regions, 'comment', flags=sublime.DRAW_OUTLINED)
-
-    def _handle_no_results(self, fallback: bool = False, side_by_side: bool = False) -> None:
-        window = self.view.window()
-
-        if not window:
-            return
-
-        if fallback:
-            window.run_command("goto_reference", {"side_by_side": side_by_side})
-        else:
-            window.status_message("No references found")
 
 
 def _get_relative_path(base_dir: Optional[str], file_path: str) -> str:


### PR DESCRIPTION
It is a follow-up PR for https://github.com/sublimelsp/LSP/pull/1986

This PR adds an optional `fallback` parameter to the `lsp_symbol_references ` command that allows fallback to the built-in `goto_reference` command in case no results were found.