### PR TITLE
Add option to highlight hover range

### DIFF
--- a/ColorSchemes/Breakers.sublime-color-scheme
+++ b/ColorSchemes/Breakers.sublime-color-scheme
@@ -1,6 +1,14 @@
 {
     "rules": [
         {
+            "scope": "markup.highlight",
+            "background": "color(var(grey2) alpha(0.2))"
+        },
+        {
+            "scope": "markup.highlight.hover",
+            "background": "color(var(blue2) alpha(0.15))"
+        },
+        {
             "scope": "meta.semantic-token",
             "background": "#00000001"
         }

--- a/ColorSchemes/Celeste.sublime-color-scheme
+++ b/ColorSchemes/Celeste.sublime-color-scheme
@@ -1,6 +1,14 @@
 {
     "rules": [
         {
+            "scope": "markup.highlight",
+            "background": "color(var(dark_gray) alpha(0.1))"
+        },
+        {
+            "scope": "markup.highlight.hover",
+            "background": "color(var(teal) alpha(0.15))"
+        },
+        {
             "scope": "meta.semantic-token",
             "background": "#00000001"
         }

--- a/ColorSchemes/Mariana.sublime-color-scheme
+++ b/ColorSchemes/Mariana.sublime-color-scheme
@@ -1,6 +1,14 @@
 {
     "rules": [
         {
+            "scope": "markup.highlight",
+            "background": "color(var(white3) alpha(0.15))"
+        },
+        {
+            "scope": "markup.highlight.hover",
+            "background": "color(var(blue5) alpha(0.15))"
+        },
+        {
             "scope": "meta.semantic-token",
             "background": "#00000001"
         }

--- a/ColorSchemes/Monokai.sublime-color-scheme
+++ b/ColorSchemes/Monokai.sublime-color-scheme
@@ -1,6 +1,14 @@
 {
     "rules": [
         {
+            "scope": "markup.highlight",
+            "background": "color(var(white3) alpha(0.15))"
+        },
+        {
+            "scope": "markup.highlight.hover",
+            "background": "color(var(blue) alpha(0.15))"
+        },
+        {
             "scope": "meta.semantic-token",
             "background": "#00000001"
         }

--- a/ColorSchemes/Sixteen.sublime-color-scheme
+++ b/ColorSchemes/Sixteen.sublime-color-scheme
@@ -1,6 +1,14 @@
 {
     "rules": [
         {
+            "scope": "markup.highlight",
+            "background": "color(var(grey2) alpha(0.2))"
+        },
+        {
+            "scope": "markup.highlight.hover",
+            "background": "color(var(blue2) alpha(0.15))"
+        },
+        {
             "scope": "meta.semantic-token",
             "background": "#00000001"
         }

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -81,9 +81,14 @@
 
   // Highlighting style of "highlights": accentuating nearby text entities that
   // are related to the one under your cursor.
-  // Valid values are "fill", "underline", "stippled", or "".
+  // Valid values are "background", "underline", "stippled", or "".
   // When set to the empty string (""), no document highlighting is requested.
   "document_highlight_style": "underline",
+
+  // Highlight style of the word or range for which a hover popup is shown.
+  // Valid values are "background", "underline", "stippled", or "".
+  // When set to the empty string (""), no highlighting is applied.
+  "hover_highlight_style": "",
 
   // Highlight style of code diagnostics.
   // Can be a string, or a mapping of string->string for severity-based styling.

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -83,11 +83,15 @@
   // are related to the one under your cursor.
   // Valid values are "background", "underline", "stippled", or "".
   // When set to the empty string (""), no document highlighting is requested.
+  // See https://lsp.sublimetext.io/customization/#document-highlights for how to
+  // customize the color.
   "document_highlight_style": "underline",
 
   // Highlight style of the word or range for which a hover popup is shown.
   // Valid values are "background", "underline", "stippled", or "".
   // When set to the empty string (""), no highlighting is applied.
+  // See https://lsp.sublimetext.io/customization/#hover-highlights for how to
+  // customize the color.
   "hover_highlight_style": "",
 
   // Highlight style of code diagnostics.

--- a/docs/src/customization.md
+++ b/docs/src/customization.md
@@ -156,7 +156,18 @@ If neither a scope for a custom token type is defined, nor a color scheme rule f
 | `markup.highlight.write.lsp` | Write | Write-access of a symbol, like writing to a variable |
 
 !!! note
-    If `document_highlight_style` is set to "fill" in the LSP settings, the highlighting color can be controlled via the "background" color from a color scheme rule for the listed scopes.
+    If `document_highlight_style` is set to "background" in the LSP settings, the highlighting color can be controlled via the "background" color from a color scheme rule for the listed scopes.
+
+### Hover Highlights
+
+Allows to highlight the word or range for which a hover popup is shown (disabled by default).
+
+| scope |
+| ----- |
+| `markup.highlight.hover.lsp` |
+
+!!! note
+    If `hover_highlight_style` is set to "background" in the LSP settings, the highlighting color can be controlled via the "background" color from a color scheme rule.
 
 ### Diagnostics
 

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -191,6 +191,7 @@ class Settings:
     diagnostics_panel_include_severity_level = None  # type: int
     disabled_capabilities = None  # type: List[str]
     document_highlight_style = None  # type: str
+    hover_highlight_style = None  # type: str
     inhibit_snippet_completions = None  # type: bool
     inhibit_word_completions = None  # type: bool
     link_highlight_style = None  # type: str
@@ -231,6 +232,7 @@ class Settings:
         r("diagnostics_panel_include_severity_level", 4)
         r("disabled_capabilities", [])
         r("document_highlight_style", "underline")
+        r("hover_highlight_style", "")
         r("link_highlight_style", "underline")
         r("log_debug", False)
         r("log_max_size", 8 * 1024)
@@ -295,10 +297,10 @@ class Settings:
 
         set_debug_logging(self.log_debug)
 
-    def document_highlight_style_region_flags(self) -> Tuple[int, int]:
-        if self.document_highlight_style == "fill":
+    def highlight_style_region_flags(self, style_str: str) -> Tuple[int, int]:
+        if style_str in ("background", "fill"):  # Backwards-compatible with "fill"
             return sublime.DRAW_NO_OUTLINE, sublime.DRAW_NO_OUTLINE
-        elif self.document_highlight_style == "stippled":
+        elif style_str == "stippled":
             return sublime.DRAW_NO_FILL, sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE | sublime.DRAW_STIPPLED_UNDERLINE  # noqa: E501
         else:
             return sublime.DRAW_NO_FILL, sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE | sublime.DRAW_SOLID_UNDERLINE  # noqa: E501

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -567,7 +567,8 @@ def show_lsp_popup(view: sublime.View, contents: str, location: int = -1, md: bo
         wrapper_class=wrapper_class,
         max_width=int(view.em_width() * float(userprefs().popup_max_characters_width)),
         max_height=int(view.line_height() * float(userprefs().popup_max_characters_height)),
-        on_navigate=on_navigate)
+        on_navigate=on_navigate,
+        on_hide=on_hide)
 
 
 def update_lsp_popup(view: sublime.View, contents: str, md: bool = False, css: Optional[str] = None,

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -676,7 +676,8 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
 
         def render_highlights_on_main_thread() -> None:
             self._clear_highlight_regions()
-            flags_multi, flags_single = userprefs().document_highlight_style_region_flags()
+            prefs = userprefs()
+            flags_multi, flags_single = prefs.highlight_style_region_flags(prefs.document_highlight_style)
             for tup, regions in kind2regions.items():
                 if not regions:
                     continue

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -8,6 +8,7 @@ from .core.protocol import Error
 from .core.protocol import ExperimentalTextDocumentRangeParams
 from .core.protocol import Hover
 from .core.protocol import Position
+from .core.protocol import Range
 from .core.protocol import RangeLsp
 from .core.protocol import Request
 from .core.protocol import TextDocumentPositionParams
@@ -28,11 +29,13 @@ from .core.views import make_command_link
 from .core.views import make_link
 from .core.views import MarkdownLangMap
 from .core.views import minihtml
+from .core.views import range_to_region
 from .core.views import show_lsp_popup
 from .core.views import text_document_position_params
 from .core.views import text_document_range_params
 from .core.views import unpack_href_location
 from .core.views import update_lsp_popup
+from .session_view import HOVER_HIGHLIGHT_KEY
 from urllib.parse import unquote, urlparse
 import functools
 import re
@@ -264,6 +267,14 @@ class LspHoverCommand(LspTextCommand):
             contents.append(minihtml(self.view, content, allowed_formats, language_map))
         return '<hr>'.join(contents)
 
+    def hover_range(self) -> Optional[sublime.Region]:
+        for hover, _ in self._hover_responses:
+            hover_range = hover.get('range')
+            if hover_range:
+                return range_to_region(Range.from_lsp(hover_range), self.view)
+        else:
+            return None
+
     def show_hover(self, listener: AbstractViewListener, point: int, only_diagnostics: bool) -> None:
         sublime.set_timeout(lambda: self._show_hover(listener, point, only_diagnostics))
 
@@ -271,7 +282,8 @@ class LspHoverCommand(LspTextCommand):
         hover_content = self.hover_content()
         contents = self.diagnostics_content() + hover_content + code_actions_content(self._actions_by_config)
         link_content, link_has_standard_tooltip = self._document_link_content
-        if userprefs().show_symbol_action_links and contents and not only_diagnostics and hover_content:
+        prefs = userprefs()
+        if prefs.show_symbol_action_links and contents and not only_diagnostics and hover_content:
             symbol_actions_content = self.symbol_actions_content(listener, point)
             if link_content and link_has_standard_tooltip:
                 if symbol_actions_content:
@@ -288,6 +300,15 @@ class LspHoverCommand(LspTextCommand):
         _test_contents.append(contents)  # for testing only
 
         if contents:
+            if prefs.hover_highlight_style:
+                hover_range = self.hover_range()
+                if hover_range:
+                    _, flags = prefs.highlight_style_region_flags(prefs.hover_highlight_style)
+                    self.view.add_regions(
+                        HOVER_HIGHLIGHT_KEY,
+                        regions=[hover_range],
+                        scope="region.cyanish markup.highlight.hover.lsp",
+                        flags=flags)
             if self.view.is_popup_visible():
                 update_lsp_popup(self.view, contents)
             else:
@@ -296,7 +317,8 @@ class LspHoverCommand(LspTextCommand):
                     contents,
                     flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY,
                     location=point,
-                    on_navigate=lambda href: self._on_navigate(href, point))
+                    on_navigate=lambda href: self._on_navigate(href, point),
+                    on_hide=lambda: self.view.erase_regions(HOVER_HIGHLIGHT_KEY))
 
     def _on_navigate(self, href: str, point: int) -> None:
         if href.startswith("subl:"):

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -20,6 +20,7 @@ import functools
 import sublime
 
 DIAGNOSTIC_TAG_VALUES = [v for (k, v) in DiagnosticTag.__dict__.items() if not k.startswith('_')]
+HOVER_HIGHLIGHT_KEY = "lsp_hover_highlight"
 
 
 class SessionView:
@@ -113,15 +114,18 @@ class SessionView:
         """
         r = [sublime.Region(0, 0)]
         document_highlight_style = userprefs().document_highlight_style
+        hover_highlight_style = userprefs().hover_highlight_style
         document_highlight_kinds = ["text", "read", "write"]
         line_modes = ["m", "s"]
         self.view.add_regions(self.CODE_ACTIONS_KEY, r)  # code actions lightbulb icon should always be on top
         for key in range(1, 100):
             self.view.add_regions("lsp_semantic_{}".format(key), r)
-        if document_highlight_style == "fill":
+        if document_highlight_style in ("background", "fill"):
             for kind in document_highlight_kinds:
                 for mode in line_modes:
                     self.view.add_regions("lsp_highlight_{}{}".format(kind, mode), r)
+        if hover_highlight_style in ("background", "fill"):
+            self.view.add_regions(HOVER_HIGHLIGHT_KEY, r)
         for severity in range(1, 5):
             for mode in line_modes:
                 for tag in range(1, 3):
@@ -130,10 +134,12 @@ class SessionView:
         for severity in range(1, 5):
             for mode in line_modes:
                 self.view.add_regions("lsp{}d{}{}".format(self.session.config.name, mode, severity), r)
-        if document_highlight_style != "fill":
+        if document_highlight_style in ("underline", "stippled"):
             for kind in document_highlight_kinds:
                 for mode in line_modes:
                     self.view.add_regions("lsp_highlight_{}{}".format(kind, mode), r)
+        if hover_highlight_style in ("underline", "stippled"):
+            self.view.add_regions(HOVER_HIGHLIGHT_KEY, r)
 
     def _clear_auto_complete_triggers(self, settings: sublime.Settings) -> None:
         '''Remove all of our modifications to the view's "auto_complete_triggers"'''

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -349,13 +349,23 @@
             },
             "document_highlight_style": {
               "enum": [
-                "fill",
+                "background",
                 "underline",
                 "stippled",
                 ""
               ],
               "default": "underline",
-              "markdownDescription": "Highlighting style of `\"highlights\"`: accentuating nearby text entities that are related to the one under your cursor. When set to the empty string (`\"\"`), no diagnostics are shown in-line."
+              "markdownDescription": "Highlighting style of `\"highlights\"`: accentuating nearby text entities that are related to the one under your cursor."
+            },
+            "hover_highlight_style": {
+              "enum": [
+                "background",
+                "underline",
+                "stippled",
+                ""
+              ],
+              "default": "",
+              "markdownDescription": "Highlight style of the word or range for which a hover popup is shown."
             },
             "diagnostics_gutter_marker": {
               "enum": [

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -355,7 +355,7 @@
                 ""
               ],
               "default": "underline",
-              "markdownDescription": "Highlighting style of `\"highlights\"`: accentuating nearby text entities that are related to the one under your cursor."
+              "markdownDescription": "Highlighting style of `\"highlights\"`: accentuating nearby text entities that are related to the one under your cursor.\n\nSee https://lsp.sublimetext.io/customization/#document-highlights for how to customize the color."
             },
             "hover_highlight_style": {
               "enum": [
@@ -365,7 +365,7 @@
                 ""
               ],
               "default": "",
-              "markdownDescription": "Highlight style of the word or range for which a hover popup is shown."
+              "markdownDescription": "Highlight style of the word or range for which a hover popup is shown.\n\nSee https://lsp.sublimetext.io/customization/#hover-highlights for how to customize the color."
             },
             "diagnostics_gutter_marker": {
               "enum": [


### PR DESCRIPTION
Inspired by VSCode. Not sure if it's needed, and there seems to be a slight aversion to introduce new settings. But I kind of like it (and it's disabled by default).

![hover](https://user-images.githubusercontent.com/6579999/186329811-ae84cca4-9722-40be-88d7-cafb7603dbb1.gif)

For the "document_highlight_style" setting I have also renamed the "fill" option to "background" (which I now think is a better name), but kept it fully backwards compatible with "fill".

Feel free to merge or close.