### PR TITLE
Add group argument for LspGotoCommand

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -198,7 +198,8 @@
     //     "command": "lsp_symbol_type_definition",
     //     "args": {
     //         "side_by_side": false,
-    //         "force_group": true
+    //         "force_group": true,
+    //         "group": -1
     //     },
     //     "keys": [
     //         "UNBOUND"
@@ -221,7 +222,8 @@
     //     "command": "lsp_symbol_declaration",
     //     "args": {
     //         "side_by_side": false,
-    //         "force_group": true
+    //         "force_group": true,
+    //         "group": -1
     //     },
     //     "keys": [
     //         "UNBOUND"
@@ -244,7 +246,8 @@
     //     "command": "lsp_symbol_implementation",
     //     "args": {
     //         "side_by_side": false,
-    //         "force_group": true
+    //         "force_group": true,
+    //         "group": -1
     //     },
     //     "keys": [
     //         "UNBOUND"

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -174,7 +174,8 @@
     //     "args": {
     //         "side_by_side": false,
     //         "force_group": true,
-    //         "fallback": false
+    //         "fallback": false,
+    //         "group": -1
     //     },
     //     "keys": [
     //         "f12"

--- a/docs/src/features.md
+++ b/docs/src/features.md
@@ -34,6 +34,8 @@ In addition to the basic "Goto Definition", the protocol also provides further r
 Additionally, the LSP's "Goto Definition" command can fall back to the built-in Sublime's "Goto Definition" if the `fallback` argument is set to `true`.
 This way, when there are no results found the built-in "Goto Definition" command will be triggered.
 
+To always open the results in a certain group, you can pass the `group` argument.
+
 ## Find References
 
 [Example GIF 1](https://user-images.githubusercontent.com/6579999/128551752-b37fe407-148c-41cf-b1e4-6fe96ed0f77c.gif)

--- a/docs/src/features.md
+++ b/docs/src/features.md
@@ -34,7 +34,7 @@ In addition to the basic "Goto Definition", the protocol also provides further r
 Additionally, the LSP's "Goto Definition" command can fall back to the built-in Sublime's "Goto Definition" if the `fallback` argument is set to `true`.
 This way, when there are no results found the built-in "Goto Definition" command will be triggered.
 
-To always open the results in a certain group, you can use the `group` argument.
+To attempt to open the results in a certain group, you can use the `group` argument. If the specified `group` does not exist, then it will be ignored.
 
 ## Find References
 

--- a/docs/src/features.md
+++ b/docs/src/features.md
@@ -34,7 +34,7 @@ In addition to the basic "Goto Definition", the protocol also provides further r
 Additionally, the LSP's "Goto Definition" command can fall back to the built-in Sublime's "Goto Definition" if the `fallback` argument is set to `true`.
 This way, when there are no results found the built-in "Goto Definition" command will be triggered.
 
-To always open the results in a certain group, you can pass the `group` argument.
+To always open the results in a certain group, you can use the `group` argument.
 
 ## Find References
 

--- a/plugin/core/open.py
+++ b/plugin/core/open.py
@@ -15,15 +15,16 @@ import subprocess
 opening_files = {}  # type: Dict[str, Tuple[Promise[Optional[sublime.View]], ResolveFunc[Optional[sublime.View]]]]
 
 
-def _return_existing_view(flags: int, is_view_in_active_group: bool, specified_group: int) -> bool:
+def _return_existing_view(flags: int, existing_view_group: int, active_group: int, specified_group: int) -> bool:
     # the specified_group is supplied
     if specified_group > -1:
-        return is_view_in_active_group
+        # use existing_view_group if it is in the specified group
+        return existing_view_group == specified_group
     # open side by side
     if bool(flags & (sublime.ADD_TO_SELECTION | sublime.REPLACE_MRU)):
         return False
-    # view is in active group ( no group is specified and not side by side )
-    if is_view_in_active_group:
+    # existing view is in active group ( no group is specified and not side by side )
+    if existing_view_group == active_group:
         return True
     # Jump to the file if sublime.FORCE_GROUP is not set
     return not bool(flags & sublime.FORCE_GROUP)
@@ -41,7 +42,7 @@ def open_file(
     # window.open_file brings the file to focus if it's already opened, which we don't want (unless it's supposed
     # to open as a separate view).
     view = window.find_open_file(file)
-    if view and _return_existing_view(flags, window.get_view_index(view)[0] == window.active_group(), group):
+    if view and _return_existing_view(flags, window.get_view_index(view)[0], window.active_group(), group):
         return Promise.resolve(view)
 
     view = window.open_file(file, flags, group)

--- a/plugin/core/open.py
+++ b/plugin/core/open.py
@@ -15,7 +15,7 @@ import subprocess
 opening_files = {}  # type: Dict[str, Tuple[Promise[Optional[sublime.View]], ResolveFunc[Optional[sublime.View]]]]
 
 
-def _return_existing_view(flags: int, open_file_group: int, active_group: int, specified_group: int ) -> bool:
+def _return_existing_view(flags: int, open_file_group: int, active_group: int, specified_group: int) -> bool:
     open_side_by_side = bool(flags & (sublime.ADD_TO_SELECTION | sublime.REPLACE_MRU))
     file_in_active_group = open_file_group == active_group
 
@@ -33,6 +33,7 @@ def _return_existing_view(flags: int, open_file_group: int, active_group: int, s
         return True
     else:
         return select_file
+
 
 def open_file(
     window: sublime.Window, uri: DocumentUri, flags: int = 0, group: int = -1

--- a/plugin/core/open.py
+++ b/plugin/core/open.py
@@ -16,23 +16,16 @@ opening_files = {}  # type: Dict[str, Tuple[Promise[Optional[sublime.View]], Res
 
 
 def _return_existing_view(flags: int, open_file_group: int, active_group: int, specified_group: int) -> bool:
-    open_side_by_side = bool(flags & (sublime.ADD_TO_SELECTION | sublime.REPLACE_MRU))
-    file_in_active_group = open_file_group == active_group
-
-    # true if DONT want to force it to open in the active group
-    # i.e. just jump to the file
-    select_file = not bool(flags & sublime.FORCE_GROUP)
-
     if specified_group > -1:
         return False
+    open_side_by_side = bool(flags & (sublime.ADD_TO_SELECTION | sublime.REPLACE_MRU))
     if open_side_by_side:
-        # default is -1... and is ignored
-        # always open in the specific group if pass in
         return False
-    elif file_in_active_group:
+    file_in_active_group = open_file_group == active_group
+    if file_in_active_group:
         return True
-    else:
-        return select_file
+    # Jump to the file if sublime.FORCE_GROUP is set
+    return not bool(flags & sublime.FORCE_GROUP)
 
 
 def open_file(
@@ -47,12 +40,10 @@ def open_file(
     # window.open_file brings the file to focus if it's already opened, which we don't want (unless it's supposed
     # to open as a separate view).
     view = window.find_open_file(file)
-
     if view:
         return_existing_view = _return_existing_view(
             flags, window.get_view_index(view)[0], window.active_group(), group
         )
-
         if return_existing_view:
             return Promise.resolve(view)
 

--- a/plugin/core/open.py
+++ b/plugin/core/open.py
@@ -16,17 +16,12 @@ opening_files = {}  # type: Dict[str, Tuple[Promise[Optional[sublime.View]], Res
 
 
 def _return_existing_view(flags: int, existing_view_group: int, active_group: int, specified_group: int) -> bool:
-    # the specified_group is supplied
     if specified_group > -1:
-        # use existing_view_group if it is in the specified group
         return existing_view_group == specified_group
-    # open side by side
     if bool(flags & (sublime.ADD_TO_SELECTION | sublime.REPLACE_MRU)):
         return False
-    # existing view is in active group ( no group is specified and not side by side )
     if existing_view_group == active_group:
         return True
-    # Jump to the file if sublime.FORCE_GROUP is not set
     return not bool(flags & sublime.FORCE_GROUP)
 
 

--- a/plugin/core/open.py
+++ b/plugin/core/open.py
@@ -15,16 +15,18 @@ import subprocess
 opening_files = {}  # type: Dict[str, Tuple[Promise[Optional[sublime.View]], ResolveFunc[Optional[sublime.View]]]]
 
 
-def _return_existing_view(flags: int, open_file_group: int, active_group: int, specified_group: int) -> bool:
+def _return_existing_view(flags: int, existing_view_group: int, active_group: int, specified_group: int) -> bool:
+    # the specified_group is supplied
     if specified_group > -1:
+        # use existing_view_group if it is in the active group
+        return existing_view_group == active_group
+    # open side by side
+    if bool(flags & (sublime.ADD_TO_SELECTION | sublime.REPLACE_MRU)):
         return False
-    open_side_by_side = bool(flags & (sublime.ADD_TO_SELECTION | sublime.REPLACE_MRU))
-    if open_side_by_side:
-        return False
-    file_in_active_group = open_file_group == active_group
-    if file_in_active_group:
+    # existing view is in active group ( no group is specified and not side by side )
+    if existing_view_group == active_group:
         return True
-    # Jump to the file if sublime.FORCE_GROUP is set
+    # Jump to the file if sublime.FORCE_GROUP is not set
     return not bool(flags & sublime.FORCE_GROUP)
 
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1518,6 +1518,8 @@ class Session(TransportCallbacks):
             result = Promise.packaged_task()  # type: PackagedTask[Optional[sublime.View]]
 
             def open_scratch_buffer(title: str, content: str, syntax: str) -> None:
+                if group > -1:
+                    self.window.focus_group(group)
                 v = self.window.new_file(syntax=syntax, flags=flags)
                 # Note: the __init__ of ViewEventListeners is invoked in the next UI frame, so we can fill in the
                 # settings object here at our leisure.

--- a/plugin/goto.py
+++ b/plugin/goto.py
@@ -23,7 +23,8 @@ class LspGotoCommand(LspTextCommand):
         point: Optional[int] = None,
         side_by_side: bool = False,
         force_group: bool = True,
-        fallback: bool = False
+        fallback: bool = False,
+        group: int = -1
     ) -> bool:
         return fallback or super().is_enabled(event, point)
 

--- a/plugin/goto.py
+++ b/plugin/goto.py
@@ -71,7 +71,9 @@ class LspGotoCommand(LspTextCommand):
                 open_location_async(session, response[0], side_by_side, force_group, group)
             else:
                 self.view.run_command("add_jump_record", {"selection": [(r.a, r.b) for r in self.view.sel()]})
-                sublime.set_timeout(functools.partial(LocationPicker, self.view, session, response, side_by_side, group))
+                sublime.set_timeout(
+                    functools.partial(LocationPicker, self.view, session, response, side_by_side, group)
+                )
         else:
             self._handle_no_results(fallback, side_by_side)
 

--- a/plugin/locationpicker.py
+++ b/plugin/locationpicker.py
@@ -110,6 +110,12 @@ class LocationPicker:
                     functools.partial(open_location_async, session, location, self._side_by_side, True, self._group))
         else:
             self._window.focus_view(self._view)
+            # When a group was specified close the current highlighted
+            # sheet upon canceling if the sheet is transient
+            if self._group > -1 and self._highlighted_view:
+                sheet = self._highlighted_view.sheet()
+                if sheet and sheet.is_transient():
+                    self._highlighted_view.close()
             # When in side-by-side mode close the current highlighted
             # sheet upon canceling if the sheet is semi-transient
             if self._side_by_side and self._highlighted_view:

--- a/plugin/locationpicker.py
+++ b/plugin/locationpicker.py
@@ -16,7 +16,8 @@ def open_location_async(
     session: Session,
     location: Union[Location, LocationLink],
     side_by_side: bool,
-    force_group: bool
+    force_group: bool,
+    group: int = -1
 ) -> None:
     flags = sublime.ENCODED_POSITION
     if force_group:
@@ -28,7 +29,7 @@ def open_location_async(
         if not view:
             sublime.error_message("Unable to open URI")
 
-    session.open_location_async(location, flags).then(check_success_async)
+    session.open_location_async(location, flags, group).then(check_success_async)
 
 
 def open_basic_file(
@@ -59,7 +60,8 @@ class LocationPicker:
         view: sublime.View,
         session: Session,
         locations: Union[List[Location], List[LocationLink]],
-        side_by_side: bool
+        side_by_side: bool,
+        group: int = -1
     ) -> None:
         self._view = view
         self._view_states = ([r.to_tuple() for r in view.sel()], view.viewport_position())
@@ -69,10 +71,12 @@ class LocationPicker:
         self._window = window
         self._weaksession = weakref.ref(session)
         self._side_by_side = side_by_side
+        self._group = group
         self._items = locations
         self._highlighted_view = None  # type: Optional[sublime.View]
         manager = session.manager()
         base_dir = manager.get_project_path(view.file_name() or "") if manager else None
+        self._window.focus_group(group)
         self._window.show_quick_panel(
             items=[location_to_human_readable(session.config, base_dir, location) for location in locations],
             on_select=self._select_entry,
@@ -103,7 +107,7 @@ class LocationPicker:
                         self._window.status_message("Unable to open {}".format(uri))
             else:
                 sublime.set_timeout_async(
-                    functools.partial(open_location_async, session, location, self._side_by_side, True))
+                    functools.partial(open_location_async, session, location, self._side_by_side, True, self._group))
         else:
             self._window.focus_view(self._view)
             # When in side-by-side mode close the current highlighted


### PR DESCRIPTION
This PR will allow the user to pass a group for `Goto` commands.

When the group is specified:  

- The result will always open in the group.
- If there's more than one result, it will focus to the group and open the `LocationPicker`.

Relates to: #2022 