### PR TITLE
Fix unescaped special characters in minihtml

### DIFF
--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -38,6 +38,7 @@ from .core.views import update_lsp_popup
 from .session_view import HOVER_HIGHLIGHT_KEY
 from urllib.parse import unquote, urlparse
 import functools
+import html
 import re
 import sublime
 import webbrowser
@@ -224,7 +225,7 @@ class LspHoverCommand(LspTextCommand):
             title = link.get("tooltip") or "Follow link"
             if title != "Follow link":
                 link_has_standard_tooltip = False
-            contents.append('<a href="{}">{}</a>'.format(target, title))
+            contents.append('<a href="{}">{}</a>'.format(html.escape(target), html.escape(title)))
         if len(contents) > 1:
             link_has_standard_tooltip = False
         link_range = range_to_region(Range.from_lsp(links[0]["range"]), self.view) if links else None

--- a/plugin/inlay_hint.py
+++ b/plugin/inlay_hint.py
@@ -101,9 +101,9 @@ def get_inlay_hint_html(view: sublime.View, inlay_hint: InlayHint, session: Sess
 
 def format_inlay_hint_tooltip(tooltip: Optional[Union[str, MarkupContent]]) -> str:
     if isinstance(tooltip, str):
-        return tooltip
+        return html.escape(tooltip)
     if isinstance(tooltip, dict):  # MarkupContent
-        return tooltip.get('value') or ""
+        return html.escape(tooltip.get('value') or "")
     return ""
 
 


### PR DESCRIPTION
Make sure special characters like `&` are properly escaped in minihtml content.

For example with LSP-html and hover over the link in the following file:

```html
<!DOCTYPE html>
<html>
<body>
    <img src="https://avatars.githubusercontent.com/u/684879?s=200&v=4" />
</body>
</html>
```

I assume that this might fix #2034, but due to lack of motivation to install Rust + rust-analyzer manually, I have not tested it.
@minerscale If you want, you could give it a try and see if it fixes your issue :)