### PR TITLE
Add icons and isPreferred support for code actions

### DIFF
--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -11,6 +11,7 @@ from .core.settings import userprefs
 from .core.typing import Any, List, Dict, Callable, Optional, Tuple, Union, Sequence
 from .core.views import entire_content_region
 from .core.views import first_selection_region
+from .core.views import format_code_actions_for_quick_panel
 from .core.views import text_document_code_action_params
 from .save_command import LspSaveCommand, SaveTask
 import sublime
@@ -308,10 +309,14 @@ class LspCodeActionsCommand(LspTextCommand):
 
     def show_code_actions(self) -> None:
         if len(self.commands) > 0:
-            items = [command[1] for command in self.commands]
             window = self.view.window()
             if window:
-                window.show_quick_panel(items, self.handle_select, placeholder="Code action")
+                items, selected_index = format_code_actions_for_quick_panel([command[2] for command in self.commands])
+                window.show_quick_panel(
+                    items,
+                    self.handle_select,
+                    selected_index=selected_index,
+                    placeholder="Code action")
         else:
             self.view.show_popup('No actions available', sublime.HIDE_ON_MOUSE_MOVE_AWAY)
 

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -275,7 +275,7 @@ class LspCodeActionsCommand(LspTextCommand):
         only_kinds: Optional[List[str]] = None,
         commands_by_config: Optional[CodeActionsByConfigName] = None
     ) -> None:
-        self.commands = []  # type: List[Tuple[str, str, CodeActionOrCommand]]
+        self.commands = []  # type: List[Tuple[str, CodeActionOrCommand]]
         self.commands_by_config = {}  # type: CodeActionsByConfigName
         if commands_by_config:
             self.handle_responses_async(commands_by_config, run_first=True)
@@ -300,18 +300,18 @@ class LspCodeActionsCommand(LspTextCommand):
         else:
             self.show_code_actions()
 
-    def combine_commands(self) -> 'List[Tuple[str, str, CodeActionOrCommand]]':
+    def combine_commands(self) -> 'List[Tuple[str, CodeActionOrCommand]]':
         results = []
         for config, commands in self.commands_by_config.items():
             for command in commands:
-                results.append((config, command['title'], command))
+                results.append((config, command))
         return results
 
     def show_code_actions(self) -> None:
         if len(self.commands) > 0:
             window = self.view.window()
             if window:
-                items, selected_index = format_code_actions_for_quick_panel([command[2] for command in self.commands])
+                items, selected_index = format_code_actions_for_quick_panel([command[1] for command in self.commands])
                 window.show_quick_panel(
                     items,
                     self.handle_select,
@@ -328,7 +328,7 @@ class LspCodeActionsCommand(LspTextCommand):
                 session = self.session_by_name(selected[0])
                 if session:
                     name = session.config.name
-                    session.run_code_action_async(selected[2], progress=True).then(
+                    session.run_code_action_async(selected[1], progress=True).then(
                         lambda resp: self.handle_response_async(name, resp))
 
             sublime.set_timeout_async(run_async)

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -199,17 +199,6 @@ CodeActionDisabledInformation = TypedDict('CodeActionDisabledInformation', {
 }, total=True)
 
 
-CodeAction = TypedDict('CodeAction', {
-    'title': str,
-    'kind': Optional[str],
-    'diagnostics': Optional[List[Any]],
-    'isPreferred': Optional[bool],
-    'disabled': Optional[CodeActionDisabledInformation],
-    'edit': Optional[dict],
-    'command': Optional[Command],
-}, total=True)
-
-
 CodeLens = TypedDict('CodeLens', {
     'range': RangeLsp,
     'command': Optional[Command],
@@ -294,6 +283,17 @@ Diagnostic = TypedDict('Diagnostic', {
     'message': str,
     'tags': List[int],
     'relatedInformation': List[DiagnosticRelatedInformation]
+}, total=False)
+
+CodeAction = TypedDict('CodeAction', {
+    'title': str,
+    'kind': str,  # NotRequired
+    'diagnostics': List[Diagnostic],  # NotRequired
+    'isPreferred': bool,  # NotRequired
+    'disabled': CodeActionDisabledInformation,  # NotRequired
+    'edit': dict,  # NotRequired
+    'command': Command,  # NotRequired
+    'data': Any  # NotRequired
 }, total=False)
 
 TextEdit = TypedDict('TextEdit', {

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -321,6 +321,7 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
             },
             "dataSupport": True,
             "disabledSupport": True,
+            "isPreferredSupport": True,
             "resolveSupport": {
                 "properties": [
                     "edit"

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -1,4 +1,6 @@
 from .css import css as lsp_css
+from .protocol import CodeAction
+from .protocol import Command
 from .protocol import CompletionItem
 from .protocol import CompletionItemKind
 from .protocol import CompletionItemTag
@@ -87,6 +89,10 @@ KIND_UNIT = (sublime.KIND_ID_VARIABLE, "u", "Unit")
 KIND_VALUE = (sublime.KIND_ID_VARIABLE, "v", "Value")
 KIND_VARIABLE = (sublime.KIND_ID_VARIABLE, "v", "Variable")
 
+KIND_QUICKFIX = (sublime.KIND_ID_COLOR_YELLOWISH, "f", "QuickFix")
+KIND_REFACTOR = (sublime.KIND_ID_COLOR_CYANISH, "r", "Refactor")
+KIND_SOURCE = (sublime.KIND_ID_COLOR_PURPLISH, "s", "Source")
+
 KIND_UNSPECIFIED = (sublime.KIND_ID_AMBIGUOUS, "?", "???")
 
 COMPLETION_KINDS = {
@@ -144,6 +150,12 @@ SYMBOL_KINDS = {
     SymbolKind.Event: KIND_EVENT,
     SymbolKind.Operator: KIND_OPERATOR,
     SymbolKind.TypeParameter: KIND_TYPEPARAMETER
+}
+
+CODE_ACTION_KINDS = {
+    "quickfix": KIND_QUICKFIX,
+    "refactor": KIND_REFACTOR,
+    "source": KIND_SOURCE
 }
 
 SYMBOL_KIND_SCOPES = {
@@ -988,3 +1000,17 @@ def format_completion(
     if item.get('textEdit'):
         completion.flags = sublime.COMPLETION_FLAG_KEEP_PREFIX
     return completion
+
+
+def format_code_actions_for_quick_panel(
+    code_actions: List[Union[CodeAction, Command]]
+) -> Tuple[List[sublime.QuickPanelItem], int]:
+    items = []  # type: List[sublime.QuickPanelItem]
+    selected_index = -1
+    for idx, code_action in enumerate(code_actions):
+        lsp_kind = str(code_action.get("kind", ""))
+        kind = CODE_ACTION_KINDS.get(lsp_kind.split(".")[0], sublime.KIND_AMBIGUOUS)
+        items.append(sublime.QuickPanelItem(code_action["title"], kind=kind))
+        if code_action.get('isPreferred', False):
+            selected_index = idx
+    return items, selected_index

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -33,6 +33,7 @@ from .core.views import diagnostic_severity
 from .core.views import DOCUMENT_HIGHLIGHT_KIND_SCOPES
 from .core.views import DOCUMENT_HIGHLIGHT_KINDS
 from .core.views import first_selection_region
+from .core.views import format_code_actions_for_quick_panel
 from .core.views import format_completion
 from .core.views import make_command_link
 from .core.views import MarkdownLangMap
@@ -598,12 +599,16 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
     def _on_navigate(self, href: str, point: int) -> None:
         if href.startswith('code-actions:'):
             _, config_name = href.split(":")
-            titles = [command["title"] for command in self._actions_by_config[config_name]]
-            if len(titles) > 1:
+            actions = self._actions_by_config[config_name]
+            if len(actions) > 1:
                 window = self.view.window()
                 if window:
-                    window.show_quick_panel(titles, lambda i: self.handle_code_action_select(config_name, i),
-                                            placeholder="Code actions")
+                    items, selected_index = format_code_actions_for_quick_panel(actions)
+                    window.show_quick_panel(
+                        items,
+                        lambda i: self.handle_code_action_select(config_name, i),
+                        selected_index=selected_index,
+                        placeholder="Code actions")
             else:
                 self.handle_code_action_select(config_name, 0)
 

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -21,6 +21,7 @@ from .core.settings import userprefs
 from .core.typing import List, Optional, Dict, Tuple, Sequence, Union
 from .core.views import diagnostic_severity
 from .core.views import first_selection_region
+from .core.views import format_code_actions_for_quick_panel
 from .core.views import format_diagnostic_for_html
 from .core.views import FORMAT_MARKED_STRING
 from .core.views import FORMAT_MARKUP_CONTENT
@@ -338,13 +339,17 @@ class LspHoverCommand(LspTextCommand):
                 window.open_file(fn, flags=sublime.ENCODED_POSITION)
         elif href.startswith('code-actions:'):
             _, config_name = href.split(":")
-            titles = [command["title"] for command in self._actions_by_config[config_name]]
+            actions = self._actions_by_config[config_name]
             self.view.run_command("lsp_selection_set", {"regions": [(point, point)]})
-            if len(titles) > 1:
+            if len(actions) > 1:
                 window = self.view.window()
                 if window:
-                    window.show_quick_panel(titles, lambda i: self.handle_code_action_select(config_name, i),
-                                            placeholder="Code actions")
+                    items, selected_index = format_code_actions_for_quick_panel(actions)
+                    window.show_quick_panel(
+                        items,
+                        lambda i: self.handle_code_action_select(config_name, i),
+                        selected_index=selected_index,
+                        placeholder="Code actions")
             else:
                 self.handle_code_action_select(config_name, 0)
         elif is_location_href(href):


### PR DESCRIPTION
- if there are multiple code actions and one of them uses `"isPreferred": true`, then preselect it in the quick panel
- add icons for the quick panel entries if CodeActionKind is provided :)

I'm not sure whether multiple code actions can be "preferred" for a given range at the same time, but I would interpret the description at https://code.visualstudio.com/updates/v1_32#_auto-fix-and-preferred-code-actions in such a way that it should not happen.

Other possible enhancements for a future PR:
- add a `only_preferred` argument for the `lsp_code_actions` command, which will then only consider code actions with `"isPreferred": true`
- sort code actions by CodeActionKind for the quick panel