### PR TITLE
Add support for triggerKind in code action requests

### DIFF
--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -85,7 +85,7 @@ class CodeActionsManager:
         session_buffer_diagnostics: List[Tuple[SessionBufferProtocol, List[Diagnostic]]],
         actions_handler: Callable[[CodeActionsByConfigName], None],
         only_kinds: Optional[Dict[str, bool]] = None,
-        manual: Optional[bool] = False,
+        manual: bool = False,
     ) -> None:
         """
         Requests code actions with provided diagnostics and specified region. If there are
@@ -118,7 +118,7 @@ class CodeActionsManager:
         only_with_diagnostics: bool,
         actions_handler: Callable[[CodeActionsByConfigName], None],
         on_save_actions: Optional[Dict[str, bool]] = None,
-        manual: Optional[bool] = False,
+        manual: bool = False,
     ) -> None:
         location_cache_key = None
         use_cache = on_save_actions is None and not manual

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -8,7 +8,7 @@ from .core.registry import LspTextCommand
 from .core.registry import windows
 from .core.sessions import SessionBufferProtocol
 from .core.settings import userprefs
-from .core.typing import Any, List, Dict, Callable, Optional, Tuple, Union, Sequence
+from .core.typing import Any, List, Dict, Callable, Optional, Tuple, Union
 from .core.views import entire_content_region
 from .core.views import first_selection_region
 from .core.views import format_code_actions_for_quick_panel
@@ -82,15 +82,16 @@ class CodeActionsManager:
         self,
         view: sublime.View,
         region: sublime.Region,
-        session_buffer_diagnostics: Sequence[Tuple[SessionBufferProtocol, Sequence[Diagnostic]]],
+        session_buffer_diagnostics: List[Tuple[SessionBufferProtocol, List[Diagnostic]]],
         actions_handler: Callable[[CodeActionsByConfigName], None],
-        only_kinds: Optional[Dict[str, bool]] = None
+        only_kinds: Optional[Dict[str, bool]] = None,
+        manual: Optional[bool] = False,
     ) -> None:
         """
         Requests code actions with provided diagnostics and specified region. If there are
         no diagnostics for given session, the request will be made with empty diagnostics list.
         """
-        self._request_async(view, region, session_buffer_diagnostics, False, actions_handler, only_kinds)
+        self._request_async(view, region, session_buffer_diagnostics, False, actions_handler, only_kinds, manual)
 
     def request_on_save(
         self,
@@ -106,19 +107,21 @@ class CodeActionsManager:
             return
         region = entire_content_region(view)
         session_buffer_diagnostics, _ = listener.diagnostics_intersecting_region_async(region)
-        self._request_async(view, region, session_buffer_diagnostics, False, actions_handler, on_save_actions)
+        self._request_async(
+            view, region, session_buffer_diagnostics, False, actions_handler, on_save_actions, manual=False)
 
     def _request_async(
         self,
         view: sublime.View,
         region: sublime.Region,
-        session_buffer_diagnostics: Sequence[Tuple[SessionBufferProtocol, Sequence[Diagnostic]]],
+        session_buffer_diagnostics: List[Tuple[SessionBufferProtocol, List[Diagnostic]]],
         only_with_diagnostics: bool,
         actions_handler: Callable[[CodeActionsByConfigName], None],
-        on_save_actions: Optional[Dict[str, bool]] = None
+        on_save_actions: Optional[Dict[str, bool]] = None,
+        manual: Optional[bool] = False,
     ) -> None:
         location_cache_key = None
-        use_cache = on_save_actions is None
+        use_cache = on_save_actions is None and not manual
         if use_cache:
             location_cache_key = "{}#{}:{}:{}".format(
                 view.buffer_id(), view.change_count(), region, only_with_diagnostics)
@@ -129,13 +132,12 @@ class CodeActionsManager:
                     return
                 else:
                     self._response_cache = None
-
         collector = CodeActionsCollector(actions_handler)
         with collector:
             listener = windows.listener_for_view(view)
             if listener:
                 for session in listener.sessions_async('codeActionProvider'):
-                    diagnostics = []  # type: Sequence[Diagnostic]
+                    diagnostics = []  # type: List[Diagnostic]
                     for sb, diags in session_buffer_diagnostics:
                         if sb.session == session:
                             diagnostics = diags
@@ -144,14 +146,14 @@ class CodeActionsManager:
                         supported_kinds = session.get_capability('codeActionProvider.codeActionKinds')
                         matching_kinds = get_matching_kinds(on_save_actions, supported_kinds or [])
                         if matching_kinds:
-                            params = text_document_code_action_params(view, region, diagnostics, matching_kinds)
+                            params = text_document_code_action_params(view, region, diagnostics, matching_kinds, manual)
                             request = Request.codeAction(params, view)
                             session.send_request_async(
                                 request, *filtering_collector(session.config.name, matching_kinds, collector))
                     else:
                         if only_with_diagnostics and not diagnostics:
                             continue
-                        params = text_document_code_action_params(view, region, diagnostics)
+                        params = text_document_code_action_params(view, region, diagnostics, None, manual)
                         request = Request.codeAction(params, view)
                         session.send_request_async(request, collector.create_collector(session.config.name))
         if location_cache_key:
@@ -290,7 +292,7 @@ class LspCodeActionsCommand(LspTextCommand):
             session_buffer_diagnostics, covering = listener.diagnostics_intersecting_async(region)
             dict_kinds = {kind: True for kind in only_kinds} if only_kinds else None
             actions_manager.request_for_region_async(
-                view, covering, session_buffer_diagnostics, self.handle_responses_async, dict_kinds)
+                view, covering, session_buffer_diagnostics, self.handle_responses_async, dict_kinds, manual=True)
 
     def handle_responses_async(self, responses: CodeActionsByConfigName, run_first: bool = False) -> None:
         self.commands_by_config = responses

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -23,6 +23,11 @@ class DiagnosticTag:
     Deprecated = 2
 
 
+class CodeActionTriggerKind:
+    Invoked = 1
+    Automatic = 2
+
+
 class CompletionItemKind:
     Text = 1
     Method = 2
@@ -295,6 +300,18 @@ CodeAction = TypedDict('CodeAction', {
     'command': Command,  # NotRequired
     'data': Any  # NotRequired
 }, total=False)
+
+CodeActionContext = TypedDict('CodeActionContext', {
+    'diagnostics': List[Diagnostic],
+    'only': List[str],  # NotRequired
+    'triggerKind': int,  # NotRequired
+}, total=False)
+
+CodeActionParams = TypedDict('CodeActionParams', {
+    'textDocument': TextDocumentIdentifier,
+    'range': RangeLsp,
+    'context': CodeActionContext,
+}, total=True)
 
 TextEdit = TypedDict('TextEdit', {
     'newText': str,

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -53,7 +53,7 @@ from .types import DocumentSelector
 from .types import method_to_capability
 from .types import SettingsRegistration
 from .types import sublime_pattern_to_glob
-from .typing import Callable, cast, Dict, Any, Optional, List, Tuple, Generator, Iterable, Type, Protocol, Sequence, Mapping, Union  # noqa: E501
+from .typing import Callable, cast, Dict, Any, Optional, List, Tuple, Generator, Iterable, Type, Protocol, Mapping, Union  # noqa: E501
 from .url import filename_to_uri
 from .url import parse_uri
 from .version import __version__
@@ -594,14 +594,14 @@ class AbstractViewListener(metaclass=ABCMeta):
     @abstractmethod
     def diagnostics_async(
         self
-    ) -> Iterable[Tuple['SessionBufferProtocol', Sequence[Tuple[Diagnostic, sublime.Region]]]]:
+    ) -> Iterable[Tuple['SessionBufferProtocol', List[Tuple[Diagnostic, sublime.Region]]]]:
         raise NotImplementedError()
 
     @abstractmethod
     def diagnostics_intersecting_region_async(
         self,
         region: sublime.Region
-    ) -> Tuple[Sequence[Tuple['SessionBufferProtocol', Sequence[Diagnostic]]], sublime.Region]:
+    ) -> Tuple[List[Tuple['SessionBufferProtocol', List[Diagnostic]]], sublime.Region]:
         raise NotImplementedError()
 
     @abstractmethod
@@ -609,13 +609,13 @@ class AbstractViewListener(metaclass=ABCMeta):
         self,
         pt: int,
         max_diagnostic_severity_level: int = DiagnosticSeverity.Hint
-    ) -> Tuple[Sequence[Tuple['SessionBufferProtocol', Sequence[Diagnostic]]], sublime.Region]:
+    ) -> Tuple[List[Tuple['SessionBufferProtocol', List[Diagnostic]]], sublime.Region]:
         raise NotImplementedError()
 
     def diagnostics_intersecting_async(
         self,
         region_or_point: Union[sublime.Region, int]
-    ) -> Tuple[Sequence[Tuple['SessionBufferProtocol', Sequence[Diagnostic]]], sublime.Region]:
+    ) -> Tuple[List[Tuple['SessionBufferProtocol', List[Diagnostic]]], sublime.Region]:
         if isinstance(region_or_point, int):
             return self.diagnostics_touching_point_async(region_or_point)
         elif region_or_point.empty():

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -1,5 +1,8 @@
 from .css import css as lsp_css
 from .protocol import CodeAction
+from .protocol import CodeActionContext
+from .protocol import CodeActionParams
+from .protocol import CodeActionTriggerKind
 from .protocol import Command
 from .protocol import CompletionItem
 from .protocol import CompletionItemKind
@@ -25,7 +28,7 @@ from .protocol import TextDocumentIdentifier
 from .protocol import TextDocumentPositionParams
 from .settings import userprefs
 from .types import ClientConfig
-from .typing import Callable, Optional, Dict, Any, Iterable, List, Union, Tuple, Sequence, cast
+from .typing import Callable, Optional, Dict, Any, Iterable, List, Union, Tuple, cast
 from .url import parse_uri
 from .workspace import is_subpath_of
 import html
@@ -544,14 +547,16 @@ def selection_range_params(view: sublime.View) -> Dict[str, Any]:
 def text_document_code_action_params(
     view: sublime.View,
     region: sublime.Region,
-    diagnostics: Sequence[Diagnostic],
-    on_save_actions: Optional[Sequence[str]] = None
-) -> Dict[str, Any]:
+    diagnostics: List[Diagnostic],
+    on_save_actions: Optional[List[str]] = None,
+    manual: Optional[bool] = False
+) -> CodeActionParams:
     context = {
-        "diagnostics": diagnostics
-    }  # type: Dict[str, Any]
+        "diagnostics": diagnostics,
+        "triggerKind": CodeActionTriggerKind.Invoked if manual else CodeActionTriggerKind.Automatic,
+    }  # type: CodeActionContext
     if on_save_actions:
-        context['only'] = on_save_actions
+        context["only"] = on_save_actions
     return {
         "textDocument": text_document_identifier(view),
         "range": region_to_range(view, region).to_lsp(),

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -549,7 +549,7 @@ def text_document_code_action_params(
     region: sublime.Region,
     diagnostics: List[Diagnostic],
     on_save_actions: Optional[List[str]] = None,
-    manual: Optional[bool] = False
+    manual: bool = False
 ) -> CodeActionParams:
     context = {
         "diagnostics": diagnostics,

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -145,7 +145,7 @@ class LspHoverCommand(LspTextCommand):
             if not only_diagnostics and userprefs().show_code_actions_in_hover:
                 actions_manager.request_for_region_async(
                     self.view, covering, self._diagnostics_by_config,
-                    functools.partial(self.handle_code_actions, listener, hover_point))
+                    functools.partial(self.handle_code_actions, listener, hover_point), manual=False)
 
         sublime.set_timeout_async(run_async)
 


### PR DESCRIPTION
Set triggerKind for code action requests to indicate whether action was automatic or manual. Typescript server returns different refactorings depending on how the request is made.

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionContext
https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionTriggerKind

Adding support for triggerKind in typescript in https://github.com/typescript-language-server/typescript-language-server/pull/579 in case someone wants to test.

Resolves #2041
Resolves #1890