### PR TITLE
Log panel should never be empty

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -172,9 +172,6 @@
   // The maximum number of characters (approximately) before a scrollbar appears.
   "popup_max_characters_height": 1000,
 
-  // Show verbose debug messages in the sublime console.
-  "log_debug": false,
-
   // Log communication from and to language servers.
   // Set to an array of values:
   // - "panel" - log to the LSP Language Servers output panel

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -185,7 +185,7 @@
   // This output panel can be toggled from the command palette with the
   // command "LSP: Toggle Log Panel".
   "log_server": [
-    // "panel",
+    "panel"
     // "remote",
   ],
 

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -1,6 +1,6 @@
 ## Self-help instructions
 
-The LSP client/server communications log can be seen by running `LSP: Toggle Log Panel` from the Command Palette. It might be a good idea to restart Sublime Text and reproduce the issue again, so that the logs are clean.
+The LSP client/server communication log can be seen by running `LSP: Toggle Log Panel` from the Command Palette. It might be a good idea to restart Sublime Text and reproduce the issue again, so that the logs are clean.
 
 If you believe the issue is with this package, please include the output from the Sublime console in your issue report!
 

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -1,13 +1,6 @@
 ## Self-help instructions
 
-To get more visibility into the inner-workings of the LSP client and the server and be able to diagnose problems, open `Preferences: LSP Settings` from the Command Palette and set the following options:
-
-| Option                  | Description                                                          |
-| ----------------------- | -------------------------------------------------------------------- |
-| `log_debug: true`       | Show verbose debug messages in the Sublime Text console.             |
-| `log_server: ["panel"]` | Log communication from and to language servers in the output panel.  |
-
-Once enabled (no restart necessary), the communication log can be seen by running `LSP: Toggle Log Panel` from the Command Palette. It might be a good idea to restart Sublime Text and reproduce the issue again, so that the logs are clean.
+The LSP client/server communications log can be seen by running `LSP: Toggle Log Panel` from the Command Palette. It might be a good idea to restart Sublime Text and reproduce the issue again, so that the logs are clean.
 
 If you believe the issue is with this package, please include the output from the Sublime console in your issue report!
 

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -195,7 +195,6 @@ class Settings:
     inhibit_snippet_completions = None  # type: bool
     inhibit_word_completions = None  # type: bool
     link_highlight_style = None  # type: str
-    log_debug = None  # type: bool
     log_max_size = None  # type: int
     log_server = None  # type: List[str]
     lsp_code_actions_on_save = None  # type: Dict[str, bool]
@@ -234,7 +233,6 @@ class Settings:
         r("document_highlight_style", "underline")
         r("hover_highlight_style", "")
         r("link_highlight_style", "underline")
-        r("log_debug", False)
         r("log_max_size", 8 * 1024)
         r("lsp_code_actions_on_save", {})
         r("lsp_format_on_save", False)
@@ -294,8 +292,6 @@ class Settings:
         code_action_on_save_timeout_ms = s.get("code_action_on_save_timeout_ms")
         if isinstance(code_action_on_save_timeout_ms, int):
             self.on_save_task_timeout_ms = code_action_on_save_timeout_ms
-
-        set_debug_logging(self.log_debug)
 
     def highlight_style_region_flags(self, style_str: str) -> Tuple[int, int]:
         if style_str in ("background", "fill"):  # Backwards-compatible with "fill"

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -1,6 +1,6 @@
 from .collections import DottedDict
 from .file_watcher import FileWatcherEventType
-from .logging import debug, set_debug_logging
+from .logging import debug
 from .protocol import TextDocumentSyncKindNone
 from .typing import Any, Optional, List, Dict, Generator, Callable, Iterable, Union, Set, Tuple, TypedDict, TypeVar
 from .typing import cast

--- a/plugin/panels.py
+++ b/plugin/panels.py
@@ -1,3 +1,4 @@
+from .core.logging import set_debug_logging
 from .core.diagnostics import ensure_diagnostics_panel
 from .core.panels import ensure_server_panel
 from .core.panels import PanelName
@@ -15,6 +16,7 @@ class LspToggleServerPanelCommand(WindowCommand):
     def run(self) -> None:
         ensure_server_panel(self.window)
         toggle_output_panel(self.window, PanelName.LanguageServers)
+        set_debug_logging(True)
 
 
 class LspShowDiagnosticsPanelCommand(WindowCommand):

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -477,6 +477,7 @@
             },
             "log_debug": {
               "type": "boolean",
+              "deprecationMessage": "@deprecated Instead from the command palette run `LSP: Toggle Log Panel` and the logs will be visible.",
               "default": false,
               "markdownDescription": "Show verbose debug messages in the sublime console."
             },


### PR DESCRIPTION
- [make "log_server" default to ["panel"]](https://github.com/sublimelsp/LSP/commit/611da895475299fab71450ad1aabb738f6e82b3a)

- [always enable logs when toggling the log panel](https://github.com/sublimelsp/LSP/commit/043b1ebb99b22c0c68d9419f1420e3a0f11dcbbf)

- [remove the log_debug](https://github.com/sublimelsp/LSP/commit/566a4a6df41060f1d4cc4938dc6e3ee80502f052)

closes #1508 