### PR TITLE
Add context menu entry in log panel for toggling lines limit

### DIFF
--- a/Context LSP Log Panel.sublime-menu
+++ b/Context LSP Log Panel.sublime-menu
@@ -1,6 +1,6 @@
 [
     {
-        "caption": "Clear Log Panel",
+        "caption": "Clear",
         "command": "lsp_clear_log_panel",
     },
     {

--- a/Context LSP Log Panel.sublime-menu
+++ b/Context LSP Log Panel.sublime-menu
@@ -1,7 +1,11 @@
 [
     {
+        "caption": "Clear Log Panel",
         "command": "lsp_clear_log_panel",
-        "caption": "Clear Log Panel"
+    },
+    {
+        "caption": "Limit to 500 Lines",
+        "command": "lsp_toggle_log_panel_lines_limit",
     },
     {
         "caption": "-"

--- a/Context LSP Log Panel.sublime-menu
+++ b/Context LSP Log Panel.sublime-menu
@@ -6,6 +6,7 @@
     {
         "caption": "Limit to 500 Lines",
         "command": "lsp_toggle_log_panel_lines_limit",
+        "checkbox": true
     },
     {
         "caption": "-"

--- a/boot.py
+++ b/boot.py
@@ -18,6 +18,7 @@ from .plugin.core.open import opening_files
 from .plugin.core.panels import destroy_output_panels
 from .plugin.core.panels import LspClearLogPanelCommand
 from .plugin.core.panels import LspClearPanelCommand
+from .plugin.core.panels import LspToggleLogPanelLinesLimitCommand
 from .plugin.core.panels import LspUpdatePanelCommand
 from .plugin.core.panels import LspUpdateLogPanelCommand
 from .plugin.core.panels import WindowPanelListener

--- a/plugin/core/panels.py
+++ b/plugin/core/panels.py
@@ -4,9 +4,6 @@ import sublime
 import sublime_plugin
 
 
-# about 80 chars per line implies maintaining a buffer of about 40kb per window
-LOG_PANEL_MAX_LINES = 500
-
 OUTPUT_PANEL_SETTINGS = {
     "auto_indent": False,
     "draw_indent_guides": False,
@@ -132,11 +129,17 @@ def ensure_panel(window: sublime.Window, name: str, result_file_regex: str, resu
 
 class LspToggleLogPanelLinesLimitCommand(sublime_plugin.TextCommand):
     SETTING_NAME = 'lsp_limit_lines'
+    MAX_LINES_LIMIT_ON = 500
+    MAX_LINES_LIMIT_OFF = 10000
 
     @classmethod
     def is_limit_enabled(cls, window: Optional[sublime.Window]) -> bool:
         panel = get_panel(window, PanelName.Log)
         return bool(panel and panel.settings().get(cls.SETTING_NAME, True))
+
+    @classmethod
+    def get_lines_limit(cls, window: Optional[sublime.Window]) -> int:
+        return cls.MAX_LINES_LIMIT_ON if cls.is_limit_enabled(window) else cls.MAX_LINES_LIMIT_OFF
 
     def run(self, edit: sublime.Edit) -> None:
         window = self.view.window()
@@ -187,9 +190,10 @@ def log_server_message(window: sublime.Window, prefix: str, message: str) -> Non
         return
     WindowPanelListener.server_log_map[window_id].append((prefix, message))
     list_len = len(WindowPanelListener.server_log_map[window_id])
-    if LspToggleLogPanelLinesLimitCommand.is_limit_enabled(window) and list_len >= LOG_PANEL_MAX_LINES:
+    max_lines = LspToggleLogPanelLinesLimitCommand.get_lines_limit(window)
+    if list_len >= max_lines:
         # Trim leading items in the list, leaving only the max allowed count.
-        del WindowPanelListener.server_log_map[window_id][:list_len - LOG_PANEL_MAX_LINES]
+        del WindowPanelListener.server_log_map[window_id][:list_len - max_lines]
     panel = ensure_log_panel(window)
     if is_panel_open(window, PanelName.Log) and panel:
         update_log_panel(panel, window_id)
@@ -211,16 +215,16 @@ class LspUpdateLogPanelCommand(sublime_plugin.TextCommand):
                 new_lines.append("{}: {}\n".format(prefix, message))
             if new_lines:
                 self.view.insert(edit, self.view.size(), ''.join(new_lines))
-                if LspToggleLogPanelLinesLimitCommand.is_limit_enabled(self.view.window()):
-                    last_region_end = 0  # Starting from point 0 in the panel ...
-                    total_lines, _ = self.view.rowcol(self.view.size())
-                    for _ in range(0, max(0, total_lines - LOG_PANEL_MAX_LINES)):
-                        # ... collect all regions that span an entire line ...
-                        region = self.view.full_line(last_region_end)
-                        last_region_end = region.b
-                    erase_region = sublime.Region(0, last_region_end)
-                    if not erase_region.empty():
-                        self.view.erase(edit, erase_region)
+                last_region_end = 0  # Starting from point 0 in the panel ...
+                total_lines, _ = self.view.rowcol(self.view.size())
+                max_lines = LspToggleLogPanelLinesLimitCommand.get_lines_limit(self.view.window())
+                for _ in range(0, max(0, total_lines - max_lines)):
+                    # ... collect all regions that span an entire line ...
+                    region = self.view.full_line(last_region_end)
+                    last_region_end = region.b
+                erase_region = sublime.Region(0, last_region_end)
+                if not erase_region.empty():
+                    self.view.erase(edit, erase_region)
         clear_undo_stack(self.view)
 
 

--- a/tests/test_server_panel_circular.py
+++ b/tests/test_server_panel_circular.py
@@ -1,6 +1,6 @@
 from LSP.plugin.core.panels import ensure_log_panel
-from LSP.plugin.core.panels import LOG_PANEL_MAX_LINES
 from LSP.plugin.core.panels import log_server_message
+from LSP.plugin.core.panels import LspToggleLogPanelLinesLimitCommand
 from unittesting import DeferrableTestCase
 import sublime
 
@@ -29,7 +29,7 @@ class LspServerPanelTests(DeferrableTestCase):
         log_server_message(self.window, "test", msg)
 
     def test_server_panel_circular_behavior(self):
-        n = LOG_PANEL_MAX_LINES
+        n = LspToggleLogPanelLinesLimitCommand.MAX_LINES_LIMIT_ON
         for i in range(0, n + 1):
             self.update_panel(str(i))
         self.update_panel("overflow")


### PR DESCRIPTION
Toggles the limit per window rather than globally. I've assumed it's better that way as it will "limit the damage" if someone leaves it disabled for a long period of time.

Resolves #1810