### PR TITLE
Parse position or selection from link fragment

### DIFF
--- a/plugin/core/open.py
+++ b/plugin/core/open.py
@@ -132,7 +132,7 @@ def center_selection(v: sublime.View, r: RangeLsp) -> sublime.View:
 
 def open_in_browser(uri: str) -> None:
     # NOTE: Remove this check when on py3.8.
-    if not (uri.lower().startswith("http://") or uri.lower().startswith("https://")):
+    if not uri.lower().startswith(("http://", "https://")):
         uri = "https://" + uri
     if not webbrowser.open(uri):
         sublime.status_message("failed to open: " + uri)

--- a/plugin/core/open.py
+++ b/plugin/core/open.py
@@ -133,7 +133,7 @@ def center_selection(v: sublime.View, r: RangeLsp) -> sublime.View:
 def open_in_browser(uri: str) -> None:
     # NOTE: Remove this check when on py3.8.
     if not (uri.lower().startswith("http://") or uri.lower().startswith("https://")):
-        uri = "http://" + uri
+        uri = "https://" + uri
     if not webbrowser.open(uri):
         sublime.status_message("failed to open: " + uri)
 

--- a/plugin/core/open.py
+++ b/plugin/core/open.py
@@ -31,16 +31,16 @@ def open_file_uri(
             # Line and column numbers in the fragment are assumed to be 1-based and need to be converted to 0-based
             # numbers for the LSP Position structure.
             start_line, start_column, end_line, end_column = [max(0, int(g) - 1) if g else None for g in match.groups()]
-            if start_line is not None:
+            if start_line:
                 selection['start']['line'] = start_line
                 selection['end']['line'] = start_line
-            if start_column is not None:
+            if start_column:
                 selection['start']['character'] = start_column
                 selection['end']['character'] = start_column
-            if end_line is not None:
+            if end_line:
                 selection['end']['line'] = end_line
                 selection['end']['character'] = UINT_MAX
-            if end_column is not None:
+            if end_column:
                 selection['end']['character'] = end_column
         return selection
 

--- a/plugin/core/open.py
+++ b/plugin/core/open.py
@@ -55,18 +55,16 @@ def open_file_uri(
 
     decoded_uri = unquote(uri)  # decode percent-encoded characters
     parsed = urlparse(decoded_uri)
+    open_promise = open_file(window, decoded_uri, flags, group)
     if parsed.fragment:
-        r = parse_fragment(parsed.fragment)
+        return open_promise.then(lambda view: _select_and_center(view, parse_fragment(parsed.fragment)))
+    return open_promise
 
-        def handle_continuation(view: Optional[sublime.View]) -> Promise[Optional[sublime.View]]:
-            if view:
-                center_selection(view, r)
-                return Promise.resolve(view)
-            return Promise.resolve(None)
 
-        return open_file(window, decoded_uri, flags, group).then(handle_continuation)
-    else:
-        return open_file(window, decoded_uri, flags, group)
+def _select_and_center(view: Optional[sublime.View], r: RangeLsp) -> Optional[sublime.View]:
+    if view:
+        return center_selection(view, r)
+    return None
 
 
 def _return_existing_view(flags: int, existing_view_group: int, active_group: int, specified_group: int) -> bool:

--- a/plugin/core/open.py
+++ b/plugin/core/open.py
@@ -40,7 +40,7 @@ def open_file_uri(
             if end_line:
                 selection['end']['line'] = end_line
                 selection['end']['character'] = UINT_MAX
-            if end_column:
+            if end_column is not None:
                 selection['end']['character'] = end_column
         return selection
 

--- a/plugin/core/open.py
+++ b/plugin/core/open.py
@@ -24,19 +24,11 @@ def open_file_uri(
     window: sublime.Window, uri: DocumentUri, flags: int = 0, group: int = -1
 ) -> Promise[Optional[sublime.View]]:
 
-    def parse_int(s: Optional[str]) -> Optional[int]:
-        if s:
-            try:
-                # assume that line and column numbers in the fragment are 1-based
-                return max(1, int(s))
-            except ValueError:
-                return None
-        return None
-
     def parse_fragment(fragment: str) -> RangeLsp:
         match = FRAGMENT_PATTERN.match(fragment)
         if match:
-            start_line, start_column, end_line, end_column = [parse_int(g) for g in match.groups()]
+            # assume that line and column numbers in the fragment are 1-based
+            start_line, start_column, end_line, end_column = [max(1, int(g)) if g else None for g in match.groups()]
             if start_line is not None:
                 if end_line is not None:
                     if start_column is not None and end_column is not None:

--- a/plugin/core/url.py
+++ b/plugin/core/url.py
@@ -51,7 +51,7 @@ def parse_uri(uri: str) -> Tuple[str, str]:
         path = url2pathname(parsed.path)
         if os.name == 'nt':
             netloc = url2pathname(parsed.netloc)
-            path = path.lstrip("\\")
+            path = re.sub(r"^[/\\]([a-zA-Z]:)", r"\1", path)  # remove slash or backslash preceding drive letter
             path = re.sub(r"^([a-z]):", _uppercase_driveletter, path)
             if netloc:
                 # Convert to UNC path

--- a/plugin/core/url.py
+++ b/plugin/core/url.py
@@ -51,7 +51,8 @@ def parse_uri(uri: str) -> Tuple[str, str]:
         path = url2pathname(parsed.path)
         if os.name == 'nt':
             netloc = url2pathname(parsed.netloc)
-            path = re.sub(r"^[/\\]([a-zA-Z]:)", r"\1", path)  # remove slash or backslash preceding drive letter
+            path = path.lstrip("\\")
+            path = re.sub(r"^/([a-zA-Z]:)", r"\1", path)  # remove slash preceding drive letter
             path = re.sub(r"^([a-z]):", _uppercase_driveletter, path)
             if netloc:
                 # Convert to UNC path

--- a/plugin/document_link.py
+++ b/plugin/document_link.py
@@ -1,12 +1,11 @@
 from .core.logging import debug
+from .core.open import open_file_uri
+from .core.open import open_in_browser
 from .core.protocol import DocumentLink, Request
 from .core.registry import get_position
 from .core.registry import LspTextCommand
 from .core.typing import Optional
-from urllib.parse import unquote, urlparse
-import re
 import sublime
-import webbrowser
 
 
 class LspOpenLinkCommand(LspTextCommand):
@@ -57,15 +56,6 @@ class LspOpenLinkCommand(LspTextCommand):
         if target.startswith("file:"):
             window = self.view.window()
             if window:
-                decoded = unquote(target)  # decode percent-encoded characters
-                parsed = urlparse(decoded)
-                filepath = parsed.path
-                if sublime.platform() == "windows":
-                    filepath = re.sub(r"^/([a-zA-Z]:)", r"\1", filepath)  # remove slash preceding drive letter
-                fn = "{}:{}".format(filepath, parsed.fragment) if parsed.fragment else filepath
-                window.open_file(fn, flags=sublime.ENCODED_POSITION)
+                open_file_uri(window, target)
         else:
-            if not (target.lower().startswith("http://") or target.lower().startswith("https://")):
-                target = "http://" + target
-            if not webbrowser.open(target):
-                sublime.status_message("failed to open: " + target)
+            open_in_browser(target)

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -1,6 +1,7 @@
 from .code_actions import actions_manager
 from .code_actions import CodeActionOrCommand
-from .core.logging import debug
+from .core.open import open_file_uri
+from .core.open import open_in_browser
 from .core.promise import Promise
 from .core.protocol import Diagnostic
 from .core.protocol import DocumentLink
@@ -37,12 +38,9 @@ from .core.views import text_document_range_params
 from .core.views import unpack_href_location
 from .core.views import update_lsp_popup
 from .session_view import HOVER_HIGHLIGHT_KEY
-from urllib.parse import unquote, urlparse
 import functools
 import html
-import re
 import sublime
-import webbrowser
 
 
 SUBLIME_WORD_MASK = 515
@@ -330,13 +328,7 @@ class LspHoverCommand(LspTextCommand):
         elif href.startswith("file:"):
             window = self.view.window()
             if window:
-                decoded = unquote(href)  # decode percent-encoded characters
-                parsed = urlparse(decoded)
-                filepath = parsed.path
-                if sublime.platform() == "windows":
-                    filepath = re.sub(r"^/([a-zA-Z]:)", r"\1", filepath)  # remove slash preceding drive letter
-                fn = "{}:{}".format(filepath, parsed.fragment) if parsed.fragment else filepath
-                window.open_file(fn, flags=sublime.ENCODED_POSITION)
+                open_file_uri(window, href)
         elif href.startswith('code-actions:'):
             _, config_name = href.split(":")
             actions = self._actions_by_config[config_name]
@@ -360,11 +352,7 @@ class LspHoverCommand(LspTextCommand):
                 r = {"start": position, "end": position}  # type: RangeLsp
                 sublime.set_timeout_async(functools.partial(session.open_uri_async, uri, r))
         else:
-            # NOTE: Remove this check when on py3.8.
-            if not (href.lower().startswith("http://") or href.lower().startswith("https://")):
-                href = "http://" + href
-            if not webbrowser.open(href):
-                debug("failed to open:", href)
+            open_in_browser(href)
 
     def handle_code_action_select(self, config_name: str, index: int) -> None:
         if index > -1:


### PR DESCRIPTION
Should handle the following formats which are supported by VSCode:
https://github.com/microsoft/vscode/blob/835ace5796cec0ed19a7eec119b26b57220b0f1a/src/vs/platform/opener/common/opener.ts#L153-L160

It applies to Markdown links in the hover content and also to `DocumentLink.target` from the "Document Link" response.

Can be tested for example with LSP-html and the following file:
```html
<!DOCTYPE html>
<html>
<body>
    <h1 id="anchor">Heading</h1>

    <a href="#anchor">link</a>
</body>
</html>
```

Closes #2009.