### PR TITLE
Change log_server default value to  ["panel"]

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -193,7 +193,7 @@
   // This output panel can be toggled from the command palette with the
   // command "LSP: Toggle Log Panel".
   "log_server": [
-    // "panel",
+    "panel",
     // "remote",
   ],
 

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -5,7 +5,6 @@ To get more visibility into the inner-workings of the LSP client and the server 
 | Option                  | Description                                                          |
 | ----------------------- | -------------------------------------------------------------------- |
 | `log_debug: true`       | Show verbose debug messages in the Sublime Text console.             |
-| `log_server: ["panel"]` | Log communication from and to language servers in the output panel.  |
 
 Once enabled (no restart necessary), the communication log can be seen by running `LSP: Toggle Log Panel` from the Command Palette. It might be a good idea to restart Sublime Text and reproduce the issue again, so that the logs are clean.
 

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -490,6 +490,7 @@
               "oneOf": [
                 {
                   "type": "array",
+                  "default": ["panel"],
                   "items": {
                     "type": "string",
                     "enum": [


### PR DESCRIPTION
Currently if the user want to enable logging, 
the following settings have to be set:
```
"log_debug": true,
"log_server": ["panel"],
```

----

With this PR the user just have to enable:
```
"log_debug": true,
```
So we skip one additional thing that needs to be enabled.

----

EDIT:

closes https://github.com/sublimelsp/LSP/issues/1508