### PR TITLE
Make `Preferences: LSP Key Bindings` open the default keybinding file

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -12,7 +12,6 @@
         "command": "edit_settings",
         "args": {
             "base_file": "${packages}/LSP/Default.sublime-keymap",
-            "user_file": "${packages}/User/Default ($platform).sublime-keymap",
             "default": "[\n\t$0\n]\n",
         }
     },

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -159,7 +159,6 @@
                 "command": "edit_settings",
                 "args": {
                   "base_file": "${packages}/LSP/Default.sublime-keymap",
-                  "user_file": "${packages}/User/Default (${platform}).sublime-keymap",
                   "default": "[\n\t$0\n]\n",
                 }
               },


### PR DESCRIPTION
Currently, my user keybindings are stored in  `Default.sublime-keymap`.

Note, the `platform` is not in the file name (`Default (Linux).sublime-keymap`, `Default (Windows).sublime-keymap`, `Default (OSX).sublime-keymap`) 

Currently,
Each time I run  `Preferences: LSP Key Bindings`, 
ST will open an empty `Default (Linux).sublime-keymap`, because the incorrect "user_file" was specified (I store my keybindings in `Default.sublime-keymap`).

![image](https://user-images.githubusercontent.com/22029477/189886195-8b7040e1-23bf-4e0e-a55b-db7474d33998.png)

With this PR,
ST will open the correct user defined keymap file.

![image](https://user-images.githubusercontent.com/22029477/189886373-bea3fef7-4692-40ae-9705-46c923fe58fd.png)

