### PR TITLE
Only update content of diagnostics panel when visible

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -301,6 +301,30 @@
     //         "shift+f8"
     //     ],
     // },
+    // Jump to next Diagnostic in Tab
+    // {
+    //     "command": "lsp_next_diagnostic",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //      "context": [
+    //          {
+    //              "key": "setting.lsp_active"
+    //          }
+    //      ]
+    // },
+    // Jump to previous Diagnostic in Tab
+    // {
+    //     "command": "lsp_prev_diagnostic",
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //      "context": [
+    //          {
+    //              "key": "setting.lsp_active"
+    //          }
+    //      ]
+    // },
     // Rename
     // {
     //     "command": "lsp_symbol_rename",

--- a/boot.py
+++ b/boot.py
@@ -27,6 +27,8 @@ from .plugin.core.panels import WindowPanelListener
 from .plugin.core.protocol import Error
 from .plugin.core.protocol import Location
 from .plugin.core.protocol import LocationLink
+from .plugin.core.registry import LspNextDiagnosticCommand
+from .plugin.core.registry import LspPrevDiagnosticCommand
 from .plugin.core.registry import LspRecheckSessionsCommand
 from .plugin.core.registry import LspRestartServerCommand
 from .plugin.core.registry import windows
@@ -177,11 +179,7 @@ class Listener(sublime_plugin.EventListener):
                     break
 
     def on_post_window_command(self, window: sublime.Window, command_name: str, args: Optional[Dict[str, Any]]) -> None:
-        if command_name in ("next_result", "prev_result"):
-            view = window.active_view()
-            if view:
-                view.run_command("lsp_hover", {"only_diagnostics": True})
-        elif command_name == "show_panel" and args and args.get("panel") == "output.{}".format(PanelName.Diagnostics):
+        if command_name == "show_panel" and args and args.get("panel") == "output.{}".format(PanelName.Diagnostics):
             sublime.set_timeout_async(windows.lookup(window).update_diagnostics_panel_async)
 
 

--- a/boot.py
+++ b/boot.py
@@ -17,11 +17,13 @@ from .plugin.core.css import load as load_css
 from .plugin.core.logging import exception_log
 from .plugin.core.open import opening_files
 from .plugin.core.panels import destroy_output_panels
+from .plugin.core.panels import is_panel_open
 from .plugin.core.panels import LspClearLogPanelCommand
 from .plugin.core.panels import LspClearPanelCommand
 from .plugin.core.panels import LspToggleLogPanelLinesLimitCommand
 from .plugin.core.panels import LspUpdatePanelCommand
 from .plugin.core.panels import LspUpdateLogPanelCommand
+from .plugin.core.panels import PanelName
 from .plugin.core.panels import WindowPanelListener
 from .plugin.core.protocol import Error
 from .plugin.core.protocol import Location
@@ -180,6 +182,8 @@ class Listener(sublime_plugin.EventListener):
             view = window.active_view()
             if view:
                 view.run_command("lsp_hover", {"only_diagnostics": True})
+        elif command_name == "show_panel" and args and args.get("panel") == "output.{}".format(PanelName.Diagnostics):
+            sublime.set_timeout_async(windows.lookup(window).update_diagnostics_panel_async)
 
 
 class LspOpenLocationCommand(sublime_plugin.TextCommand):

--- a/boot.py
+++ b/boot.py
@@ -17,7 +17,6 @@ from .plugin.core.css import load as load_css
 from .plugin.core.logging import exception_log
 from .plugin.core.open import opening_files
 from .plugin.core.panels import destroy_output_panels
-from .plugin.core.panels import is_panel_open
 from .plugin.core.panels import LspClearLogPanelCommand
 from .plugin.core.panels import LspClearPanelCommand
 from .plugin.core.panels import LspToggleLogPanelLinesLimitCommand

--- a/docs/src/keyboard_shortcuts.md
+++ b/docs/src/keyboard_shortcuts.md
@@ -23,8 +23,8 @@ Refer to the [Customization section](customization.md#keyboard-shortcuts-key-bin
 | Goto Type Definition | unbound | `lsp_symbol_type_definition`
 | Hover Popup | unbound | `lsp_hover`
 | Insert/Replace Completions | <kbd>alt</kbd> <kbd>enter</kbd> | `lsp_commit_completion_with_opposite_insert_mode`
-| Next Diagnostic | <kbd>F4</kbd> | -
-| Previous Diagnostic | <kbd>shift</kbd> <kbd>F4</kbd> | -
+| Next Diagnostic | unbound | `lsp_next_diagnostic`
+| Previous Diagnostic | unbound | `lsp_prev_diagnostic`
 | Rename | unbound | `lsp_symbol_rename`
 | Restart Server | unbound | `lsp_restart_server`
 | Run Code Action | unbound | `lsp_code_actions`

--- a/docs/src/keyboard_shortcuts.md
+++ b/docs/src/keyboard_shortcuts.md
@@ -5,9 +5,6 @@ Refer to the [Customization section](customization.md#keyboard-shortcuts-key-bin
 !!! Mac
     If you using macOS, replace <kbd>ctrl</kbd> with <kbd>command</kbd>.
 
-!!! Note
-    If <kbd>F4</kbd> / <kbd>shift</kbd> <kbd>F4</kbd> stop working, double-click a diagnostic in the Diagnostics Panel. It should work again afterwards.
-
 | Feature | Shortcut | Command |
 | ------- | -------- | ------- |
 | Auto Complete | <kbd>ctrl</kbd> <kbd>space</kbd> (also on macOS) | `auto_complete`

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -1,9 +1,15 @@
 from .configurations import ConfigManager
+from .protocol import Diagnostic
+from .protocol import Point
 from .sessions import AbstractViewListener
 from .sessions import Session
 from .settings import client_configs
-from .typing import Optional, Any, Generator, Iterable
+from .typing import Optional, Any, Generator, Iterable, List
+from .views import MissingUriError
+from .views import point_to_offset
+from .views import uri_from_view
 from .windows import WindowRegistry
+import operator
 import sublime
 import sublime_plugin
 
@@ -161,3 +167,50 @@ class LspRestartServerCommand(LspTextCommand):
 class LspRecheckSessionsCommand(sublime_plugin.WindowCommand):
     def run(self, config_name: Optional[str] = None) -> None:
         sublime.set_timeout_async(lambda: windows.lookup(self.window).restart_sessions_async(config_name))
+
+
+def navigate_diagnostics(view: sublime.View, point: Optional[int] = None, forward: bool = True) -> None:
+    try:
+        uri = uri_from_view(view)
+    except MissingUriError:
+        return
+    window = view.window()
+    if not window:
+        return
+
+    diagnostics = []  # type: List[Diagnostic]
+    for session in windows.lookup(window).get_sessions():
+        diagnostics.extend(session.diagnostics_manager.diagnostics_by_document_uri(uri))
+    if not diagnostics:
+        return
+    # Sort diagnostics by location
+    diagnostics.sort(key=lambda d: operator.itemgetter('line', 'character')(d['range']['start']), reverse=not forward)
+    if not point:
+        try:
+            point = view.sel()[0].b
+        except IndexError:
+            point = 0
+    # Find next diagnostic or wrap around and jump to the first/last one, if there are no more diagnostics in this view
+    # after/before the cursor
+    for diagnostic in diagnostics:
+        diag_pos = point_to_offset(Point.from_lsp(diagnostic['range']['start']), view)
+        op_func = operator.gt if forward else operator.lt
+        if op_func(diag_pos, point):
+            break
+    else:
+        diag_pos = point_to_offset(Point.from_lsp(diagnostics[0]['range']['start']), view)
+    view.show_at_center(diag_pos)
+    view.run_command('lsp_selection_set', {'regions': [(diag_pos, diag_pos)]})
+    view.run_command('lsp_hover', {'only_diagnostics': True, 'point': diag_pos})
+
+
+class LspNextDiagnosticCommand(LspTextCommand):
+
+    def run(self, edit: sublime.Edit, point: Optional[int] = None) -> None:
+        navigate_diagnostics(self.view, point, forward=True)
+
+
+class LspPrevDiagnosticCommand(LspTextCommand):
+
+    def run(self, edit: sublime.Edit, point: Optional[int] = None) -> None:
+        navigate_diagnostics(self.view, point, forward=False)

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -5,6 +5,7 @@ from .sessions import AbstractViewListener
 from .sessions import Session
 from .settings import client_configs
 from .typing import Optional, Any, Generator, Iterable, List
+from .views import first_selection_region
 from .views import MissingUriError
 from .views import point_to_offset
 from .views import uri_from_view
@@ -186,10 +187,8 @@ def navigate_diagnostics(view: sublime.View, point: Optional[int], forward: bool
     # Sort diagnostics by location
     diagnostics.sort(key=lambda d: operator.itemgetter('line', 'character')(d['range']['start']), reverse=not forward)
     if point is None:
-        try:
-            point = view.sel()[0].b
-        except IndexError:
-            point = 0
+        region = first_selection_region(view)
+        point = region.b if region is not None else 0
     # Find next/previous diagnostic or wrap around and jump to the first/last one, if there are no more diagnostics in
     # this view after/before the cursor
     op_func = operator.gt if forward else operator.lt

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -10,7 +10,6 @@ from .views import MissingUriError
 from .views import point_to_offset
 from .views import uri_from_view
 from .windows import WindowRegistry
-from functools import partial
 import operator
 import sublime
 import sublime_plugin
@@ -198,17 +197,11 @@ def navigate_diagnostics(view: sublime.View, point: Optional[int], forward: bool
             break
     else:
         diag_pos = point_to_offset(Point.from_lsp(diagnostics[0]['range']['start']), view)
-    # If the new position is not contained in the current viewport, we need a small delay before showing the popup to
-    # wait for the scrolling animation to finish. Otherwise ST would immediately hide the popup for being out of bounds.
-    # Also it doesn't seem to work without the delay when scrolling upwards (regardless of the distance).
-    need_dalay = not forward or not view.visible_region().contains(diag_pos)
-    show_popup = partial(view.run_command, 'lsp_hover', {'only_diagnostics': True, 'point': diag_pos})
     view.run_command('lsp_selection_set', {'regions': [(diag_pos, diag_pos)]})
     view.show_at_center(diag_pos)
-    if need_dalay:
-        sublime.set_timeout_async(show_popup, 200)
-    else:
-        show_popup()
+    # We need a small delay before showing the popup to wait for the scrolling animation to finish. Otherwise ST would
+    # immediately hide the popup.
+    sublime.set_timeout_async(lambda: view.run_command('lsp_hover', {'only_diagnostics': True, 'point': diag_pos}), 200)
 
 
 class LspNextDiagnosticCommand(LspTextCommand):

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -14,6 +14,8 @@ from .logging import exception_log
 from .open import center_selection
 from .open import open_externally
 from .open import open_file
+from .panels import is_panel_open
+from .panels import PanelName
 from .progress import WindowProgressReporter
 from .promise import PackagedTask
 from .promise import Promise
@@ -1683,7 +1685,8 @@ class Session(TransportCallbacks):
         if isinstance(reason, str):
             return debug("ignoring unsuitable diagnostics for", uri, "reason:", reason)
         self.diagnostics_manager.add_diagnostics_async(uri, params["diagnostics"])
-        mgr.update_diagnostics_panel_async()
+        if is_panel_open(self.window, PanelName.Diagnostics):
+            mgr.update_diagnostics_panel_async()
         sb = self.get_session_buffer_for_uri_async(uri)
         if sb:
             sb.on_diagnostics_async(params["diagnostics"], params.get("version"))

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -91,11 +91,14 @@ KIND_UNIT = (sublime.KIND_ID_VARIABLE, "u", "Unit")
 KIND_VALUE = (sublime.KIND_ID_VARIABLE, "v", "Value")
 KIND_VARIABLE = (sublime.KIND_ID_VARIABLE, "v", "Variable")
 
+KIND_ERROR = (sublime.KIND_ID_COLOR_REDISH, "e", "Error")
+KIND_WARNING = (sublime.KIND_ID_COLOR_YELLOWISH, "w", "Warning")
+KIND_INFORMATION = (sublime.KIND_ID_COLOR_BLUISH, "i", "Information")
+KIND_HINT = (sublime.KIND_ID_COLOR_BLUISH, "h", "Hint")
+
 KIND_QUICKFIX = (sublime.KIND_ID_COLOR_YELLOWISH, "f", "QuickFix")
 KIND_REFACTOR = (sublime.KIND_ID_COLOR_CYANISH, "r", "Refactor")
 KIND_SOURCE = (sublime.KIND_ID_COLOR_PURPLISH, "s", "Source")
-
-KIND_UNSPECIFIED = (sublime.KIND_ID_AMBIGUOUS, "?", "???")
 
 COMPLETION_KINDS = {
     CompletionItemKind.Text: KIND_TEXT,
@@ -152,6 +155,13 @@ SYMBOL_KINDS = {
     SymbolKind.Event: KIND_EVENT,
     SymbolKind.Operator: KIND_OPERATOR,
     SymbolKind.TypeParameter: KIND_TYPEPARAMETER
+}
+
+DIAGNOSTIC_KINDS = {
+    DiagnosticSeverity.Error: KIND_ERROR,
+    DiagnosticSeverity.Warning: KIND_WARNING,
+    DiagnosticSeverity.Information: KIND_INFORMATION,
+    DiagnosticSeverity.Hint: KIND_HINT
 }
 
 CODE_ACTION_KINDS = {
@@ -975,7 +985,7 @@ def format_completion(
     lsp_filter_text = item.get('filterText') or ""
     lsp_detail = (item.get('detail') or "").replace("\n", " ")
 
-    kind = COMPLETION_KINDS.get(item.get('kind', -1), KIND_UNSPECIFIED)
+    kind = COMPLETION_KINDS.get(item.get('kind', -1), sublime.KIND_AMBIGUOUS)
 
     details = []  # type: List[str]
     if can_resolve_completion_items or item.get('documentation'):

--- a/plugin/goto_diagnostic.py
+++ b/plugin/goto_diagnostic.py
@@ -6,6 +6,7 @@ from .core.settings import userprefs
 from .core.types import ClientConfig
 from .core.typing import Dict, Iterable, Iterator, List, Optional, Tuple, Union
 from .core.url import parse_uri, unparse_uri
+from .core.views import DIAGNOSTIC_KINDS
 from .core.views import MissingUriError, uri_from_view, get_uri_and_position_from_location, to_encoded_filename
 from .core.views import format_diagnostic_for_html
 from .core.views import diagnostic_severity, format_diagnostic_source_and_code, format_severity
@@ -15,12 +16,7 @@ import functools
 import sublime
 import sublime_plugin
 
-DIAGNOSTIC_KIND = {
-    DiagnosticSeverity.Error: (sublime.KIND_ID_COLOR_REDISH, "e", "Error"),
-    DiagnosticSeverity.Warning: (sublime.KIND_ID_COLOR_YELLOWISH, "w", "Warning"),
-    DiagnosticSeverity.Information: (sublime.KIND_ID_COLOR_BLUISH, "i", "Information"),
-    DiagnosticSeverity.Hint: (sublime.KIND_ID_COLOR_BLUISH, "h", "Hint"),
-}
+
 PREVIEW_PANE_CSS = """
     .diagnostics {padding: 0.5em}
     .diagnostics a {color: var(--bluish)}
@@ -108,7 +104,7 @@ class DiagnosticUriInputHandler(sublime_plugin.ListInputHandler):
             text = "{}: {}".format(format_severity(min(counts)), self._simple_project_path(parsed_uri))
             annotation = "E: {}, W: {}".format(counts.get(DiagnosticSeverity.Error, 0),
                                                counts.get(DiagnosticSeverity.Warning, 0))
-            kind = DIAGNOSTIC_KIND[min(counts)]
+            kind = DIAGNOSTIC_KINDS[min(counts)]
             uri = unparse_uri(parsed_uri)
             if uri == self.uri:
                 selected = i  # restore selection after coming back from diagnostics list
@@ -185,7 +181,7 @@ class DiagnosticInputHandler(sublime_plugin.ListInputHandler):
                     first_line += " …"
                 text = "{}: {}".format(format_severity(diagnostic_severity(diagnostic)), first_line)
                 annotation = format_diagnostic_source_and_code(diagnostic)
-                kind = DIAGNOSTIC_KIND[diagnostic_severity(diagnostic)]
+                kind = DIAGNOSTIC_KINDS[diagnostic_severity(diagnostic)]
                 list_items.append(sublime.ListInputItem(text, (i, diagnostic), annotation=annotation, kind=kind))
         return list_items
 

--- a/plugin/panels.py
+++ b/plugin/panels.py
@@ -8,7 +8,7 @@ from sublime_plugin import WindowCommand
 
 def toggle_output_panel(window: Window, panel_type: str) -> None:
     panel_name = "output.{}".format(panel_type)
-    command = "{}_panel".format("hide" if is_panel_open(window, panel_type) else "show")
+    command = "hide_panel" if is_panel_open(window, panel_type) else "show_panel"
     window.run_command(command, {"panel": panel_name})
 
 

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -1,3 +1,5 @@
+from .core.panels import is_panel_open
+from .core.panels import PanelName
 from .core.protocol import Diagnostic
 from .core.protocol import DiagnosticSeverity
 from .core.protocol import DocumentLink
@@ -127,7 +129,7 @@ class SessionBuffer:
 
     def __del__(self) -> None:
         mgr = self.session.manager()
-        if mgr:
+        if mgr and is_panel_open(mgr.window(), PanelName.Diagnostics):
             mgr.update_diagnostics_panel_async()
         self.color_phantoms.update([])
         # If the session is exiting then there's no point in sending textDocument/didClose and there's also no point

--- a/plugin/symbols.py
+++ b/plugin/symbols.py
@@ -3,7 +3,6 @@ from .core.protocol import Request, DocumentSymbol, SymbolInformation, SymbolTag
 from .core.registry import LspTextCommand
 from .core.sessions import print_to_status_bar
 from .core.typing import Any, List, Optional, Tuple, Dict, Generator, Union, cast
-from .core.views import KIND_UNSPECIFIED
 from .core.views import range_to_region
 from .core.views import SYMBOL_KIND_SCOPES
 from .core.views import SYMBOL_KINDS
@@ -18,7 +17,7 @@ SUPPRESS_INPUT_SETTING_KEY = 'lsp_suppress_input'
 
 
 def unpack_lsp_kind(kind: int) -> Tuple[int, str, str]:
-    return SYMBOL_KINDS.get(kind, KIND_UNSPECIFIED)
+    return SYMBOL_KINDS.get(kind, sublime.KIND_AMBIGUOUS)
 
 
 def format_symbol_kind(kind: int) -> str:

--- a/tests/test_server_notifications.py
+++ b/tests/test_server_notifications.py
@@ -1,3 +1,4 @@
+from LSP.plugin.core.panels import PanelName
 from LSP.plugin.core.protocol import DiagnosticSeverity
 from LSP.plugin.core.protocol import DiagnosticTag
 from LSP.plugin.core.protocol import PublishDiagnosticsParams
@@ -5,6 +6,7 @@ from LSP.plugin.core.typing import Generator
 from LSP.plugin.core.url import filename_to_uri
 from setup import TextDocumentTestCase
 import sublime
+import time
 
 
 class ServerNotifications(TextDocumentTestCase):
@@ -51,6 +53,9 @@ class ServerNotifications(TextDocumentTestCase):
         self.assertEqual(info[0], sublime.Region(4, 5))
 
         # Testing whether the popup with the diagnostic moves along with next_result
+
+        self.view.window().run_command("show_panel", {"panel": "output.{}".format(PanelName.Diagnostics)})
+        time.sleep(0.1)  # Give Diagnostics panel a bit of time to update its content (on async thread)
 
         self.view.window().run_command("next_result")
         yield self.view.is_popup_visible

--- a/tests/test_server_notifications.py
+++ b/tests/test_server_notifications.py
@@ -56,6 +56,9 @@ class ServerNotifications(TextDocumentTestCase):
 
         self.view.window().run_command("show_panel", {"panel": "output.{}".format(PanelName.Diagnostics)})
         time.sleep(0.1)  # Give Diagnostics panel a bit of time to update its content (on async thread)
+        # Make sure diagnostics panel has focus, so that "next_result" & "prev_result" commands don't
+        # navigate between build results, find results, or find references
+        self.view.window().focus_view(self.view.window().find_output_panel(PanelName.Diagnostics))
 
         self.view.window().run_command("next_result")
         yield self.view.is_popup_visible

--- a/tests/test_server_notifications.py
+++ b/tests/test_server_notifications.py
@@ -5,6 +5,7 @@ from LSP.plugin.core.typing import Generator
 from LSP.plugin.core.url import filename_to_uri
 from setup import TextDocumentTestCase
 import sublime
+import time
 
 
 class ServerNotifications(TextDocumentTestCase):
@@ -53,16 +54,19 @@ class ServerNotifications(TextDocumentTestCase):
         # Testing whether the popup with the diagnostic moves along with lsp_next_diagnostic
 
         self.view.window().run_command("lsp_next_diagnostic")
+        time.sleep(0.25)
         yield self.view.is_popup_visible
         self.assertEqual(self.view.sel()[0].a, self.view.sel()[0].b)
         self.assertEqual(self.view.sel()[0].b, 0)
 
         self.view.window().run_command("lsp_next_diagnostic")
+        time.sleep(0.25)
         yield self.view.is_popup_visible
         self.assertEqual(self.view.sel()[0].a, self.view.sel()[0].b)
         self.assertEqual(self.view.sel()[0].b, 2)
 
         self.view.window().run_command("lsp_next_diagnostic")
+        time.sleep(0.25)
         yield self.view.is_popup_visible
         self.assertEqual(self.view.sel()[0].a, self.view.sel()[0].b)
         self.assertEqual(self.view.sel()[0].b, 4)
@@ -70,15 +74,21 @@ class ServerNotifications(TextDocumentTestCase):
         # lsp_prev_diagnostic should work as well
 
         self.view.window().run_command("lsp_prev_diagnostic")
+        time.sleep(0.25)
+        yield self.view.is_popup_visible
         self.assertEqual(self.view.sel()[0].a, self.view.sel()[0].b)
         self.assertEqual(self.view.sel()[0].b, 2)
 
         self.view.window().run_command("lsp_prev_diagnostic")
+        time.sleep(0.25)
+        yield self.view.is_popup_visible
         self.assertEqual(self.view.sel()[0].a, self.view.sel()[0].b)
         self.assertEqual(self.view.sel()[0].b, 0)
 
         # Testing to wrap around if there are no more diagnostics in the direction
 
         self.view.window().run_command("lsp_prev_diagnostic")
+        time.sleep(0.25)
+        yield self.view.is_popup_visible
         self.assertEqual(self.view.sel()[0].a, self.view.sel()[0].b)
         self.assertEqual(self.view.sel()[0].b, 4)

--- a/tests/test_server_notifications.py
+++ b/tests/test_server_notifications.py
@@ -1,4 +1,3 @@
-from LSP.plugin.core.panels import PanelName
 from LSP.plugin.core.protocol import DiagnosticSeverity
 from LSP.plugin.core.protocol import DiagnosticTag
 from LSP.plugin.core.protocol import PublishDiagnosticsParams
@@ -6,7 +5,6 @@ from LSP.plugin.core.typing import Generator
 from LSP.plugin.core.url import filename_to_uri
 from setup import TextDocumentTestCase
 import sublime
-import time
 
 
 class ServerNotifications(TextDocumentTestCase):
@@ -52,37 +50,31 @@ class ServerNotifications(TextDocumentTestCase):
         self.assertEqual(len(info), 1)
         self.assertEqual(info[0], sublime.Region(4, 5))
 
-        # Testing whether the popup with the diagnostic moves along with next_result
+        # Testing whether the popup with the diagnostic moves along with lsp_next_diagnostic
 
-        self.view.window().run_command("show_panel", {"panel": "output.{}".format(PanelName.Diagnostics)})
-        time.sleep(0.1)  # Give Diagnostics panel a bit of time to update its content (on async thread)
-        # Make sure diagnostics panel has focus, so that "next_result" & "prev_result" commands don't
-        # navigate between build results, find results, or find references
-        self.view.window().focus_view(self.view.window().find_output_panel(PanelName.Diagnostics))
-
-        self.view.window().run_command("next_result")
+        self.view.window().run_command("lsp_next_diagnostic")
         yield self.view.is_popup_visible
         self.assertEqual(self.view.sel()[0].a, self.view.sel()[0].b)
         self.assertEqual(self.view.sel()[0].b, 0)
 
-        self.view.window().run_command("next_result")
+        self.view.window().run_command("lsp_next_diagnostic")
         yield self.view.is_popup_visible
         self.assertEqual(self.view.sel()[0].a, self.view.sel()[0].b)
         self.assertEqual(self.view.sel()[0].b, 2)
 
-        self.view.window().run_command("next_result")
+        self.view.window().run_command("lsp_next_diagnostic")
         yield self.view.is_popup_visible
         self.assertEqual(self.view.sel()[0].a, self.view.sel()[0].b)
         self.assertEqual(self.view.sel()[0].b, 4)
 
-        # prev_result should work as well
+        # lsp_prev_diagnostic should work as well
 
-        self.view.window().run_command("prev_result")
+        self.view.window().run_command("lsp_prev_diagnostic")
         yield self.view.is_popup_visible
         self.assertEqual(self.view.sel()[0].a, self.view.sel()[0].b)
         self.assertEqual(self.view.sel()[0].b, 2)
 
-        self.view.window().run_command("prev_result")
+        self.view.window().run_command("lsp_prev_diagnostic")
         yield self.view.is_popup_visible
         self.assertEqual(self.view.sel()[0].a, self.view.sel()[0].b)
         self.assertEqual(self.view.sel()[0].b, 0)

--- a/tests/test_server_notifications.py
+++ b/tests/test_server_notifications.py
@@ -5,7 +5,6 @@ from LSP.plugin.core.typing import Generator
 from LSP.plugin.core.url import filename_to_uri
 from setup import TextDocumentTestCase
 import sublime
-import time
 
 
 class ServerNotifications(TextDocumentTestCase):
@@ -51,44 +50,32 @@ class ServerNotifications(TextDocumentTestCase):
         self.assertEqual(len(info), 1)
         self.assertEqual(info[0], sublime.Region(4, 5))
 
-        # Testing whether the popup with the diagnostic moves along with lsp_next_diagnostic
+        # Testing whether the cursor position moves along with lsp_next_diagnostic
 
         self.view.window().run_command("lsp_next_diagnostic")
-        time.sleep(0.25)
-        yield self.view.is_popup_visible
         self.assertEqual(self.view.sel()[0].a, self.view.sel()[0].b)
         self.assertEqual(self.view.sel()[0].b, 0)
 
         self.view.window().run_command("lsp_next_diagnostic")
-        time.sleep(0.25)
-        yield self.view.is_popup_visible
         self.assertEqual(self.view.sel()[0].a, self.view.sel()[0].b)
         self.assertEqual(self.view.sel()[0].b, 2)
 
         self.view.window().run_command("lsp_next_diagnostic")
-        time.sleep(0.25)
-        yield self.view.is_popup_visible
         self.assertEqual(self.view.sel()[0].a, self.view.sel()[0].b)
         self.assertEqual(self.view.sel()[0].b, 4)
 
         # lsp_prev_diagnostic should work as well
 
         self.view.window().run_command("lsp_prev_diagnostic")
-        time.sleep(0.25)
-        yield self.view.is_popup_visible
         self.assertEqual(self.view.sel()[0].a, self.view.sel()[0].b)
         self.assertEqual(self.view.sel()[0].b, 2)
 
         self.view.window().run_command("lsp_prev_diagnostic")
-        time.sleep(0.25)
-        yield self.view.is_popup_visible
         self.assertEqual(self.view.sel()[0].a, self.view.sel()[0].b)
         self.assertEqual(self.view.sel()[0].b, 0)
 
         # Testing to wrap around if there are no more diagnostics in the direction
 
         self.view.window().run_command("lsp_prev_diagnostic")
-        time.sleep(0.25)
-        yield self.view.is_popup_visible
         self.assertEqual(self.view.sel()[0].a, self.view.sel()[0].b)
         self.assertEqual(self.view.sel()[0].b, 4)

--- a/tests/test_server_notifications.py
+++ b/tests/test_server_notifications.py
@@ -78,3 +78,10 @@ class ServerNotifications(TextDocumentTestCase):
         yield self.view.is_popup_visible
         self.assertEqual(self.view.sel()[0].a, self.view.sel()[0].b)
         self.assertEqual(self.view.sel()[0].b, 0)
+
+        # Testing to wrap around if there are no more diagnostics in the direction
+
+        self.view.window().run_command("lsp_prev_diagnostic")
+        yield self.view.is_popup_visible
+        self.assertEqual(self.view.sel()[0].a, self.view.sel()[0].b)
+        self.assertEqual(self.view.sel()[0].b, 4)

--- a/tests/test_server_notifications.py
+++ b/tests/test_server_notifications.py
@@ -70,18 +70,15 @@ class ServerNotifications(TextDocumentTestCase):
         # lsp_prev_diagnostic should work as well
 
         self.view.window().run_command("lsp_prev_diagnostic")
-        yield self.view.is_popup_visible
         self.assertEqual(self.view.sel()[0].a, self.view.sel()[0].b)
         self.assertEqual(self.view.sel()[0].b, 2)
 
         self.view.window().run_command("lsp_prev_diagnostic")
-        yield self.view.is_popup_visible
         self.assertEqual(self.view.sel()[0].a, self.view.sel()[0].b)
         self.assertEqual(self.view.sel()[0].b, 0)
 
         # Testing to wrap around if there are no more diagnostics in the direction
 
         self.view.window().run_command("lsp_prev_diagnostic")
-        yield self.view.is_popup_visible
         self.assertEqual(self.view.sel()[0].a, self.view.sel()[0].b)
         self.assertEqual(self.view.sel()[0].b, 4)


### PR DESCRIPTION
This makes the console command `sublime.log_commands(True)` usable again if you type in a view which has diagnostics.