### PR TITLE
WIP: Investigate code lens refresh issues

### DIFF
--- a/plugin/code_lens.py
+++ b/plugin/code_lens.py
@@ -86,11 +86,11 @@ class CodeLensView:
         return self._init
 
     def _clear_annotations(self) -> None:
-        for index, _ in enumerate(self._flat_iteration()):
-            self.view.erase_regions(self._region_key(index))
+        for index, lens in enumerate(self._flat_iteration()):
+            self.view.erase_regions(self._region_key(lens.session_name, index))
 
-    def _region_key(self, index: int) -> str:
-        return '{0}.{1}'.format(self.CODE_LENS_KEY, index)
+    def _region_key(self, session_name: str, index: int) -> str:
+        return '{0}.{1}.{2}'.format(self.CODE_LENS_KEY, session_name, index)
 
     def clear_view(self) -> None:
         self._phantom.update([])
@@ -161,9 +161,11 @@ class CodeLensView:
                 phantoms.append(sublime.Phantom(phantom_region, html, sublime.LAYOUT_BELOW))
             self._phantom.update(phantoms)
         else:  # 'annotation'
+            self._clear_annotations()
             accent = self.view.style_for_scope("region.greenish markup.accent.codelens.lsp")["foreground"]
             for index, lens in enumerate(self._flat_iteration()):
-                self.view.add_regions(self._region_key(index), [lens.region], "", "", 0, [lens.small_html], accent)
+                self.view.add_regions(
+                    self._region_key(lens.session_name, index), [lens.region], "", "", 0, [lens.small_html], accent)
 
     def get_resolved_code_lenses_for_region(self, region: sublime.Region) -> Generator[CodeLens, None, None]:
         region = self.view.line(region)


### PR DESCRIPTION
I've noticed that this weird thing is happening with code lens annotations on moving the cursor:

https://user-images.githubusercontent.com/153197/190275044-6db9ace3-c2c1-4097-a741-eefe14cb14ba.mov

- there is no relevant communication with the server on moving the cursor
- we are just redrawing the code lenses that we already have cached
- we are calling `view.add_regions` without erasing the regions first. I guess the assumption is that ST handles duplicate region keys itself and it will result in a no-op but it seems that this issue is more apparent when not erasing explicitly
- even with erasing and using more unique region key (to avoid conflicts between sessions), the issue still reproduces so it seems to be an ST bug.

I will create an ST issue when I have more time.