### PR TITLE
Remove Range class and rename RangeLsp to Range

### DIFF
--- a/plugin/code_lens.py
+++ b/plugin/code_lens.py
@@ -1,4 +1,4 @@
-from .core.protocol import CodeLens, Error, Range
+from .core.protocol import CodeLens, Error
 from .core.typing import List, Tuple, Dict, Iterable, Generator, Union
 from .core.registry import LspTextCommand
 from .core.registry import windows
@@ -20,7 +20,7 @@ class CodeLensData:
 
     def __init__(self, data: CodeLens, view: sublime.View, session_name: str) -> None:
         self.data = data
-        self.region = range_to_region(Range.from_lsp(data['range']), view)
+        self.region = range_to_region(data['range'], view)
         self.session_name = session_name
         self.annotation = '...'
         self.resolve_annotation()
@@ -63,7 +63,7 @@ class CodeLensData:
             self.annotation = html_escape(str(code_lens_or_error))
             return
         self.data = code_lens_or_error
-        self.region = range_to_region(Range.from_lsp(code_lens_or_error['range']), view)
+        self.region = range_to_region(code_lens_or_error['range'], view)
         self.resolve_annotation()
 
 

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -1,6 +1,6 @@
 from .core.edit import parse_text_edit
 from .core.logging import debug
-from .core.protocol import InsertReplaceEdit, TextEdit, RangeLsp, Request, InsertTextFormat, Range, CompletionItem
+from .core.protocol import InsertReplaceEdit, TextEdit, Range, Request, InsertTextFormat, CompletionItem
 from .core.registry import LspTextCommand
 from .core.settings import userprefs
 from .core.typing import List, Dict, Optional, Generator, Union, cast
@@ -17,7 +17,7 @@ import webbrowser
 SessionName = str
 
 
-def get_text_edit_range(text_edit: Union[TextEdit, InsertReplaceEdit]) -> RangeLsp:
+def get_text_edit_range(text_edit: Union[TextEdit, InsertReplaceEdit]) -> Range:
     if 'insert' in text_edit and 'replace' in text_edit:
         text_edit = cast(InsertReplaceEdit, text_edit)
         insert_mode = userprefs().completion_insert_mode
@@ -103,7 +103,7 @@ class LspSelectCompletionItemCommand(LspTextCommand):
         text_edit = item.get("textEdit")
         if text_edit:
             new_text = text_edit["newText"].replace("\r", "")
-            edit_region = range_to_region(Range.from_lsp(get_text_edit_range(text_edit)), self.view)
+            edit_region = range_to_region(get_text_edit_range(text_edit), self.view)
             for region in self._translated_regions(edit_region):
                 self.view.erase(edit, region)
         else:

--- a/plugin/core/open.py
+++ b/plugin/core/open.py
@@ -3,7 +3,6 @@ from .promise import Promise
 from .promise import ResolveFunc
 from .protocol import DocumentUri
 from .protocol import Range
-from .protocol import RangeLsp
 from .protocol import UINT_MAX
 from .typing import Dict, Tuple, Optional
 from .typing import cast
@@ -25,10 +24,10 @@ def open_file_uri(
     window: sublime.Window, uri: DocumentUri, flags: int = 0, group: int = -1
 ) -> Promise[Optional[sublime.View]]:
 
-    def parse_fragment(fragment: str) -> Optional[RangeLsp]:
+    def parse_fragment(fragment: str) -> Optional[Range]:
         match = FRAGMENT_PATTERN.match(fragment)
         if match:
-            selection = {'start': {'line': 0, 'character': 0}, 'end': {'line': 0, 'character': 0}}  # type: RangeLsp
+            selection = {'start': {'line': 0, 'character': 0}, 'end': {'line': 0, 'character': 0}}  # type: Range
             # Line and column numbers in the fragment are assumed to be 1-based and need to be converted to 0-based
             # numbers for the LSP Position structure.
             start_line, start_column, end_line, end_column = [max(0, int(g) - 1) if g else None for g in match.groups()]
@@ -52,11 +51,11 @@ def open_file_uri(
     if parsed.fragment:
         selection = parse_fragment(parsed.fragment)
         if selection:
-            return open_promise.then(lambda view: _select_and_center(view, cast(RangeLsp, selection)))
+            return open_promise.then(lambda view: _select_and_center(view, cast(Range, selection)))
     return open_promise
 
 
-def _select_and_center(view: Optional[sublime.View], r: RangeLsp) -> Optional[sublime.View]:
+def _select_and_center(view: Optional[sublime.View], r: Range) -> Optional[sublime.View]:
     if view:
         return center_selection(view, r)
     return None
@@ -111,8 +110,8 @@ def open_file(
     return promise
 
 
-def center_selection(v: sublime.View, r: RangeLsp) -> sublime.View:
-    selection = range_to_region(Range.from_lsp(r), v)
+def center_selection(v: sublime.View, r: Range) -> sublime.View:
+    selection = range_to_region(r, v)
     v.run_command("lsp_selection_set", {"regions": [(selection.a, selection.a)]})
     window = v.window()
     if window:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -32,7 +32,7 @@ from .protocol import ErrorCode
 from .protocol import ExecuteCommandParams
 from .protocol import FileEvent
 from .protocol import Notification
-from .protocol import RangeLsp
+from .protocol import Range
 from .protocol import Request
 from .protocol import Response
 from .protocol import SemanticTokenModifiers
@@ -1467,7 +1467,7 @@ class Session(TransportCallbacks):
     def open_uri_async(
         self,
         uri: DocumentUri,
-        r: Optional[RangeLsp] = None,
+        r: Optional[Range] = None,
         flags: int = 0,
         group: int = -1
     ) -> Promise[Optional[sublime.View]]:
@@ -1489,7 +1489,7 @@ class Session(TransportCallbacks):
     def _open_file_uri_async(
         self,
         uri: DocumentUri,
-        r: Optional[RangeLsp] = None,
+        r: Optional[Range] = None,
         flags: int = 0,
         group: int = -1
     ) -> Promise[Optional[sublime.View]]:
@@ -1507,7 +1507,7 @@ class Session(TransportCallbacks):
         self,
         plugin: AbstractPlugin,
         uri: DocumentUri,
-        r: Optional[RangeLsp],
+        r: Optional[Range],
         flags: int,
         group: int,
     ) -> Promise[Optional[sublime.View]]:

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -327,7 +327,8 @@ def region_to_range(view: sublime.View, region: sublime.Region) -> Range:
 
 
 def is_range_equal(lhs: Range, rhs: Range) -> bool:
-    return lhs['start'] == rhs['start'] and lhs['end'] == rhs['end']
+    return lhs['start']['line'] == rhs['start']['line'] and lhs['start']['character'] == rhs['start']['character'] and \
+        lhs['end']['line'] == rhs['end']['line'] and lhs['end']['character'] == rhs['end']['character']
 
 
 def to_encoded_filename(path: str, position: Position) -> str:

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -13,7 +13,6 @@ from .core.protocol import Diagnostic
 from .core.protocol import DiagnosticSeverity
 from .core.protocol import DocumentHighlightKind
 from .core.protocol import Error
-from .core.protocol import Range
 from .core.protocol import Request
 from .core.protocol import SignatureHelp
 from .core.protocol import SignatureHelpContext
@@ -692,7 +691,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             response = []
         kind2regions = {}  # type: Dict[Tuple[int, bool], List[sublime.Region]]
         for highlight in response:
-            r = range_to_region(Range.from_lsp(highlight["range"]), self.view)
+            r = range_to_region(highlight["range"], self.view)
             kind = highlight.get("kind", DocumentHighlightKind.Text)
             kind2regions.setdefault((kind, len(self.view.split_by_newlines(r)) > 1), []).append(r)
 

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -87,7 +87,7 @@ class LspExecuteCommand(LspTextCommand):
                 elif arg in ["$position", "${position}"]:
                     command_args[i] = offset_to_point(view, region.b).to_lsp()
                 elif arg in ["$range", "${range}"]:
-                    command_args[i] = region_to_range(view, region).to_lsp()
+                    command_args[i] = region_to_range(view, region)
         window = view.window()
         window_variables = window.extract_variables() if window else {}
         return sublime.expand_variables(command_args, window_variables)

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -10,7 +10,6 @@ from .core.protocol import ExperimentalTextDocumentRangeParams
 from .core.protocol import Hover
 from .core.protocol import Position
 from .core.protocol import Range
-from .core.protocol import RangeLsp
 from .core.protocol import Request
 from .core.protocol import TextDocumentPositionParams
 from .core.registry import LspTextCommand
@@ -227,7 +226,7 @@ class LspHoverCommand(LspTextCommand):
             contents.append('<a href="{}">{}</a>'.format(html.escape(target), html.escape(title)))
         if len(contents) > 1:
             link_has_standard_tooltip = False
-        link_range = range_to_region(Range.from_lsp(links[0]["range"]), self.view) if links else None
+        link_range = range_to_region(links[0]["range"], self.view) if links else None
         self._document_link = ('<br>'.join(contents) if contents else '', link_has_standard_tooltip, link_range)
         self.show_hover(listener, point, only_diagnostics=False)
 
@@ -272,7 +271,7 @@ class LspHoverCommand(LspTextCommand):
         for hover, _ in self._hover_responses:
             hover_range = hover.get('range')
             if hover_range:
-                return range_to_region(Range.from_lsp(hover_range), self.view)
+                return range_to_region(hover_range, self.view)
         else:
             return None
 
@@ -349,7 +348,7 @@ class LspHoverCommand(LspTextCommand):
             session = self.session_by_name(session_name)
             if session:
                 position = {"line": row, "character": col_utf16}  # type: Position
-                r = {"start": position, "end": position}  # type: RangeLsp
+                r = {"start": position, "end": position}  # type: Range
                 sublime.set_timeout_async(functools.partial(session.open_uri_async, uri, r))
         else:
             open_in_browser(href)

--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -2,7 +2,6 @@ from .core.edit import parse_workspace_edit
 from .core.edit import TextEditTuple
 from .core.panels import ensure_panel
 from .core.panels import PanelName
-from .core.protocol import Range
 from .core.protocol import Request
 from .core.registry import get_position
 from .core.registry import LspTextCommand
@@ -150,7 +149,7 @@ class LspSymbolRenameCommand(LspTextCommand):
         else:
             placeholder = self.view.substr(self.view.word(pos))
             r = response
-        region = range_to_region(Range.from_lsp(r), self.view)
+        region = range_to_region(r, self.view)
         args = {"placeholder": placeholder, "position": region.a, "event": self.event}
         self.view.run_command("lsp_symbol_rename", args)
 

--- a/plugin/selection_range.py
+++ b/plugin/selection_range.py
@@ -1,4 +1,3 @@
-from .core.protocol import Range
 from .core.protocol import Request
 from .core.registry import get_position
 from .core.registry import LspTextCommand
@@ -58,7 +57,7 @@ class LspExpandSelectionCommand(LspTextCommand):
         self.view.run_command("expand_selection", {"to": "smart"})
 
     def _smallest_containing(self, region: sublime.Region, param: Dict[str, Any]) -> Tuple[int, int]:
-        r = range_to_region(Range.from_lsp(param["range"]), self.view)
+        r = range_to_region(param["range"], self.view)
         # Test for *strict* containment
         if r.contains(region) and (r.a < region.a or r.b > region.b):
             return r.a, r.b

--- a/plugin/symbols.py
+++ b/plugin/symbols.py
@@ -1,5 +1,5 @@
 import weakref
-from .core.protocol import Request, Range, DocumentSymbol, SymbolInformation, SymbolTag
+from .core.protocol import Request, DocumentSymbol, SymbolInformation, SymbolTag
 from .core.registry import LspTextCommand
 from .core.sessions import print_to_status_bar
 from .core.typing import Any, List, Optional, Tuple, Dict, Generator, Union, cast
@@ -182,8 +182,8 @@ class LspDocumentSymbolsCommand(LspTextCommand):
     def process_document_symbol_recursive(self, quick_panel_items: List[sublime.QuickPanelItem], item: DocumentSymbol,
                                           names: List[str]) -> None:
         lsp_kind = item["kind"]
-        self.regions.append((range_to_region(Range.from_lsp(item['range']), self.view),
-                             range_to_region(Range.from_lsp(item['selectionRange']), self.view),
+        self.regions.append((range_to_region(item['range'], self.view),
+                             range_to_region(item['selectionRange'], self.view),
                              get_symbol_scope_from_lsp_kind(lsp_kind)))
         name = item['name']
         with _additional_name(names, name):
@@ -210,7 +210,7 @@ class LspDocumentSymbolsCommand(LspTextCommand):
     def process_symbol_informations(self, items: List[SymbolInformation]) -> List[sublime.QuickPanelItem]:
         quick_panel_items = []  # type: List[sublime.QuickPanelItem]
         for item in items:
-            self.regions.append((range_to_region(Range.from_lsp(item['location']['range']), self.view),
+            self.regions.append((range_to_region(item['location']['range'], self.view),
                                  None, get_symbol_scope_from_lsp_kind(item['kind'])))
             quick_panel_item = symbol_information_to_quick_panel_item(item, show_file_name=False)
             quick_panel_items.append(quick_panel_item)

--- a/tests/test_code_actions.py
+++ b/tests/test_code_actions.py
@@ -16,7 +16,14 @@ TEST_FILE_URI = filename_to_uri(TEST_FILE_PATH)
 
 
 def edit_to_lsp(edit: Tuple[str, Range]) -> Dict[str, Any]:
-    return {"newText": edit[0], "range": edit[1].to_lsp()}
+    return {"newText": edit[0], "range": edit[1]}
+
+
+def range_from_points(start: Point, end: Point) -> Range:
+    return {
+        'start': start.to_lsp(),
+        'end': end.to_lsp()
+    }
 
 
 def create_code_action_edit(view: sublime.View, version: int, edits: List[Tuple[str, Range]]) -> Dict[str, Any]:
@@ -75,7 +82,7 @@ def create_test_diagnostics(diagnostics: List[Tuple[str, Range]]) -> Dict:
         message, range = diagnostic
         return {
             "message": message,
-            "range": range.to_lsp()
+            "range": range
         }
     return {
         "uri": TEST_FILE_URI,
@@ -107,7 +114,7 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
         code_action = create_test_code_action(
             self.view,
             self.view.change_count(),
-            [(';', Range(Point(0, 11), Point(0, 11)))],
+            [(';', range_from_points(Point(0, 11), Point(0, 11)))],
             code_action_kind
         )
         self.set_response('textDocument/codeAction', [code_action])
@@ -123,7 +130,7 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
         code_action = create_test_code_action(
             self.view,
             self.view.change_count(),
-            [(';', Range(Point(0, 11), Point(0, 11)))],
+            [(';', range_from_points(Point(0, 11), Point(0, 11)))],
             code_action_kind
         )
         self.set_response('textDocument/codeAction', [code_action])
@@ -141,7 +148,7 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
         yield from self.await_client_notification(
             "textDocument/publishDiagnostics",
             create_test_diagnostics([
-                ('Missing semicolon', Range(Point(0, 11), Point(0, 11))),
+                ('Missing semicolon', range_from_points(Point(0, 11), Point(0, 11))),
             ])
         )
         code_action_kind = 'source.fixAll'
@@ -152,7 +159,7 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
                     create_test_code_action(
                         self.view,
                         initial_change_count,
-                        [(';', Range(Point(0, 11), Point(0, 11)))],
+                        [(';', range_from_points(Point(0, 11), Point(0, 11)))],
                         code_action_kind
                     )
                 ]
@@ -163,7 +170,7 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
                     create_test_code_action(
                         self.view,
                         initial_change_count + 1,
-                        [('\nAnd again!', Range(Point(0, 12), Point(0, 12)))],
+                        [('\nAnd again!', range_from_points(Point(0, 12), Point(0, 12)))],
                         code_action_kind
                     )
                 ]
@@ -180,7 +187,7 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
         code_action = create_test_code_action(
             self.view,
             self.view.change_count(),
-            [(';', Range(Point(0, 11), Point(0, 11)))],
+            [(';', range_from_points(Point(0, 11), Point(0, 11)))],
             code_action_kind
         )
         self.set_response('textDocument/codeAction', [code_action])
@@ -204,7 +211,7 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
         code_action = create_test_code_action(
             self.view,
             self.view.change_count(),
-            [(';', Range(Point(0, 11), Point(0, 11)))],
+            [(';', range_from_points(Point(0, 11), Point(0, 11)))],
             code_action_kind
         )
         self.set_response('textDocument/codeAction', [code_action])
@@ -218,7 +225,7 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
         yield from self.await_client_notification(
             "textDocument/publishDiagnostics",
             create_test_diagnostics([
-                ('Missing semicolon', Range(Point(0, 11), Point(0, 11))),
+                ('Missing semicolon', range_from_points(Point(0, 11), Point(0, 11))),
             ])
         )
 
@@ -265,9 +272,9 @@ class CodeActionsListenerTestCase(TextDocumentTestCase):
         initial_content = 'a\nb\nc'
         self.insert_characters(initial_content)
         yield from self.await_message('textDocument/didChange')
-        range_a = Range(Point(0, 0), Point(0, 1))
-        range_b = Range(Point(1, 0), Point(1, 1))
-        range_c = Range(Point(2, 0), Point(2, 1))
+        range_a = range_from_points(Point(0, 0), Point(0, 1))
+        range_b = range_from_points(Point(1, 0), Point(1, 1))
+        range_c = range_from_points(Point(2, 0), Point(2, 1))
         yield from self.await_client_notification(
             "textDocument/publishDiagnostics",
             create_test_diagnostics([('issue a', range_a), ('issue b', range_b), ('issue c', range_c)])
@@ -292,8 +299,8 @@ class CodeActionsListenerTestCase(TextDocumentTestCase):
         initial_content = 'a\nb\nc'
         self.insert_characters(initial_content)
         yield from self.await_message("textDocument/didChange")
-        range_a = Range(Point(0, 0), Point(0, 1))
-        range_b = Range(Point(1, 0), Point(1, 1))
+        range_a = range_from_points(Point(0, 0), Point(0, 1))
+        range_b = range_from_points(Point(1, 0), Point(1, 1))
         code_action1 = create_test_code_action(self.view, 0, [("A", range_a)])
         code_action2 = create_test_code_action(self.view, 0, [("B", range_b)])
         self.set_response('textDocument/codeAction', [code_action1, code_action2])
@@ -317,7 +324,7 @@ class CodeActionsListenerTestCase(TextDocumentTestCase):
         code_action = create_disabled_code_action(
             self.view,
             self.view.change_count(),
-            [(';', Range(Point(0, 0), Point(0, 1)))]
+            [(';', range_from_points(Point(0, 0), Point(0, 1)))]
         )
         self.set_response('textDocument/codeAction', [code_action])
         self.view.run_command('lsp_selection_set', {"regions": [(0, 1)]})  # Select a
@@ -332,8 +339,8 @@ class CodeActionsListenerTestCase(TextDocumentTestCase):
         yield from self.await_client_notification(
             "textDocument/publishDiagnostics",
             create_test_diagnostics([
-                ('diagnostic word', Range(Point(0, 2), Point(0, 12))),
-                ('all content', Range(Point(0, 0), Point(0, 12))),
+                ('diagnostic word', range_from_points(Point(0, 2), Point(0, 12))),
+                ('all content', range_from_points(Point(0, 0), Point(0, 12))),
             ])
         )
         self.view.run_command('lsp_selection_set', {"regions": [(0, 5)]})
@@ -361,8 +368,8 @@ class CodeActionsTestCase(TextDocumentTestCase):
         yield from self.await_client_notification(
             "textDocument/publishDiagnostics",
             create_test_diagnostics([
-                ('issue a', Range(Point(0, 0), Point(0, 1))),
-                ('issue b', Range(Point(1, 0), Point(1, 1)))
+                ('issue a', range_from_points(Point(0, 0), Point(0, 1))),
+                ('issue b', range_from_points(Point(1, 0), Point(1, 1)))
             ])
         )
         params = yield from self.await_message('textDocument/codeAction')
@@ -374,8 +381,8 @@ class CodeActionsTestCase(TextDocumentTestCase):
 
     def test_applies_code_action_with_matching_document_version(self) -> Generator:
         code_action = create_test_code_action(self.view, 3, [
-            ("c", Range(Point(0, 0), Point(0, 1))),
-            ("d", Range(Point(1, 0), Point(1, 1))),
+            ("c", range_from_points(Point(0, 0), Point(0, 1))),
+            ("d", range_from_points(Point(1, 0), Point(1, 1))),
         ])
         self.insert_characters('a\nb')
         yield from self.await_message("textDocument/didChange")
@@ -387,8 +394,8 @@ class CodeActionsTestCase(TextDocumentTestCase):
     def test_does_not_apply_with_nonmatching_document_version(self) -> Generator:
         initial_content = 'a\nb'
         code_action = create_test_code_action(self.view, 0, [
-            ("c", Range(Point(0, 0), Point(0, 1))),
-            ("d", Range(Point(1, 0), Point(1, 1))),
+            ("c", range_from_points(Point(0, 0), Point(0, 1))),
+            ("d", range_from_points(Point(1, 0), Point(1, 1))),
         ])
         self.insert_characters(initial_content)
         yield from self.await_message("textDocument/didChange")
@@ -399,8 +406,8 @@ class CodeActionsTestCase(TextDocumentTestCase):
         code_action = create_test_code_action2("dosomethinguseful", ["1", 0, {"hello": "there"}])
         resolved_code_action = deepcopy(code_action)
         resolved_code_action["edit"] = create_code_action_edit(self.view, 3, [
-            ("c", Range(Point(0, 0), Point(0, 1))),
-            ("d", Range(Point(1, 0), Point(1, 1))),
+            ("c", range_from_points(Point(0, 0), Point(0, 1))),
+            ("d", range_from_points(Point(1, 0), Point(1, 1))),
         ])
         self.set_response('codeAction/resolve', resolved_code_action)
         self.set_response('workspace/executeCommand', {"reply": "OK done"})
@@ -418,7 +425,7 @@ class CodeActionsTestCase(TextDocumentTestCase):
         self.insert_characters('🕵️hi')
         yield from self.await_message("textDocument/didChange")
         code_action = create_test_code_action(self.view, self.view.change_count(), [
-            ("bye", Range(Point(0, 3), Point(0, 5))),
+            ("bye", range_from_points(Point(0, 3), Point(0, 5))),
         ])
         yield from self.await_run_code_action(code_action)
         self.assertEquals(entire_content(self.view), '🕵️bye')

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,22 +1,9 @@
-from LSP.plugin.core.protocol import Point, Position, Range, RangeLsp, Request, Notification
+from LSP.plugin.core.protocol import Point, Position, Request, Notification
 from LSP.plugin.core.transports import JsonRpcProcessor
 import unittest
 
 
 LSP_START_POSITION = {'line': 10, 'character': 4}  # type: Position
-LSP_END_POSITION = {'line': 11, 'character': 3}  # type: Position
-LSP_RANGE = {'start': LSP_START_POSITION, 'end': LSP_END_POSITION}  # type: RangeLsp
-LSP_MINIMAL_DIAGNOSTIC = {
-    'message': 'message',
-    'range': LSP_RANGE
-}
-
-LSP_FULL_DIAGNOSTIC = {
-    'message': 'message',
-    'range': LSP_RANGE,
-    'severity': 2,  # warning
-    'source': 'pyls'
-}
 
 
 class PointTests(unittest.TestCase):
@@ -28,103 +15,6 @@ class PointTests(unittest.TestCase):
         lsp_point = point.to_lsp()
         self.assertEqual(lsp_point['line'], 10)
         self.assertEqual(lsp_point['character'], 4)
-
-
-class RangeTests(unittest.TestCase):
-
-    def test_lsp_conversion(self) -> None:
-        range = Range.from_lsp(LSP_RANGE)
-        self.assertEqual(range.start.row, 10)
-        self.assertEqual(range.start.col, 4)
-        self.assertEqual(range.end.row, 11)
-        self.assertEqual(range.end.col, 3)
-        lsp_range = range.to_lsp()
-        self.assertEqual(lsp_range['start']['line'], 10)
-        self.assertEqual(lsp_range['start']['character'], 4)
-        self.assertEqual(lsp_range['end']['line'], 11)
-        self.assertEqual(lsp_range['end']['character'], 3)
-
-    def test_contains(self) -> None:
-        range = Range.from_lsp(LSP_RANGE)
-        point = Point.from_lsp(LSP_START_POSITION)
-        self.assertTrue(range.contains(point))
-        # Point inside of range with character offset lower than range end
-        range = Range.from_lsp(LSP_RANGE)
-        point = Point.from_lsp({'line': 10, 'character': 1})
-        self.assertTrue(range.contains(point))
-        # Point out of range with character offset lower than range end
-        range = Range.from_lsp({
-            'start': {'line': 0, 'character': 0},
-            'end': {'line': 1, 'character': 4}
-        })
-        point = Point.from_lsp({'line': 12, 'character': 0})
-        self.assertFalse(range.contains(point))
-        # Point within first line of range.
-        range = Range.from_lsp({
-            'start': {'line': 0, 'character': 0},
-            'end': {'line': 1, 'character': 4}
-        })
-        point = Point.from_lsp({'line': 0, 'character': 4})
-        self.assertTrue(range.contains(point))
-
-    def test_intersects(self) -> None:
-        # range2 fully contained within range1
-        range1 = Range.from_lsp({
-            'start': {'line': 0, 'character': 0},
-            'end': {'line': 1, 'character': 4}
-        })
-        range2 = Range.from_lsp({
-            'start': {'line': 0, 'character': 2},
-            'end': {'line': 0, 'character': 3}
-        })
-        self.assertTrue(range1.intersects(range2))
-        # range2 intersecting end of range 1
-        range1 = Range.from_lsp({
-            'start': {'line': 0, 'character': 0},
-            'end': {'line': 0, 'character': 3}
-        })
-        range2 = Range.from_lsp({
-            'start': {'line': 0, 'character': 2},
-            'end': {'line': 0, 'character': 4}
-        })
-        self.assertTrue(range1.intersects(range2))
-        # range2 fully outside of range 1
-        range1 = Range.from_lsp({
-            'start': {'line': 0, 'character': 0},
-            'end': {'line': 0, 'character': 3}
-        })
-        range2 = Range.from_lsp({
-            'start': {'line': 2, 'character': 0},
-            'end': {'line': 3, 'character': 0}
-        })
-        self.assertFalse(range1.intersects(range2))
-        # range2 fully within range 1
-        range1 = Range.from_lsp({
-            'start': {'line': 0, 'character': 10},
-            'end': {'line': 1, 'character': 20}
-        })
-        range2 = Range.from_lsp({
-            'start': {'line': 0, 'character': 21},
-            'end': {'line': 0, 'character': 22}
-        })
-        self.assertTrue(range1.intersects(range2))
-
-    def test_extend(self) -> None:
-        # includes range 1
-        base_range = Range(Point(0, 0), Point(0, 0))
-        other_range = Range(Point(0, 0), Point(0, 3))
-        base_range.extend(other_range)
-        self.assertEqual(base_range, other_range)
-        # includes range 2
-        base_range = Range(Point(1, 0), Point(1, 1))
-        other_range = Range(Point(0, 0), Point(2, 0))
-        base_range.extend(other_range)
-        self.assertEqual(base_range, other_range)
-        # is not extended
-        base_range = Range(Point(1, 0), Point(1, 5))
-        other_range = Range(Point(1, 1), Point(1, 2))
-        base_range.extend(other_range)
-        self.assertEqual(base_range, Range(Point(1, 0), Point(1, 5)))
 
 
 class EncodingTests(unittest.TestCase):

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,9 +1,11 @@
-from LSP.plugin.core.protocol import Point, Position, Request, Notification
+from LSP.plugin.core.protocol import Point, Position, Range, Request, Notification
 from LSP.plugin.core.transports import JsonRpcProcessor
 import unittest
 
 
 LSP_START_POSITION = {'line': 10, 'character': 4}  # type: Position
+LSP_END_POSITION = {'line': 11, 'character': 3}  # type: Position
+LSP_RANGE = {'start': LSP_START_POSITION, 'end': LSP_END_POSITION}  # type: Range
 
 
 class PointTests(unittest.TestCase):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
 from LSP.plugin.core.protocol import Diagnostic
 from LSP.plugin.core.protocol import Point
-from LSP.plugin.core.protocol import Range
 from LSP.plugin.core.types import Any
 from LSP.plugin.core.url import filename_to_uri
 from LSP.plugin.core.views import did_change
@@ -331,7 +330,7 @@ class ViewsTest(DeferrableTestCase):
         ]
         phantom = lsp_color_to_phantom(self.view, response[0])
         self.assertEqual(phantom.content, lsp_color_to_html(response[0]))
-        self.assertEqual(phantom.region, range_to_region(Range.from_lsp(response[0]["range"]), self.view))
+        self.assertEqual(phantom.region, range_to_region(response[0]["range"], self.view))
 
     def test_document_color_params(self) -> None:
         self.view.settings().set("lsp_uri", filename_to_uri(self.mock_file_name))


### PR DESCRIPTION
As suggested by @jwortmann in https://github.com/sublimelsp/LSP/pull/2049#discussion_r967910560 and also to make migration to new types much easier, renamed `RangeLsp` to `Range` and removed our custom `Range` class. It was an unnecessary intermediate class that wasn't really used for much (its `contains`, `intersects`, `extend` methods weren't even used outside of tests).