### PR TITLE
Fix submodule reloading

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -1,6 +1,17 @@
 import os
+import sys
 import sublime
 import sublime_plugin
+
+# Clear module cache to force reloading all modules of this package.
+prefix = __package__ + "."  # don't clear the base package
+for module_name in [
+    module_name
+    for module_name in sys.modules
+    if module_name.startswith(prefix) and module_name != __name__
+]:
+    del sys.modules[module_name]
+prefix = None
 
 # Please keep this list sorted (Edit -> Sort Lines)
 from .plugin.code_actions import LspCodeActionsCommand


### PR DESCRIPTION
This commit adds some lines, which helped A File Icon and GitGutter to properly upgrade even if larger structural changes are involved.

It just clears all out-dated submodules of the previously disabled LSP version from sys.modules before importing anything from current version of the package.

As a result all modules are freshly loaded, picking up any kind of change, including new, removed, changed module and global.

Removed modules should be garbage collected once all functions returned and reference counters are reset.

Motivation:

Package upgrades including structural changes such as new, renamed or removed modules often end with fatal errors which require restarting ST to get LSP working again.

Example:

```
Traceback (most recent call last):
  File "Sublime Text 4126\Lib\python33\sublime_plugin.py", line 308, in reload_plugin
    m = importlib.import_module(modulename)
  File "./python3.3/importlib/__init__.py", line 90, in import_module
  File "<frozen importlib._bootstrap>", line 1584, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1565, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1532, in _find_and_load_unlocked
  File "Sublime Text 4126\Data\Installed Packages\LSP.sublime-package\boot.py", line 53, in <module>
ImportError: No module named 'LSP.plugin.inlay_hint'

reloading python 3.3 plugin LSP.boot
Traceback (most recent call last):
  File "Sublime Text 4126\Lib\python33\sublime_plugin.py", line 308, in reload_plugin
    m = importlib.import_module(modulename)
  File "./python3.3/importlib/__init__.py", line 90, in import_module
  File "<frozen importlib._bootstrap>", line 1584, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1565, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1532, in _find_and_load_unlocked
  File "Sublime Text 4126\Lib\python33\sublime_plugin.py", line 1692, in load_module
    exec(compile(source, source_path, 'exec'), mod.__dict__)
  File "Sublime Text 4126\Data\Installed Packages\LSP.sublime-package\boot.py", line 53, in <module>
  File "Sublime Text 4126\Lib\python33\sublime_plugin.py", line 1692, in load_module
    exec(compile(source, source_path, 'exec'), mod.__dict__)
  File "Sublime Text 4126\Data\Installed Packages\LSP.sublime-package\plugin/inlay_hint.py", line 1, in <module>
ImportError: cannot import name InlayHintLabelPart
```