### PR TITLE
Ensure "Source Actions..." request includes the "source" kind

### DIFF
--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -96,8 +96,8 @@ class CodeActionsManager:
             view,
             region,
             session_buffer_diagnostics,
-            False,
-            actions_handler,
+            only_with_diagnostics=False,
+            actions_handler=actions_handler,
             on_save_actions=None,
             only_kinds=only_kinds,
             manual=manual)

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -85,14 +85,22 @@ class CodeActionsManager:
         region: sublime.Region,
         session_buffer_diagnostics: List[Tuple[SessionBufferProtocol, List[Diagnostic]]],
         actions_handler: Callable[[CodeActionsByConfigName], None],
-        only_kinds: Optional[Dict[str, bool]] = None,
+        only_kinds: Optional[List[CodeActionKind]] = None,
         manual: bool = False,
     ) -> None:
         """
         Requests code actions with provided diagnostics and specified region. If there are
         no diagnostics for given session, the request will be made with empty diagnostics list.
         """
-        self._request_async(view, region, session_buffer_diagnostics, False, actions_handler, only_kinds, manual)
+        self._request_async(
+            view,
+            region,
+            session_buffer_diagnostics,
+            False,
+            actions_handler,
+            on_save_actions=None,
+            only_kinds=only_kinds,
+            manual=manual)
 
     def request_on_save(
         self,
@@ -109,7 +117,14 @@ class CodeActionsManager:
         region = entire_content_region(view)
         session_buffer_diagnostics, _ = listener.diagnostics_intersecting_region_async(region)
         self._request_async(
-            view, region, session_buffer_diagnostics, False, actions_handler, on_save_actions, manual=False)
+            view,
+            region,
+            session_buffer_diagnostics,
+            only_with_diagnostics=False,
+            actions_handler=actions_handler,
+            on_save_actions=on_save_actions,
+            only_kinds=None,
+            manual=False)
 
     def _request_async(
         self,
@@ -119,8 +134,12 @@ class CodeActionsManager:
         only_with_diagnostics: bool,
         actions_handler: Callable[[CodeActionsByConfigName], None],
         on_save_actions: Optional[Dict[str, bool]] = None,
+        only_kinds: Optional[List[CodeActionKind]] = None,
         manual: bool = False,
     ) -> None:
+        listener = windows.listener_for_view(view)
+        if not listener:
+            return
         location_cache_key = None
         use_cache = on_save_actions is None and not manual
         if use_cache:
@@ -135,28 +154,26 @@ class CodeActionsManager:
                     self._response_cache = None
         collector = CodeActionsCollector(actions_handler)
         with collector:
-            listener = windows.listener_for_view(view)
-            if listener:
-                for session in listener.sessions_async('codeActionProvider'):
-                    diagnostics = []  # type: List[Diagnostic]
-                    for sb, diags in session_buffer_diagnostics:
-                        if sb.session == session:
-                            diagnostics = diags
-                            break
-                    if on_save_actions:
-                        supported_kinds = session.get_capability('codeActionProvider.codeActionKinds')  # type: Optional[List[CodeActionKind]] # noqa
-                        matching_kinds = get_matching_kinds(on_save_actions, supported_kinds or [])
-                        if matching_kinds:
-                            params = text_document_code_action_params(view, region, diagnostics, matching_kinds, manual)
-                            request = Request.codeAction(params, view)
-                            session.send_request_async(
-                                request, *filtering_collector(session.config.name, matching_kinds, collector))
-                    else:
-                        if only_with_diagnostics and not diagnostics:
-                            continue
-                        params = text_document_code_action_params(view, region, diagnostics, None, manual)
+            for session in listener.sessions_async('codeActionProvider'):
+                diagnostics = []  # type: List[Diagnostic]
+                for sb, diags in session_buffer_diagnostics:
+                    if sb.session == session:
+                        diagnostics = diags
+                        break
+                if on_save_actions is not None:
+                    supported_kinds = session.get_capability('codeActionProvider.codeActionKinds')  # type: Optional[List[CodeActionKind]] # noqa: E501
+                    matching_kinds = get_matching_kinds(on_save_actions, supported_kinds or [])
+                    if matching_kinds:
+                        params = text_document_code_action_params(view, region, diagnostics, matching_kinds, manual)
                         request = Request.codeAction(params, view)
-                        session.send_request_async(request, collector.create_collector(session.config.name))
+                        session.send_request_async(
+                            request, *filtering_collector(session.config.name, matching_kinds, collector))
+                else:
+                    if only_with_diagnostics and not diagnostics:
+                        continue
+                    params = text_document_code_action_params(view, region, diagnostics, only_kinds, manual)
+                    request = Request.codeAction(params, view)
+                    session.send_request_async(request, collector.create_collector(session.config.name))
         if location_cache_key:
             self._response_cache = (location_cache_key, collector)
 
@@ -275,7 +292,7 @@ class LspCodeActionsCommand(LspTextCommand):
         self,
         edit: sublime.Edit,
         event: Optional[dict] = None,
-        only_kinds: Optional[List[str]] = None,
+        only_kinds: Optional[List[CodeActionKind]] = None,
         commands_by_config: Optional[CodeActionsByConfigName] = None
     ) -> None:
         self.commands = []  # type: List[Tuple[str, CodeActionOrCommand]]
@@ -291,9 +308,8 @@ class LspCodeActionsCommand(LspTextCommand):
             if not listener:
                 return
             session_buffer_diagnostics, covering = listener.diagnostics_intersecting_async(region)
-            dict_kinds = {kind: True for kind in only_kinds} if only_kinds else None
             actions_manager.request_for_region_async(
-                view, covering, session_buffer_diagnostics, self.handle_responses_async, dict_kinds, manual=True)
+                view, covering, session_buffer_diagnostics, self.handle_responses_async, only_kinds, manual=True)
 
     def handle_responses_async(self, responses: CodeActionsByConfigName, run_first: bool = False) -> None:
         self.commands_by_config = responses

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -5873,7 +5873,7 @@ class Request:
         return Request("textDocument/signatureHelp", params, view)
 
     @classmethod
-    def codeAction(cls, params: Mapping[str, Any], view: sublime.View) -> 'Request':
+    def codeAction(cls, params: CodeActionParams, view: sublime.View) -> 'Request':
         return Request("textDocument/codeAction", params, view)
 
     @classmethod

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -566,15 +566,15 @@ def text_document_code_action_params(
     view: sublime.View,
     region: sublime.Region,
     diagnostics: List[Diagnostic],
-    on_save_actions: Optional[List[CodeActionKind]] = None,
+    only_kinds: Optional[List[CodeActionKind]] = None,
     manual: bool = False
 ) -> CodeActionParams:
     context = {
         "diagnostics": diagnostics,
         "triggerKind": CodeActionTriggerKind.Invoked if manual else CodeActionTriggerKind.Automatic,
     }  # type: CodeActionContext
-    if on_save_actions:
-        context["only"] = on_save_actions
+    if only_kinds:
+        context["only"] = only_kinds
     return {
         "textDocument": text_document_identifier(view),
         "range": region_to_range(view, region),

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -359,7 +359,7 @@ class ViewsTest(DeferrableTestCase):
             view=self.view,
             region=sublime.Region(0, 1),
             diagnostics=[diagnostic],
-            on_save_actions=["refactor"]
+            only_kinds=["refactor"]
         )
         self.assertEqual(params["textDocument"], {"uri": filename_to_uri(self.mock_file_name)})
 


### PR DESCRIPTION
Makes sure that the code action request that we make when triggering the "Source actions..." command explicitly includes `"only": ["source"]` kind.

Related to https://github.com/sublimelsp/LSP/issues/1846#issuecomment-1255150008

(More readable diff with `Hide whitespace changes` enabled)

@jwortmann 