### PR TITLE
Request color presentations when clicking on a color box

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -5,6 +5,7 @@ import sublime_plugin
 # Please keep this list sorted (Edit -> Sort Lines)
 from .plugin.code_actions import LspCodeActionsCommand
 from .plugin.code_lens import LspCodeLensCommand
+from .plugin.color import LspColorPresentationCommand
 from .plugin.completion import LspCommitCompletionWithOppositeInsertMode
 from .plugin.completion import LspResolveDocsCommand
 from .plugin.completion import LspSelectCompletionItemCommand

--- a/plugin/color.py
+++ b/plugin/color.py
@@ -3,7 +3,7 @@ from .core.protocol import ColorPresentation
 from .core.protocol import ColorPresentationParams
 from .core.protocol import Request
 from .core.registry import LspTextCommand
-from .core.typing import List, Optional
+from .core.typing import List
 from .core.views import range_to_region
 import sublime
 
@@ -12,12 +12,15 @@ class LspColorPresentationCommand(LspTextCommand):
 
     capability = 'colorProvider'
 
-    def run(self, edit: sublime.Edit, params: ColorPresentationParams, event: Optional[dict] = None) -> None:
+    def run(self, edit: sublime.Edit, params: ColorPresentationParams) -> None:
         session = self.best_session(self.capability)
         if session:
             self._version = self.view.change_count()
             self._range = params['range']
             session.send_request_async(Request.colorPresentation(params, self.view), self._handle_response_async)
+
+    def want_event(self) -> bool:
+        return False
 
     def _handle_response_async(self, response: List[ColorPresentation]) -> None:
         if not response:

--- a/plugin/color.py
+++ b/plugin/color.py
@@ -1,10 +1,12 @@
 from .core.edit import parse_text_edit
+from .core.protocol import ColorInformation
 from .core.protocol import ColorPresentation
 from .core.protocol import ColorPresentationParams
 from .core.protocol import Request
 from .core.registry import LspTextCommand
 from .core.typing import List
 from .core.views import range_to_region
+from .core.views import text_document_identifier
 import sublime
 
 
@@ -12,11 +14,16 @@ class LspColorPresentationCommand(LspTextCommand):
 
     capability = 'colorProvider'
 
-    def run(self, edit: sublime.Edit, params: ColorPresentationParams) -> None:
+    def run(self, edit: sublime.Edit, color_information: ColorInformation) -> None:
         session = self.best_session(self.capability)
         if session:
             self._version = self.view.change_count()
-            self._range = params['range']
+            self._range = color_information['range']
+            params = {
+                'textDocument': text_document_identifier(self.view),
+                'color': color_information['color'],
+                'range': self._range
+            }  # type: ColorPresentationParams
             session.send_request_async(Request.colorPresentation(params, self.view), self._handle_response_async)
 
     def want_event(self) -> bool:

--- a/plugin/color.py
+++ b/plugin/color.py
@@ -41,10 +41,11 @@ class LspColorPresentationCommand(LspTextCommand):
             elif item['label'] == old_text:
                 continue
             self._filtered_response.append(item)
-        window.show_quick_panel(
-            [sublime.QuickPanelItem(item['label']) for item in self._filtered_response],
-            self._on_select,
-            placeholder="Change color format")
+        if self._filtered_response:
+            window.show_quick_panel(
+                [sublime.QuickPanelItem(item['label']) for item in self._filtered_response],
+                self._on_select,
+                placeholder="Change color format")
 
     def _on_select(self, index: int) -> None:
         if index > -1:

--- a/plugin/color.py
+++ b/plugin/color.py
@@ -1,0 +1,50 @@
+from .core.edit import parse_text_edit
+from .core.protocol import ColorPresentation
+from .core.protocol import ColorPresentationParams
+from .core.protocol import Request
+from .core.registry import LspTextCommand
+from .core.typing import List, Optional
+from .core.views import range_to_region
+import sublime
+
+
+class LspColorPresentationCommand(LspTextCommand):
+
+    capability = 'colorProvider'
+
+    def run(self, edit: sublime.Edit, params: ColorPresentationParams, event: Optional[dict] = None) -> None:
+        session = self.best_session(self.capability)
+        if session:
+            self._version = self.view.change_count()
+            self._range = params['range']
+            session.send_request_async(Request.colorPresentation(params, self.view), self._handle_response_async)
+
+    def _handle_response_async(self, response: List[ColorPresentation]) -> None:
+        if not response:
+            return
+        window = self.view.window()
+        if not window:
+            return
+        if self._version != self.view.change_count():
+            return
+        old_text = self.view.substr(range_to_region(self._range, self.view))
+        self._filtered_response = []  # type: List[ColorPresentation]
+        for item in response:
+            # Filter out items that would apply no change
+            text_edit = item.get('textEdit')
+            if text_edit:
+                if text_edit['range'] == self._range and text_edit['newText'] == old_text:
+                    continue
+            elif item['label'] == old_text:
+                continue
+            self._filtered_response.append(item)
+        window.show_quick_panel(
+            [sublime.QuickPanelItem(item['label']) for item in self._filtered_response],
+            self._on_select,
+            placeholder="Change color format")
+
+    def _on_select(self, index: int) -> None:
+        if index > -1:
+            color_pres = self._filtered_response[index]
+            text_edit = color_pres.get('textEdit') or {'range': self._range, 'newText': color_pres['label']}
+            self.view.run_command('lsp_apply_document_edit', {'changes': [parse_text_edit(text_edit, self._version)]})

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -5881,6 +5881,10 @@ class Request:
         return Request('textDocument/documentColor', params, view)
 
     @classmethod
+    def colorPresentation(cls, params: ColorPresentationParams, view: sublime.View) -> 'Request':
+        return Request('textDocument/colorPresentation', params, view)
+
+    @classmethod
     def willSaveWaitUntil(cls, params: Mapping[str, Any], view: sublime.View) -> 'Request':
         return Request("textDocument/willSaveWaitUntil", params, view)
 

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -813,13 +813,7 @@ def color_to_hex(color: Color) -> str:
 
 
 def lsp_color_to_html(view: sublime.View, color_info: ColorInformation) -> str:
-    command = sublime.command_url('lsp_color_presentation', {
-        'params': {
-            'textDocument': text_document_identifier(view),
-            'color': color_info['color'],
-            'range': color_info['range']
-        }
-    })
+    command = sublime.command_url('lsp_color_presentation', {'color_information': color_info})
     return COLOR_BOX_HTML.format(command=command, color=color_to_hex(color_info['color']))
 
 

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -803,12 +803,12 @@ COLOR_BOX_HTML = """
 
 
 def color_to_hex(color: Color) -> str:
-    red = int(color['red'] * 255)
-    green = int(color['green'] * 255)
-    blue = int(color['blue'] * 255)
+    red = round(color['red'] * 255)
+    green = round(color['green'] * 255)
+    blue = round(color['blue'] * 255)
     alpha_dec = color['alpha']
     if alpha_dec < 1:
-        return "#{:02x}{:02x}{:02x}{:02x}".format(red, green, blue, int(alpha_dec * 255))
+        return "#{:02x}{:02x}{:02x}{:02x}".format(red, green, blue, round(alpha_dec * 255))
     return "#{:02x}{:02x}{:02x}".format(red, green, blue)
 
 

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -795,6 +795,7 @@ COLOR_BOX_HTML = """
         margin-top: 0.1em;
         border: 1px solid color(var(--foreground) alpha(0.25));
         background-color: {color};
+        text-decoration: none;
     }}
 </style>
 <body id='lsp-color-box'>

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -355,6 +355,9 @@ class SessionBuffer:
             )
 
     def _on_color_boxes_async(self, view: sublime.View, response: List[ColorInformation]) -> None:
+        if response is None:  # Guard against spec violation from certain language servers
+            self.color_phantoms.update([])
+            return
         self.color_phantoms.update([lsp_color_to_phantom(view, color_info) for color_info in response])
 
     # --- textDocument/documentLink ------------------------------------------------------------------------------------

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -1,5 +1,6 @@
 from .core.panels import is_panel_open
 from .core.panels import PanelName
+from .core.protocol import ColorInformation
 from .core.protocol import Diagnostic
 from .core.protocol import DiagnosticSeverity
 from .core.protocol import DocumentLink
@@ -353,9 +354,8 @@ class SessionBuffer:
                 self._if_view_unchanged(self._on_color_boxes_async, version)
             )
 
-    def _on_color_boxes_async(self, view: sublime.View, response: Any) -> None:
-        color_infos = response if response else []
-        self.color_phantoms.update([lsp_color_to_phantom(view, color_info) for color_info in color_infos])
+    def _on_color_boxes_async(self, view: sublime.View, response: List[ColorInformation]) -> None:
+        self.color_phantoms.update([lsp_color_to_phantom(view, color_info) for color_info in response])
 
     # --- textDocument/documentLink ------------------------------------------------------------------------------------
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -329,7 +329,7 @@ class ViewsTest(DeferrableTestCase):
             }
         ]
         phantom = lsp_color_to_phantom(self.view, response[0])
-        self.assertEqual(phantom.content, lsp_color_to_html(response[0]))
+        self.assertEqual(phantom.content, lsp_color_to_html(self.view, response[0]))
         self.assertEqual(phantom.region, range_to_region(response[0]["range"], self.view))
 
     def test_document_color_params(self) -> None:


### PR DESCRIPTION
This runs the `textDocument/colorPresentation` request when clicking on a color box, and shows the results in a quick panel. I think it is better to apply the change into the file only after selecting one of the quick panel entries, rather than immediately like it's implemented in the VSCode color picker when cycling through the different color formats. Because the conversion from RGB to HSL/HWB and back again might alter the original color (e.g. `#dddddd` -> `hsl(0, 0%, 87%)` -> `hwb(0 87% 13%)` -> `rgb(222, 222, 222)` -> `#dedede`).

There is no special server capability for this request by the way, so we can't decide beforehand whether or not it is supported by the server and is useful to make the color box clickable. (But maybe it's expected that servers that have the colorProvider capability, which is used for `textDocument/documentColor`, should also support colorPresentation.)

And there can be optional "additionalTextEdits" in the response, which are ignored in this PR. I don't really know what should be the use of those; maybe it's to replace all occurencies of the particular color. But that seems rather dangerous or unexpected for the user to me, so I guess it's better to leave this out for now.

Note that you can observe two color boxes for a very short amount of time after selecting a quick panel entry, but this seems unrelated to this pull request. It's probably some kind of bug in the code how the color box phantoms are updated, or in the lsp_apply_document_edit command (or in how these two situations work together).

And in case a minihtml color picker gets implemented at a later point, this functionality could be adjusted with minimal changes to be invoked from a link in the color picker.