### PR TITLE
ignore background files for toggling diagnostics panel on save

### DIFF
--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -287,7 +287,9 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             self._do_code_actions()
         self._update_diagnostic_in_status_bar_async()
         if self.view.change_count() == self._change_count_on_last_save:
-            self._toggle_diagnostics_panel_if_needed_async()
+            window = self.view.window()
+            if window and window.active_view() == self.view:
+                self._toggle_diagnostics_panel_if_needed_async()
 
     def _update_diagnostic_in_status_bar_async(self) -> None:
         if userprefs().show_diagnostics_in_view_status:
@@ -406,11 +408,9 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
                 break
         if is_panel_open(window, PanelName.Diagnostics):
             if not has_relevant_diagnostcs:
-                self._change_count_on_last_save = -1
                 self._manager.hide_diagnostics_panel_async()
         else:
             if has_relevant_diagnostcs:
-                self._change_count_on_last_save = -1
                 self._manager.show_diagnostics_panel_async()
 
     def on_close(self) -> None:

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -406,9 +406,11 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
                 break
         if is_panel_open(window, PanelName.Diagnostics):
             if not has_relevant_diagnostcs:
+                self._change_count_on_last_save = -1
                 self._manager.hide_diagnostics_panel_async()
         else:
             if has_relevant_diagnostcs:
+                self._change_count_on_last_save = -1
                 self._manager.show_diagnostics_panel_async()
 
     def on_close(self) -> None:

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -286,10 +286,10 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         if userprefs().show_code_actions:
             self._do_code_actions()
         self._update_diagnostic_in_status_bar_async()
-        if self.view.change_count() == self._change_count_on_last_save:
-            window = self.view.window()
-            if window and window.active_view() == self.view:
-                self._toggle_diagnostics_panel_if_needed_async()
+        window = self.view.window()
+        is_active_view = window and window.active_view() == self.view
+        if is_active_view and self.view.change_count() == self._change_count_on_last_save:
+            self._toggle_diagnostics_panel_if_needed_async()
 
     def _update_diagnostic_in_status_bar_async(self) -> None:
         if userprefs().show_diagnostics_in_view_status:


### PR DESCRIPTION
The issue was that files in the background have received new diagnostics and since the "last save change count" has still matched, that has triggered the panel to hide or open.

To fix, reset the "last save change count" after showing or hiding the panel so that it's only relevant again after next save.

It was reproducible by:
 1. having an error in one file and saving it
 2. hiding the panel
 3. switching to another file with no errors and saving it

The file saved in 1 would receive updated diagnostics and the logic would pop the panel open again.

(Of course those steps depend on what servers are used and whether saves in certain files trigger diagnostics in other files)