### PR TITLE
Allow empty string for workspace symbol request

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -45,6 +45,10 @@
         "command": "lsp_document_symbols"
       },
       {
+        "caption": "LSP: Goto Symbol In Project…",
+        "command": "lsp_workspace_symbols"
+      },
+      {
         "caption": "LSP: Goto Definition…",
         "command": "lsp_symbol_definition"
       },

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -5889,8 +5889,8 @@ class Request:
         return Request("textDocument/willSaveWaitUntil", params, view)
 
     @classmethod
-    def documentSymbols(cls, params: Mapping[str, Any], view: sublime.View) -> 'Request':
-        return Request("textDocument/documentSymbol", params, view)
+    def documentSymbols(cls, params: DocumentSymbolParams, view: sublime.View) -> 'Request':
+        return Request("textDocument/documentSymbol", params, view, progress=True)
 
     @classmethod
     def documentHighlight(cls, params: Mapping[str, Any], view: sublime.View) -> 'Request':
@@ -5927,6 +5927,10 @@ class Request:
     @classmethod
     def resolveInlayHint(cls, params: InlayHint, view: sublime.View) -> 'Request':
         return Request('inlayHint/resolve', params, view)
+
+    @classmethod
+    def workspaceSymbol(cls, params: WorkspaceSymbolParams) -> 'Request':
+        return Request("workspace/symbol", params, None, progress=True)
 
     @classmethod
     def shutdown(cls) -> 'Request':

--- a/plugin/symbols.py
+++ b/plugin/symbols.py
@@ -231,7 +231,7 @@ class LspWorkspaceSymbolsCommand(LspTextCommand):
     def input(self, _args: Any) -> sublime_plugin.TextInputHandler:
         return SymbolQueryInput()
 
-    def run(self, edit: sublime.Edit, symbol_query_input: str) -> None:
+    def run(self, edit: sublime.Edit, symbol_query_input: str, event: Optional[Any] = None) -> None:
         session = self.best_session(self.capability)
         if session:
             self.weaksession = weakref.ref(session)

--- a/plugin/symbols.py
+++ b/plugin/symbols.py
@@ -100,9 +100,8 @@ class LspDocumentSymbolsCommand(LspTextCommand):
         self.view.settings().set(SUPPRESS_INPUT_SETTING_KEY, True)
         session = self.best_session(self.capability)
         if session:
-            params = {"textDocument": text_document_identifier(self.view)}
             session.send_request(
-                Request("textDocument/documentSymbol", params, self.view, progress=True),
+                Request.documentSymbols({"textDocument": text_document_identifier(self.view)}, self.view),
                 lambda response: sublime.set_timeout(lambda: self.handle_response(response)),
                 lambda error: sublime.set_timeout(lambda: self.handle_response_error(error)))
 
@@ -222,7 +221,7 @@ class SymbolQueryInput(sublime_plugin.TextInputHandler):
         return False
 
     def placeholder(self) -> str:
-        return "Symbol"
+        return "Enter symbol name"
 
 
 class LspWorkspaceSymbolsCommand(LspTextCommand):
@@ -235,11 +234,11 @@ class LspWorkspaceSymbolsCommand(LspTextCommand):
     def run(self, edit: sublime.Edit, symbol_query_input: str) -> None:
         session = self.best_session(self.capability)
         if session:
-            params = {"query": symbol_query_input}
-            request = Request("workspace/symbol", params, None, progress=True)
             self.weaksession = weakref.ref(session)
-            session.send_request(request, lambda r: self._handle_response(
-                symbol_query_input, r), self._handle_error)
+            session.send_request(
+                Request.workspaceSymbol({"query": symbol_query_input}),
+                lambda r: self._handle_response(symbol_query_input, r),
+                self._handle_error)
 
     def _open_file(self, symbols: List[SymbolInformation], index: int) -> None:
         if index != -1:
@@ -256,7 +255,7 @@ class LspWorkspaceSymbolsCommand(LspTextCommand):
                     list(map(symbol_information_to_quick_panel_item, matches)),
                     lambda i: self._open_file(matches, i))
         else:
-            sublime.message_dialog("No matches found for query string: '{}'".format(query))
+            sublime.message_dialog("No matches found for query: '{}'".format(query))
 
     def _handle_error(self, error: Dict[str, Any]) -> None:
         reason = error.get("message", "none provided by server :(")

--- a/plugin/symbols.py
+++ b/plugin/symbols.py
@@ -221,9 +221,6 @@ class SymbolQueryInput(sublime_plugin.TextInputHandler):
     def want_event(self) -> bool:
         return False
 
-    def validate(self, txt: str) -> bool:
-        return txt != ""
-
     def placeholder(self) -> str:
         return "Symbol"
 
@@ -236,14 +233,13 @@ class LspWorkspaceSymbolsCommand(LspTextCommand):
         return SymbolQueryInput()
 
     def run(self, edit: sublime.Edit, symbol_query_input: str) -> None:
-        if symbol_query_input:
-            session = self.best_session(self.capability)
-            if session:
-                params = {"query": symbol_query_input}
-                request = Request("workspace/symbol", params, None, progress=True)
-                self.weaksession = weakref.ref(session)
-                session.send_request(request, lambda r: self._handle_response(
-                    symbol_query_input, r), self._handle_error)
+        session = self.best_session(self.capability)
+        if session:
+            params = {"query": symbol_query_input}
+            request = Request("workspace/symbol", params, None, progress=True)
+            self.weaksession = weakref.ref(session)
+            session.send_request(request, lambda r: self._handle_response(
+                symbol_query_input, r), self._handle_error)
 
     def _open_file(self, symbols: List[SymbolInformation], index: int) -> None:
         if index != -1:


### PR DESCRIPTION
```
/**
 * The parameters of a Workspace Symbol Request.
 */
interface WorkspaceSymbolParams extends WorkDoneProgressParams,
    PartialResultParams {
    /**
     * A query string to filter symbols by. Clients may send an empty
     * string here to request all symbols.
     */
    query: string;
}
```

closes #1008 