### PR TITLE
Do not show type errors in LSP-* plugins

### DIFF
--- a/plugin/core/typing.py
+++ b/plugin/core/typing.py
@@ -1,6 +1,6 @@
 import sys
 
-if sys.version_info >= (3, 11, 0):
+if sys.version_info >= (3, 8, 0):
 
     from enum import Enum, IntEnum, IntFlag
     from typing import Any
@@ -16,10 +16,8 @@ if sys.version_info >= (3, 11, 0):
     from typing import List
     from typing import Literal
     from typing import Mapping
-    from typing import NotRequired
     from typing import Optional
     from typing import Protocol
-    from typing import Required
     from typing import Sequence
     from typing import Set
     from typing import Tuple
@@ -120,11 +118,15 @@ else:
     class Sequence(Type):  # type: ignore
         pass
 
+    def TypeVar(*args, **kwargs) -> Any:  # type: ignore
+        return object
+
+if sys.version_info >= (3, 11, 0):
+    from typing import NotRequired
+    from typing import Required
+else:
     class Required(Type):  # type: ignore
         pass
 
     class NotRequired(Type):  # type: ignore
         pass
-
-    def TypeVar(*args, **kwargs) -> Any:  # type: ignore
-        return object


### PR DESCRIPTION
**Currently** 
LSP-* plugins that don't have `pyrightconfig.json` with python version 3.11 set,
have type errors for every type,
until they create a `pyrightconfig.json` with a python version 3.11 set:

![image](https://user-images.githubusercontent.com/22029477/193404107-5447cc42-1ef2-4fa3-8f2a-32ff2316aaef.png)

**With this change**

- If the LSP-* plugin doesn't use `NotRequired` and `Required` types, we will no longer show `Expected class type but received "Any"` type errors in that plugin.
- If the LSP-* plugin use `NotRequired` and `Required` types, but the plugin do not have a `pyrightconfig.json` with python version 3.11 set, LSP will show the following error:
![image](https://user-images.githubusercontent.com/22029477/193404019-a760420c-3206-4848-b9dc-ddb6858c7e7d.png)

In order for a LSP-* plugin to use `NotRequired` or `Required` types,
they must create a `pyrightconfig.json` file  that looks like this:
```
{
    "pythonVersion": "3.11"
}

```

![image](https://user-images.githubusercontent.com/22029477/193404178-97214958-3c29-4c37-855a-037c4646db97.png)
