### PR TITLE
Only show quickfix code actions in the view

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -32,11 +32,6 @@
                 "caption": "Code Action…"
             },
             {
-                "command": "lsp_code_actions",
-                "args": {"only_kinds": ["source"]},
-                "caption": "Source Action…"
-            },
-            {
                 "command": "lsp_format_document",
                 "caption": "Format File"
             },

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -17,6 +17,15 @@
       {
         "caption": "LSP: Format Selection",
         "command": "lsp_format_document_range"
+      },
+      {
+        "caption": "LSP: Code Action…",
+        "command": "lsp_code_actions"
+      },
+      {
+        "caption": "LSP: Source Action…",
+        "command": "lsp_code_actions",
+        "args": {"only_kinds": ["source"]}
       }
     ]
   },

--- a/docs/src/features.md
+++ b/docs/src/features.md
@@ -136,7 +136,9 @@ Code Actions are an umbrella term for "Quick Fixes" and "Refactorings". They are
 
 Formatting is different from Code Actions, because Formatting is supposed to _not_ mutate the abstract syntax tree of the file, only move around white space. Any Code Action will mutate the abstract syntax tree.
 
-This package presents Code Actions as a bluish clickable annotation positioned to the right of the viewport. Alternatively, they can be presented as a light bulb in the Gutter Area.
+This package presents "Quick Fix" Code Actions as a bluish clickable annotation positioned to the right of the viewport. Alternatively, they can be presented as a light bulb in the Gutter Area.
+
+Other types of Code Actions can be invoked from the "Edit" main menu or from the context menu.
 
 Sublime Text has no concept of Code Actions.
 

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -327,7 +327,7 @@ class DocumentHighlightKind(IntEnum):
     """ Write-access of a symbol, like writing to a variable. """
 
 
-class CodeActionKind(Enum, str):
+class CodeActionKind(str, Enum):
     """ A set of predefined code action kinds """
     Empty = ''
     """ Empty kind. """

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -327,7 +327,7 @@ class DocumentHighlightKind(IntEnum):
     """ Write-access of a symbol, like writing to a variable. """
 
 
-class CodeActionKind(Enum):
+class CodeActionKind(Enum, str):
     """ A set of predefined code action kinds """
     Empty = ''
     """ Empty kind. """

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -337,6 +337,7 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
                         CodeActionKind.RefactorInline,
                         CodeActionKind.RefactorRewrite,
                         CodeActionKind.SourceOrganizeImports,
+                        CodeActionKind.SourceFixAll,
                     ]
                 }
             },


### PR DESCRIPTION
As a result of the recent discussions I think the consensus is that LSP should filter code action kinds from the server response and only show "quickfix" actions in the view (as annotation or lightbulb).

I've also moved the "Source Action..." entry from the context menu to the "Edit" main menu, which I think is a better place for that item, but maybe it's open for discussion.

Still not addressed in this PR:

* When running "Source Actions...", the actions from the response are not filtered. This means that invoking "Source Action..." might also show other actions (for example Julia server can return "refactor" and other actions, and seems to entirely ignore `CodeActionContext.only`). I think Sublime LSP should filter the response and only show actions with "source" kind and probably also actions that have no kind.
* "Source Action..." still uses the cursor for the requested range - but it probably is ignored anyways by the servers and doesn't matter
* Apparently needs fix in https://github.com/sublimelsp/lsp-python-types - not sure how to do that