### PR TITLE
Fix short color box rendering bug after color presentation change

### DIFF
--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -813,14 +813,14 @@ def color_to_hex(color: Color) -> str:
     return "#{:02x}{:02x}{:02x}".format(red, green, blue)
 
 
-def lsp_color_to_html(view: sublime.View, color_info: ColorInformation) -> str:
+def lsp_color_to_html(color_info: ColorInformation) -> str:
     command = sublime.command_url('lsp_color_presentation', {'color_information': color_info})
     return COLOR_BOX_HTML.format(command=command, color=color_to_hex(color_info['color']))
 
 
 def lsp_color_to_phantom(view: sublime.View, color_info: ColorInformation) -> sublime.Phantom:
     region = range_to_region(color_info['range'], view)
-    return sublime.Phantom(region, lsp_color_to_html(view, color_info), sublime.LAYOUT_INLINE)
+    return sublime.Phantom(region, lsp_color_to_html(color_info), sublime.LAYOUT_INLINE)
 
 
 def document_color_params(view: sublime.View) -> Dict[str, Any]:

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -350,7 +350,8 @@ class SessionBuffer:
         if response is None:  # Guard against spec violation from certain language servers
             self.color_phantoms.update([])
             return
-        self.color_phantoms.update([lsp_color_to_phantom(view, color_info) for color_info in response])
+        phantoms = [lsp_color_to_phantom(view, color_info) for color_info in response]
+        sublime.set_timeout(lambda: self.color_phantoms.update(phantoms))
 
     # --- textDocument/documentLink ------------------------------------------------------------------------------------
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -329,7 +329,7 @@ class ViewsTest(DeferrableTestCase):
             }
         ]
         phantom = lsp_color_to_phantom(self.view, response[0])
-        self.assertEqual(phantom.content, lsp_color_to_html(self.view, response[0]))
+        self.assertEqual(phantom.content, lsp_color_to_html(response[0]))
         self.assertEqual(phantom.region, range_to_region(response[0]["range"], self.view))
 
     def test_document_color_params(self) -> None:


### PR DESCRIPTION
Doing the phantoms update on the main thread (like it's already done with the inlay hints phantoms) fixes the double color box flash after selecting another color format from the quick panel.