### PR TITLE
fix issues with restarting servers

### DIFF
--- a/plugin/configuration.py
+++ b/plugin/configuration.py
@@ -46,8 +46,6 @@ class LspDisableLanguageServerGloballyCommand(sublime_plugin.WindowCommand):
         if index > -1:
             config_name = self._items[index]
             client_configs.disable(config_name)
-            wm = windows.lookup(self.window)
-            sublime.set_timeout_async(lambda: wm._end_sessions_async(config_name))
 
 
 class LspDisableLanguageServerInProjectCommand(sublime_plugin.WindowCommand):

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -157,10 +157,7 @@ class LspRestartServerCommand(LspTextCommand):
             config_name = self._config_names[index]
             if not config_name:
                 return
-            self._wm._end_sessions_async(config_name)
-            listener = windows.listener_for_view(self.view)
-            if listener:
-                self._wm.register_listener_async(listener)
+            self._wm.restart_sessions_async(config_name)
 
         sublime.set_timeout_async(run_async)
 


### PR DESCRIPTION
There were issues with restarting servers when there were more than one views using the same session and the corresponding server was restarted. Only the active view would start the session again and on other views the session would not start.

Fixed by using `WindowManager.restart_sessions_async` which re-registers all view listeners rather than the (internal) `WindowManager._end_sessions_async` and manually registering just the active view listener.

Also removed unnecessary `WindowManager._end_sessions_async` call after disabling server globally as ending the sessions is already handled on disabling the config (saving settings).