### PR TITLE
Add `$line` and `$character` expansion variables

### DIFF
--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -50,5 +50,7 @@ You can include special variables in the `command_args` array that will be autom
 | `"$selection_begin"` or `"${selection_begin}"` | int | Character offset of the begin of the (topmost) selection |
 | `"$selection_end"` or `"${selection_end}"` | int | Character offset of the end of the (topmost) selection |
 | `"$position"` or `"${position}"` | object | JSON object `{ 'line': int, 'character': int }` of the (topmost) cursor position, see [Position](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#position) |
+| `"$line"` or `"${line}"` | int | Zero-based line number of the (topmost) cursor position, see [Position](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#position) |
+| `"$character"` or `"${character}"` | int | Zero-based character offset relative to the current line of the (topmost) cursor position, see [Position](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#position) |
 | `"$range"` or `"${range}"` | object | JSON object with `'start'` and `'end'` positions of the (topmost) selection, see [Range](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#range) |
 | `"$text_document_position"` or `"${text_document_position}"` | object | JSON object with `'textDocument'` and `'position'` of the (topmost) selection, see [TextDocumentPositionParams](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentPositionParams) |

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -86,6 +86,10 @@ class LspExecuteCommand(LspTextCommand):
                     command_args[i] = region.end()
                 elif arg in ["$position", "${position}"]:
                     command_args[i] = offset_to_point(view, region.b).to_lsp()
+                elif arg in ["$line", "${line}"]:
+                    command_args[i] = offset_to_point(view, region.b).row
+                elif arg in ["$character", "${character}"]:
+                    command_args[i] = offset_to_point(view, region.b).col
                 elif arg in ["$range", "${range}"]:
                     command_args[i] = region_to_range(view, region)
                 elif arg in ["$text_document_position", "${text_document_position}"]:


### PR DESCRIPTION
Some language server commands can only take the `line` and/or `character` integers individually instead of the entire `position` object. Allowing those variables to also be expanded adds to the flexibility of individual LSP plugins.

This was tested locally using https://github.com/sublimelsp/LSP-elixir and https://github.com/elixir-lsp/elixir-ls (specifically the `manipulatePipes` command: https://github.com/elixir-lsp/elixir-ls/blob/a4bd85e/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes.ex#L21)