### PR TITLE
Improvements for DocumentLink in hover popup

### DIFF
--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -247,7 +247,7 @@ class LspHoverCommand(LspTextCommand):
             target = link.get("target")
             label = "Follow Link" if link.get("target", "file:").startswith("file:") else "Open in Browser"
             title = link.get("tooltip")
-            tooltip = 'title="{}"'.format(html.escape(title)) if title else ""
+            tooltip = ' title="{}"'.format(html.escape(title)) if title else ""
             region = range_to_region(link["range"], self.view)
             return '<a href="{}"{}>{}</a>'.format(html.escape(target), tooltip, label) if target else label, region
         else:


### PR DESCRIPTION
I think it would be better for the popup on hover over a DocumentLink, to already indicate that it will be opened in a browser if that is the case. Otherwise it could be a bit surprising for users, because most of the time these are links to a location in another file.

-> Adjust label to "Open in Browser" if the target is not a file uri.

And in case there are multiple sessions at the same time, which all provide DocumentLinks, then combine them into a single link and open a quick panel with the target URIs to choose from when clicked, instead of just putting multiple links into the hover popup.