### PR TITLE
Don't trigger code action requests for background views

### DIFF
--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -396,7 +396,9 @@ class SessionBuffer:
 
     # --- textDocument/publishDiagnostics ------------------------------------------------------------------------------
 
-    def on_diagnostics_async(self, raw_diagnostics: List[Diagnostic], version: Optional[int]) -> None:
+    def on_diagnostics_async(
+        self, raw_diagnostics: List[Diagnostic], version: Optional[int], visible_session_views: Set[SessionViewProtocol]
+    ) -> None:
         data_per_severity = {}  # type: Dict[Tuple[int, bool], DiagnosticSeverityData]
         view = self.some_view()
         if view is None:
@@ -422,17 +424,24 @@ class SessionBuffer:
                 else:
                     data.regions.append(region)
                 diagnostics.append((diagnostic, region))
-            self._publish_diagnostics_to_session_views(diagnostics_version, diagnostics, data_per_severity)
+            self._publish_diagnostics_to_session_views(
+                diagnostics_version, diagnostics, data_per_severity, visible_session_views)
 
     def _publish_diagnostics_to_session_views(
         self,
         diagnostics_version: int,
         diagnostics: List[Tuple[Diagnostic, sublime.Region]],
         data_per_severity: Dict[Tuple[int, bool], DiagnosticSeverityData],
+        visible_session_views: Set[SessionViewProtocol],
     ) -> None:
 
         def present() -> None:
-            self._present_diagnostics_async(diagnostics_version, diagnostics, data_per_severity)
+            self.diagnostics_version = diagnostics_version
+            self.diagnostics = diagnostics
+            self.data_per_severity = data_per_severity
+            self.diagnostics_are_visible = bool(diagnostics)
+            for sv in self.session_views:
+                sv.present_diagnostics_async(sv in visible_session_views)
 
         self.diagnostics_debouncer.cancel_pending()
 
@@ -456,19 +465,6 @@ class SessionBuffer:
                     condition=lambda: bool(view and view.is_valid() and view.change_count() == diagnostics_version),
                     async_thread=True
                 )
-
-    def _present_diagnostics_async(
-        self,
-        diagnostics_version: int,
-        diagnostics: List[Tuple[Diagnostic, sublime.Region]],
-        data_per_severity: Dict[Tuple[int, bool], DiagnosticSeverityData],
-    ) -> None:
-        self.diagnostics_version = diagnostics_version
-        self.diagnostics = diagnostics
-        self.data_per_severity = data_per_severity
-        self.diagnostics_are_visible = bool(diagnostics)
-        for sv in self.session_views:
-            sv.present_diagnostics_async()
 
     # --- textDocument/semanticTokens ----------------------------------------------------------------------------------
 

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -11,7 +11,7 @@ from .core.sessions import AbstractViewListener
 from .core.sessions import Session
 from .core.settings import userprefs
 from .core.types import debounced
-from .core.typing import Any, Iterable, List, Tuple, Optional, Dict, Generator
+from .core.typing import Any, Iterable, List, Set, Tuple, Optional, Dict, Generator
 from .core.views import DIAGNOSTIC_SEVERITY
 from .core.views import text_document_identifier
 from .session_buffer import SessionBuffer
@@ -270,7 +270,7 @@ class SessionView:
                 return 'markup.{}.lsp'.format(k.lower())
         return None
 
-    def present_diagnostics_async(self) -> None:
+    def present_diagnostics_async(self, is_view_visible: bool) -> None:
         flags = userprefs().diagnostics_highlight_style_flags()  # for single lines
         multiline_flags = None if userprefs().show_multiline_diagnostics_highlights else sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE  # noqa: E501
         level = userprefs().show_diagnostics_severity_level
@@ -279,7 +279,7 @@ class SessionView:
             self._draw_diagnostics(sev, level, multiline_flags or DIAGNOSTIC_SEVERITY[sev - 1][5], True)
         listener = self.listener()
         if listener:
-            listener.on_diagnostics_updated_async()
+            listener.on_diagnostics_updated_async(is_view_visible)
 
     def _draw_diagnostics(self, severity: int, max_severity_level: int, flags: int, multiline: bool) -> None:
         ICON_FLAGS = sublime.HIDE_ON_MINIMAP | sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -11,7 +11,7 @@ from .core.sessions import AbstractViewListener
 from .core.sessions import Session
 from .core.settings import userprefs
 from .core.types import debounced
-from .core.typing import Any, Iterable, List, Set, Tuple, Optional, Dict, Generator
+from .core.typing import Any, Iterable, List, Tuple, Optional, Dict, Generator
 from .core.views import DIAGNOSTIC_SEVERITY
 from .core.views import text_document_identifier
 from .session_buffer import SessionBuffer


### PR DESCRIPTION
Servers like typescript trigger `textDocument/publishDiagnostics` for all open files on making any changes. Our `DocumentSyncListener` triggered [code action request](https://github.com/sublimelsp/LSP/blob/439b01efe862497ee67dedb7d7d9662521c12537/plugin/documents.py#L285-L286) in that case.

Changed so that code action request is only made if the view is visible.

Since the code action response can be affected by changed diagnostics, make sure that the code action request is then also made when view is activated later.

We should have been triggering code action request on view activation anyway as otherwise we have relied on `textDocument/publishDiagnostics` triggering it which is not guaranteed.

Also made sure that `on_load_async` triggers `on_activated_async` which triggers code actions/code lenses/semantic tokens because when file is initially focused the view is not registered yet so we have missed all the logic currently in `on_activated_async`.

Fixes #2101