### PR TITLE
Ignore diagnostics for files in folder_exclude_patterns

### DIFF
--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -378,6 +378,8 @@ class WindowManager(Manager):
                 for pattern in folder.get('folder_exclude_patterns', []):
                     if pattern.startswith('//'):
                         patterns.append(sublime_pattern_to_glob(pattern, True, folder['path']))
+                    elif pattern.startswith('/'):
+                        patterns.append(sublime_pattern_to_glob(pattern, True))
                     else:
                         patterns.append(sublime_pattern_to_glob('//' + pattern, True, folder['path']))
                         patterns.append(sublime_pattern_to_glob('//**/' + pattern, True, folder['path']))

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -24,6 +24,7 @@ from .settings import userprefs
 from .transports import create_transport
 from .types import ClientConfig
 from .types import matches_pattern
+from .types import sublime_pattern_to_glob
 from .typing import Optional, Any, Dict, Deque, List, Generator, Tuple, Union
 from .url import parse_uri
 from .views import extract_variables
@@ -370,7 +371,17 @@ class WindowManager(Manager):
             return "matches a pattern in binary_file_patterns"
         if matches_pattern(path, settings.get("file_exclude_patterns")):
             return "matches a pattern in file_exclude_patterns"
-        if matches_pattern(path, settings.get("folder_exclude_patterns")):
+        patterns = [sublime_pattern_to_glob(pattern, True) for pattern in settings.get("folder_exclude_patterns") or []]
+        project_data = self.window.project_data()
+        if project_data:
+            for folder in project_data.get('folders', []):
+                for pattern in folder.get('folder_exclude_patterns', []):
+                    if pattern.startswith('//'):
+                        patterns.append(sublime_pattern_to_glob(pattern, True, folder['path']))
+                    else:
+                        patterns.append(sublime_pattern_to_glob('//' + pattern, True, folder['path']))
+                        patterns.append(sublime_pattern_to_glob('//**/' + pattern, True, folder['path']))
+        if matches_pattern(path, patterns):
             return "matches a pattern in folder_exclude_patterns"
         return None
 


### PR DESCRIPTION
Files within folders excluded by `"folder_exclude_patterns"` are not shown in the sidebar and can't be opened via "Goto Anything...", so it's probably better to ignore diagnostics for those files.

The line which was removed in the diff did basically nothing, because fnmatch would never match just a folder name or path segment from the "folder_exclude_patterns" if not adapted to glob pattern conventions.