### PR TITLE
Add language id for Django templates

### DIFF
--- a/language-ids.sublime-settings
+++ b/language-ids.sublime-settings
@@ -90,6 +90,7 @@
     "source.yaml.sublime.syntax": "yaml", // https://github.com/SublimeText/PackageDev
     "source.yaml.yarn": "yaml", // https://github.com/SublimeText/AFileIcon
     "text.advanced_csv": "csv", // https://github.com/SublimeText/AFileIcon
+    "text.django": "html", // https://github.com/willstott101/django-sublime-syntax
     "text.html.basic": "html",
     "text.html.elixir": "html",  // https://github.com/elixir-editors/elixir-tmbundle
     "text.html.markdown.academicmarkdown": "markdown", // https://github.com/mangecoeur/AcademicMarkdown


### PR DESCRIPTION
I wondered why LSP wasn't working for my [Django](https://djangoproject.com) HTML templates. After I followed the steps outlined in https://github.com/sublimelsp/LSP-tailwindcss/issues/47 it worked. So here's a pull request so other people don't have to customize their configs to make it work.