### PR TITLE
Combine file and range formatting entries in context menu

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -42,12 +42,7 @@
                 "caption": "Source Action…"
             },
             {
-                "command": "lsp_format_document",
-                "caption": "Format File"
-            },
-            {
-                "command": "lsp_format_document_range",
-                "caption": "Format Selection"
+                "command": "lsp_format"
             },
             {
                 "command": "lsp_expand_selection",

--- a/boot.py
+++ b/boot.py
@@ -41,6 +41,7 @@ from .plugin.documents import DocumentSyncListener
 from .plugin.documents import TextChangeListener
 from .plugin.edit import LspApplyDocumentEditCommand
 from .plugin.execute_command import LspExecuteCommand
+from .plugin.formatting import LspFormatCommand
 from .plugin.formatting import LspFormatDocumentCommand
 from .plugin.formatting import LspFormatDocumentRangeCommand
 from .plugin.goto import LspSymbolDeclarationCommand

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -431,6 +431,11 @@ def first_selection_region(view: sublime.View) -> Optional[sublime.Region]:
         return None
 
 
+def has_single_nonempty_selection(view: sublime.View) -> bool:
+    selections = view.sel()
+    return len(selections) == 1 and not selections[0].empty()
+
+
 def entire_content_region(view: sublime.View) -> sublime.Region:
     return sublime.Region(0, view.size())
 


### PR DESCRIPTION
This is a first step towards cleaning up the context menu (#1983) by combining "Format File" and "Format Selection" into a single item with dynamic label. It also makes the question obsolete whether "Format File" should be included in the context menu or if the main menu entry is enough (https://github.com/sublimelsp/LSP/issues/2066#issuecomment-1256614309).