### PR TITLE
Hide inactive items in context menu

### DIFF
--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -262,7 +262,7 @@ class LspCodeActionsCommand(LspTextCommand):
         point: Optional[int] = None,
         only_kinds: Optional[List[CodeActionKind]] = None
     ) -> bool:
-        if event is not None and 'x' in event:
+        if self.applies_to_context_menu(event):
             return self.is_enabled(event, point)
         return True
 

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -256,6 +256,16 @@ class LspCodeActionsCommand(LspTextCommand):
 
     capability = 'codeActionProvider'
 
+    def is_visible(
+        self,
+        event: Optional[dict] = None,
+        point: Optional[int] = None,
+        only_kinds: Optional[List[CodeActionKind]] = None
+    ) -> bool:
+        if event is not None and 'x' in event:
+            return self.is_enabled(event, point)
+        return True
+
     def run(
         self,
         edit: sublime.Edit,

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -108,6 +108,10 @@ class LspTextCommand(sublime_plugin.TextCommand):
     def want_event(self) -> bool:
         return True
 
+    @staticmethod
+    def applies_to_context_menu(event: Optional[dict]) -> bool:
+        return event is not None and 'x' in event
+
     def get_listener(self) -> Optional[AbstractViewListener]:
         return windows.listener_for_view(self.view)
 

--- a/plugin/goto.py
+++ b/plugin/goto.py
@@ -39,7 +39,7 @@ class LspGotoCommand(LspTextCommand):
         fallback: bool = False,
         group: int = -1
     ) -> bool:
-        if event is not None and 'x' in event:
+        if self.applies_to_context_menu(event):
             return self.is_enabled(event, point, side_by_side, force_group, fallback, group)
         return True
 

--- a/plugin/goto.py
+++ b/plugin/goto.py
@@ -30,6 +30,19 @@ class LspGotoCommand(LspTextCommand):
     ) -> bool:
         return fallback or super().is_enabled(event, point)
 
+    def is_visible(
+        self,
+        event: Optional[dict] = None,
+        point: Optional[int] = None,
+        side_by_side: bool = False,
+        force_group: bool = True,
+        fallback: bool = False,
+        group: int = -1
+    ) -> bool:
+        if event is not None and 'x' in event:
+            return self.is_enabled(event, point, side_by_side, force_group, fallback, group)
+        return True
+
     def run(
         self,
         _: sublime.Edit,

--- a/plugin/references.py
+++ b/plugin/references.py
@@ -39,7 +39,7 @@ class LspSymbolReferencesCommand(LspTextCommand):
         side_by_side: bool = False,
         fallback: bool = False,
     ) -> bool:
-        if event is not None and 'x' in event:
+        if self.applies_to_context_menu(event):
             return self.is_enabled(event, point, side_by_side, fallback)
         return True
 

--- a/plugin/references.py
+++ b/plugin/references.py
@@ -32,6 +32,17 @@ class LspSymbolReferencesCommand(LspTextCommand):
     ) -> bool:
         return fallback or super().is_enabled(event, point)
 
+    def is_visible(
+        self,
+        event: Optional[dict] = None,
+        point: Optional[int] = None,
+        side_by_side: bool = False,
+        fallback: bool = False,
+    ) -> bool:
+        if event is not None and 'x' in event:
+            return self.is_enabled(event, point, side_by_side, fallback)
+        return True
+
     def run(
         self,
         _: sublime.Edit,

--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -64,7 +64,7 @@ class LspSymbolRenameCommand(LspTextCommand):
         event: Optional[dict] = None,
         point: Optional[int] = None
     ) -> bool:
-        if event is not None and 'x' in event:
+        if self.applies_to_context_menu(event):
             return self.is_enabled(new_name, placeholder, position, event, point)
         return True
 

--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -56,6 +56,18 @@ class LspSymbolRenameCommand(LspTextCommand):
             return True
         return super().is_enabled(event, point)
 
+    def is_visible(
+        self,
+        new_name: str = "",
+        placeholder: str = "",
+        position: Optional[int] = None,
+        event: Optional[dict] = None,
+        point: Optional[int] = None
+    ) -> bool:
+        if event is not None and 'x' in event:
+            return self.is_enabled(new_name, placeholder, position, event, point)
+        return True
+
     def input(self, args: dict) -> Optional[sublime_plugin.TextInputHandler]:
         if "new_name" not in args:
             placeholder = args.get("placeholder", "")

--- a/plugin/selection_range.py
+++ b/plugin/selection_range.py
@@ -21,7 +21,7 @@ class LspExpandSelectionCommand(LspTextCommand):
         return fallback or super().is_enabled(event, point)
 
     def is_visible(self, event: Optional[dict] = None, point: Optional[int] = None, fallback: bool = True) -> bool:
-        if event is not None and 'x' in event:
+        if self.applies_to_context_menu(event):
             return self.is_enabled(event, point, fallback)
         return True
 


### PR DESCRIPTION
This is another step towards cleaning up the context menu, by hiding unavailable items there (but not in the main menu).

For the "Expand Selection" command I added a `fallback` argument (default to `True` to preserve current behavior) similar to the "Goto" commands.

I'd personally prefer to eventually remove the submenu and put the items at the top level, maybe with an "LSP:" prefix, so that they can be accessed more quickly. In that case it would probably be better to change the "Expand Selection" `fallback` default to `False`.