### PR TITLE
Format keybindings file

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -6,447 +6,217 @@
     // {
     //     "keys": ["f1"],
     //     "command": "show_overlay",
-    //     "args": {
-    //         "overlay": "command_palette",
-    //         "text": "LSP: ",
-    //     }
+    //     "args": {"overlay": "command_palette", "text": "LSP: "}
     // },
-    // Override native save to handle Code-Actions-On-Save
-    {
-        "command": "lsp_save",
-        "keys": [
-            "primary+s"
-        ],
-        "context": [
-            {
-                "key": "lsp.session_with_capability",
-                "operator": "equal",
-                "operand": "textDocumentSync.willSave | textDocumentSync.willSaveWaitUntil | codeActionProvider.codeActionKinds | documentFormattingProvider | documentRangeFormattingProvider"
-            }
-        ]
-    },
     // Insert/Replace Completions
     {
+        "keys": ["alt+enter"],
         "command": "lsp_commit_completion_with_opposite_insert_mode",
-        "keys": [
-            "alt+enter"
-        ],
         "context": [
-            {
-                "key": "auto_complete_visible",
-                "operator": "equal",
-                "operand": true
-            },
-            {
-                "key": "lsp.session_with_capability",
-                "operator": "equal",
-                "operand": "completionProvider"
-            }
+            {"key": "lsp.session_with_capability", "operand": "completionProvider"},
+            {"key": "auto_complete_visible"}
         ]
     },
     // Save all open files with lsp_save
     // {
-    //     "command": "lsp_save_all",
-    //     "keys": [
-    //         "UNBOUND"
-    //     ]
+    //     "keys": ["UNBOUND"],
+    //     "command": "lsp_save_all"
     // },
     // Run Code Action
     // {
+    //     "keys": ["UNBOUND"],
     //     "command": "lsp_code_actions",
-    //     "keys": [
-    //         "UNBOUND"
-    //     ],
-    //     "context": [
-    //         {
-    //             "key": "lsp.session_with_capability",
-    //             "operator": "equal",
-    //             "operand": "codeActionProvider"
-    //         }
-    //     ]
+    //     "context": [{"key": "lsp.session_with_capability", "operand": "codeActionProvider"}]
     // },
     // Run Source Actions
     // {
+    //     "keys": ["UNBOUND"],
     //     "command": "lsp_code_actions",
-    //     "args": {
-    //         "only_kinds": [
-    //             "source"
-    //         ]
-    //     },
-    //     "keys": [
-    //         "UNBOUND"
-    //     ],
-    //     "context": [
-    //         {
-    //             "key": "lsp.session_with_capability",
-    //             "operator": "equal",
-    //             "operand": "codeActionProvider.codeActionKinds"
-    //         }
-    //     ]
+    //     "args": {"only_kinds": ["source"]},
+    //     "context": [{"key": "lsp.session_with_capability", "operand": "codeActionProvider.codeActionKinds"}]
     // },
     // Run Code Lens
     // {
+    //     "keys": ["UNBOUND"],
     //     "command": "lsp_code_lens",
-    //     "keys": [
-    //         "UNBOUND"
-    //     ],
-    //     "context": [
-    //         {
-    //             "key": "lsp.session_with_capability",
-    //             "operator": "equal",
-    //             "operand": "codeLensProvider"
-    //         }
-    //     ]
+    //     "context": [{"key": "lsp.session_with_capability", "operand": "codeLensProvider"}]
     // },
     // Toggle Diagnostics Panel
     {
+        "keys": ["primary+alt+m"],
         "command": "lsp_show_diagnostics_panel",
-        "keys": [
-            "primary+alt+m"
-        ],
-        "context": [
-            {
-                "key": "setting.lsp_active"
-            }
-        ]
+        "context": [{"key": "setting.lsp_active"}]
     },
     // Toggle Language Server Logs Panel
     // {
+    //     "keys": ["UNBOUND"],
     //     "command": "lsp_toggle_server_panel",
-    //     "keys": [
-    //         "UNBOUND"
-    //     ],
-    //     "context": [
-    //         {
-    //             "key": "setting.lsp_active"
-    //         }
-    //     ]
+    //     "context": [{"key": "setting.lsp_active"}]
     // },
     // Trigger Signature Help
     {
+        "keys": ["primary+alt+space"],
         "command": "lsp_signature_help_show",
-        "keys": [
-            "primary+alt+space"
-        ],
-        "context": [
-            {
-                "key": "lsp.signature_help_available",
-                "operator": "equal",
-                "operand": true
-            }
-        ]
-    },
-    // Move Up/Down in Signature Help
-    {
-        "command": "lsp_signature_help_navigate",
-        "args": {
-            "forward": false
-        },
-        "keys": [
-            "up"
-        ],
-        "context": [
-            {
-                "key": "lsp.signature_help_multiple_choices_available",
-                "operator": "equal",
-                "operand": true
-            }
-        ]
-    },
-    {
-        "command": "lsp_signature_help_navigate",
-        "args": {
-            "forward": true
-        },
-        "keys": [
-            "down"
-        ],
-        "context": [
-            {
-                "key": "lsp.signature_help_multiple_choices_available",
-                "operator": "equal",
-                "operand": true
-            }
-        ]
+        "context": [{"key": "lsp.signature_help_available"}]
     },
     // Find References
     {
+        "keys": ["shift+f12"],
         "command": "lsp_symbol_references",
-        "args": {
-            "side_by_side": false,
-            "fallback": false
-        },
-        "keys": [
-            "shift+f12"
-        ],
-        "context": [
-            {
-                "key": "lsp.session_with_capability",
-                "operator": "equal",
-                "operand": "referencesProvider"
-            },
-        ]
+        "args": {"side_by_side": false, "fallback": false},
+        "context": [{"key": "lsp.session_with_capability", "operand": "referencesProvider"}]
     },
+    // Find References (side-by-side)
+    // {
+    //     "keys": ["primary+shift+f12"],
+    //     "command": "lsp_symbol_references",
+    //     "args": {"side_by_side": true, "fallback": false},
+    //     "context": [{"key": "lsp.session_with_capability", "operand": "referencesProvider"}]
+    // },
     // Goto Definition
     // {
+    //     "keys": ["f12"],
     //     "command": "lsp_symbol_definition",
-    //     "args": {
-    //         "side_by_side": false,
-    //         "force_group": true,
-    //         "fallback": false,
-    //         "group": -1
-    //     },
-    //     "keys": [
-    //         "f12"
-    //     ],
+    //     "args": {"side_by_side": false, "force_group": true, "fallback": false, "group": -1},
     //     "context": [
-    //         {
-    //             "key": "lsp.session_with_capability",
-    //             "operator": "equal",
-    //             "operand": "definitionProvider"
-    //         },
-    //         {
-    //             "key": "auto_complete_visible",
-    //             "operator": "equal",
-    //             "operand": false
-    //         }
+    //         {"key": "lsp.session_with_capability", "operand": "definitionProvider"},
+    //         {"key": "auto_complete_visible", "operand": false}
+    //     ]
+    // },
+    // Goto Definition (side-by-side)
+    // {
+    //     "keys": ["primary+f12"],
+    //     "command": "lsp_symbol_definition",
+    //     "args": {"side_by_side": true, "force_group": true, "fallback": false, "group": -1},
+    //     "context": [
+    //         {"key": "lsp.session_with_capability", "operand": "definitionProvider"},
+    //         {"key": "auto_complete_visible", "operand": false}
     //     ]
     // },
     // Goto Type Definition
     // {
+    //     "keys": ["UNBOUND"],
     //     "command": "lsp_symbol_type_definition",
-    //     "args": {
-    //         "side_by_side": false,
-    //         "force_group": true,
-    //         "group": -1
-    //     },
-    //     "keys": [
-    //         "UNBOUND"
-    //     ],
+    //     "args": {"side_by_side": false, "force_group": true, "group": -1},
     //     "context": [
-    //         {
-    //             "key": "lsp.session_with_capability",
-    //             "operator": "equal",
-    //             "operand": "typeDefinitionProvider"
-    //         },
-    //         {
-    //             "key": "auto_complete_visible",
-    //             "operator": "equal",
-    //             "operand": false
-    //         }
+    //         {"key": "lsp.session_with_capability", "operand": "typeDefinitionProvider"},
+    //         {"key": "auto_complete_visible", "operand": false}
     //     ]
     // },
     // Goto Declaration
     // {
+    //     "keys": ["UNBOUND"],
     //     "command": "lsp_symbol_declaration",
-    //     "args": {
-    //         "side_by_side": false,
-    //         "force_group": true,
-    //         "group": -1
-    //     },
-    //     "keys": [
-    //         "UNBOUND"
-    //     ],
+    //     "args": {"side_by_side": false, "force_group": true, "group": -1},
     //     "context": [
-    //         {
-    //             "key": "lsp.session_with_capability",
-    //             "operator": "equal",
-    //             "operand": "declarationProvider"
-    //         },
-    //         {
-    //             "key": "auto_complete_visible",
-    //             "operator": "equal",
-    //             "operand": false
-    //         }
+    //         {"key": "lsp.session_with_capability", "operand": "declarationProvider"},
+    //         {"key": "auto_complete_visible", "operand": false}
     //     ]
     // },
     // Goto Implementation
     // {
+    //     "keys": ["UNBOUND"],
     //     "command": "lsp_symbol_implementation",
-    //     "args": {
-    //         "side_by_side": false,
-    //         "force_group": true,
-    //         "group": -1
-    //     },
-    //     "keys": [
-    //         "UNBOUND"
-    //     ],
+    //     "args": {"side_by_side": false, "force_group": true, "group": -1},
     //     "context": [
-    //         {
-    //             "key": "lsp.session_with_capability",
-    //             "operator": "equal",
-    //             "operand": "implementationProvider"
-    //         },
-    //         {
-    //             "key": "auto_complete_visible",
-    //             "operator": "equal",
-    //             "operand": false
-    //         }
+    //         {"key": "lsp.session_with_capability", "operand": "implementationProvider"},
+    //         {"key": "auto_complete_visible", "operand": false}
     //     ]
     // },
     // Goto Diagnostic
     // {
+    //     "keys": ["f8"],
     //     "command": "lsp_goto_diagnostic",
-    //     "args": {
-    //         "uri": "$view_uri"
-    //     },
-    //     "keys": [
-    //         "f8"
-    //     ],
+    //     "args": {"uri": "$view_uri"}
     // },
     // Goto Diagnostic in Project
     // {
-    //     "command": "lsp_goto_diagnostic",
-    //     "keys": [
-    //         "shift+f8"
-    //     ],
+    //     "keys": ["shift+f8"],
+    //     "command": "lsp_goto_diagnostic"
     // },
     // Jump to next Diagnostic in Tab
     // {
+    //     "keys": ["UNBOUND"],
     //     "command": "lsp_next_diagnostic",
-    //     "keys": [
-    //         "UNBOUND"
-    //     ],
-    //      "context": [
-    //          {
-    //              "key": "setting.lsp_active"
-    //          }
-    //      ]
+    //     "context": [{"key": "setting.lsp_active"}]
     // },
     // Jump to previous Diagnostic in Tab
     // {
+    //     "keys": ["UNBOUND"],
     //     "command": "lsp_prev_diagnostic",
-    //     "keys": [
-    //         "UNBOUND"
-    //     ],
-    //      "context": [
-    //          {
-    //              "key": "setting.lsp_active"
-    //          }
-    //      ]
+    //     "context": [{"key": "setting.lsp_active"}]
     // },
     // Rename
     // {
+    //     "keys": ["UNBOUND"],
     //     "command": "lsp_symbol_rename",
-    //     "keys": [
-    //         "UNBOUND"
-    //     ],
-    //     "context": [
-    //         {
-    //             "key": "lsp.session_with_capability",
-    //             "operator": "equal",
-    //             "operand": "renameProvider"
-    //         }
-    //     ]
+    //     "context": [{"key": "lsp.session_with_capability", "operand": "renameProvider"}]
     // },
     // Format File
     // {
+    //     "keys": ["UNBOUND"],
     //     "command": "lsp_format_document",
-    //     "keys": [
-    //         "UNBOUND"
-    //     ],
-    //     "context": [
-    //         {
-    //             "key": "lsp.session_with_capability",
-    //             "operator": "equal",
-    //             "operand": "documentFormattingProvider | documentRangeFormattingProvider"
-    //         }
-    //     ]
+    //     "context": [{"key": "lsp.session_with_capability", "operand": "documentFormattingProvider | documentRangeFormattingProvider"}]
     // },
     // Format Selection
     // {
+    //     "keys": ["UNBOUND"],
     //     "command": "lsp_format_document_range",
-    //     "keys": [
-    //         "UNBOUND"
-    //     ],
-    //     "context": [
-    //         {
-    //             "key": "lsp.session_with_capability",
-    //             "operator": "equal",
-    //             "operand": "documentRangeFormattingProvider"
-    //         }
-    //     ]
+    //     "context": [{"key": "lsp.session_with_capability", "operand": "documentRangeFormattingProvider"}]
     // },
     // Document Symbols (a replacement for ST's "Goto Symbol")
     // {
+    //     "keys": ["primary+r"],
     //     "command": "lsp_document_symbols",
-    //     "keys": [
-    //         "primary+r"
-    //     ],
-    //     "context": [
-    //         {
-    //             "key": "lsp.session_with_capability",
-    //             "operator": "equal",
-    //             "operand": "documentSymbolProvider"
-    //         }
-    //     ]
+    //     "context": [{"key": "lsp.session_with_capability", "operand": "documentSymbolProvider"}]
     // },
     // Workspace Symbols (a replacement for ST's "Goto Symbol In Project")
     // {
+    //     "keys": ["primary+shift+r"],
     //     "command": "lsp_workspace_symbols",
-    //     "keys": [
-    //         "primary+shift+r"
-    //     ],
-    //     "context": [
-    //         {
-    //             "key": "lsp.session_with_capability",
-    //             "operator": "equal",
-    //             "operand": "workspaceSymbolProvider"
-    //         }
-    //     ]
+    //     "context": [{"key": "lsp.session_with_capability", "operand": "workspaceSymbolProvider"}]
     // },
     // Hover Popup
     // {
+    //     "keys": ["UNBOUND"],
     //     "command": "lsp_hover",
-    //     "keys": [
-    //         "UNBOUND"
-    //     ],
-    //     "context": [
-    //         {
-    //             "key": "lsp.session_with_capability",
-    //             "operator": "equal",
-    //             "operand": "hoverProvider"
-    //         }
-    //     ]
+    //     "context": [{"key": "lsp.session_with_capability", "operand": "hoverProvider"}]
     // },
     // Follow Link
     // {
+    //     "keys": ["UNBOUND"],
     //     "command": "lsp_open_link",
-    //     "keys": [
-    //         "UNBOUND"
-    //     ],
-    //     "context": [
-    //         {
-    //             "key": "lsp.session_with_capability",
-    //             "operator": "equal",
-    //             "operand": "documentLinkProvider"
-    //         }
-    //     ]
+    //     "context": [{"key": "lsp.session_with_capability", "operand": "documentLinkProvider"}]
     // },
     // Expand Selection (a replacement for ST's "Expand Selection")
     // {
+    //     "keys": ["primary+shift+a"],
     //     "command": "lsp_expand_selection",
-    //     "keys": [
-    //         "primary+shift+a"
-    //     ],
-    //     "context": [
-    //         {
-    //             "key": "lsp.session_with_capability",
-    //             "operator": "equal",
-    //             "operand": "selectionRangeProvider"
-    //         }
-    //     ]
+    //     "context": [{"key": "lsp.session_with_capability", "operand": "selectionRangeProvider"}]
     // },
-    // Internal key-binding
+    //==== Internal key-bindings ====
     {
-        "keys": [
-            "<character>"
-        ],
+        "keys": ["<character>"],
         "command": "noop",
-        "context": [
-            {
-                "key": "setting.lsp_suppress_input",
-            }
-        ]
+        "context": [{"key": "setting.lsp_suppress_input"}]
+    },
+    // Move Up/Down in Signature Help
+    {
+        "keys": ["up"],
+        "command": "lsp_signature_help_navigate",
+        "args": {"forward": false},
+        "context": [{"key": "lsp.signature_help_multiple_choices_available"}]
+    },
+    {
+        "keys": ["down"],
+        "command": "lsp_signature_help_navigate",
+        "args": {"forward": true},
+        "context": [{"key": "lsp.signature_help_multiple_choices_available"}]
+    },
+    // Override native save to handle Code-Actions-On-Save
+    {
+        "keys": ["primary+s"],
+        "command": "lsp_save",
+        "context": [{"key": "lsp.session_with_capability", "operand": "textDocumentSync.willSave | textDocumentSync.willSaveWaitUntil | codeActionProvider.codeActionKinds | documentFormattingProvider | documentRangeFormattingProvider"}]
     },
 ]


### PR DESCRIPTION
The keybindings file looks like it was created by a JSON formatter with all those unnecessary linebreaks like in
```jsonc
    "keys": [
        "f12"
    ],
```

This PR makes it more readable (in my opinion), removes a few unnecessary things like `"operator": "equal", "operand": true` and adds two examples (which are commented out) for Goto Definition/References in side-by-side mode, with Sublime's default keys.