### PR TITLE
don't advertise support for disabled code actions

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -336,7 +336,6 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
                 }
             },
             "dataSupport": True,
-            "disabledSupport": True,
             "isPreferredSupport": True,
             "resolveSupport": {
                 "properties": [


### PR DESCRIPTION
Since we don't have any special handling for disabled code actions and instead just filter them away, as long as server is compliant, it should be better to just not advertise support for it as then we should not receive those in the first place.

There is still code in place to filter out "disabled: true" code actions but it can be left as a safety net for non-compliant servers (not aware of any).