### PR TITLE
Add context for lsp_open_link key binding

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -186,7 +186,7 @@
     // {
     //     "keys": ["UNBOUND"],
     //     "command": "lsp_open_link",
-    //     "context": [{"key": "lsp.session_with_capability", "operand": "documentLinkProvider"}]
+    //     "context": [{"key": "lsp.link_available"}]
     // },
     // Expand Selection (a replacement for ST's "Expand Selection")
     // {


### PR DESCRIPTION
https://github.com/sublimelsp/LSP/issues/2128#issuecomment-1349141253

This adds a new context to check for a DocumentLink at the current cursor position, which can be used for the `lsp_open_link` key binding. This way users can configure to use the same key as for "Goto Definion...", if they place the `lsp_open_link` key binding after (below) the other one (see https://docs.sublimetext.io/reference/key_bindings.html#order-of-preference-for-key-bindings).