### PR TITLE
fix code lenses not updating after Undo

### DIFF
--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -6,7 +6,6 @@ from .typing import Any, Optional, List, Dict, Generator, Callable, Iterable, Un
 from .typing import cast
 from .url import filename_to_uri
 from .url import parse_uri
-from threading import RLock
 from wcmatch.glob import BRACE
 from wcmatch.glob import globmatch
 from wcmatch.glob import GLOBSTAR

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -138,7 +138,7 @@ class DebouncerNonThreadSafe:
     Debouncer for delaying execution of a function until specified timeout time.
 
     When calling `debouce()` multiple times, with time span between calls being shorter than the specified `timeout_ms`,
-    the specified callback function will only be called once, after a period of `timeout_ms` since last call.
+    the specified callback function will only be called once, after a period of `timeout_ms` since the last call.
 
     This implementation is not thread safe. You must ensure that `debounce()` is called from the same thread as
     was choosen during initialization through the `async_thread` argument.

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -137,7 +137,7 @@ class DebouncerNonThreadSafe:
     """
     Debouncer for delaying execution of a function until specified timeout time.
 
-    When calling `debouce()` multiple times, with time span between calls being shorter than the specified `timeout_ms`,
+    When calling `debounce()` multiple times, with time span between calls being shorter than the specified `timeout_ms`,
     the specified callback function will only be called once, after a period of `timeout_ms` since the last call.
 
     This implementation is not thread safe. You must ensure that `debounce()` is called from the same thread as

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -134,41 +134,46 @@ class SettingsRegistration:
         self._settings.clear_on_change("LSP")
 
 
-class Debouncer:
+class DebouncerNonThreadSafe:
+    """
+    Debouncer for delaying execution of a function until specified timeout time.
 
-    def __init__(self) -> None:
+    When calling `debouce()` multiple times, with time span between calls being shorter than the specified `timeout_ms`,
+    the specified callback function will only be called once, after a period of `timeout_ms` since last call.
+
+    This implementation is not thread safe. You must ensure that `debounce()` is called from the same thread as
+    was choosen during initialization through the `async_thread` argument.
+    """
+
+    def __init__(self, async_thread: bool) -> None:
+        self._async_thread = async_thread
         self._current_id = -1
         self._next_id = 0
-        self._current_id_lock = RLock()
 
-    def debounce(self, f: Callable[[], None], timeout_ms: int = 0, condition: Callable[[], bool] = lambda: True,
-                 async_thread: bool = False) -> None:
+    def debounce(
+        self, f: Callable[[], None], timeout_ms: int = 0, condition: Callable[[], bool] = lambda: True
+    ) -> None:
         """
-        Possibly run a function at a later point in time, either on the async thread or on the main thread.
+        Possibly run a function at a later point in time on the thread chosen during initialization.
 
         :param      f:             The function to possibly run
         :param      timeout_ms:    The time in milliseconds after which to possibly to run the function
         :param      condition:     The condition that must evaluate to True in order to run the funtion
-        :param      async_thread:  If true, run the function on the async worker thread, otherwise run
-                                   the function on the main thread
         """
 
         def run(debounce_id: int) -> None:
-            with self._current_id_lock:
-                if debounce_id != self._current_id:
-                    return
+            if debounce_id != self._current_id:
+                return
             if condition():
                 f()
 
-        runner = sublime.set_timeout_async if async_thread else sublime.set_timeout
-        with self._current_id_lock:
-            current_id = self._current_id = self._next_id
+        runner = sublime.set_timeout_async if self._async_thread else sublime.set_timeout
+        current_id = self._current_id = self._next_id
         self._next_id += 1
         runner(lambda: run(current_id), timeout_ms)
 
     def cancel_pending(self) -> None:
-        with self._current_id_lock:
-            self._current_id = -1
+        self._current_id = -1
 
 
 def read_dict_setting(settings_obj: sublime.Settings, key: str, default: dict) -> dict:

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -137,8 +137,8 @@ class DebouncerNonThreadSafe:
     """
     Debouncer for delaying execution of a function until specified timeout time.
 
-    When calling `debounce()` multiple times, with time span between calls being shorter than the specified `timeout_ms`,
-    the specified callback function will only be called once, after a period of `timeout_ms` since the last call.
+    When calling `debounce()` multiple times, if the time span between calls is shorter than the specified `timeout_ms`,
+    the callback function will only be called once, after `timeout_ms` since the last call.
 
     This implementation is not thread safe. You must ensure that `debounce()` is called from the same thread as
     was choosen during initialization through the `async_thread` argument.

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -27,7 +27,7 @@ from .core.settings import userprefs
 from .core.signature_help import SigHelp
 from .core.types import basescope2languageid
 from .core.types import debounced
-from .core.types import Debouncer
+from .core.types import DebouncerNonThreadSafe
 from .core.types import FEATURES_TIMEOUT
 from .core.types import SettingsRegistration
 from .core.typing import Any, Callable, Optional, Dict, Generator, Iterable, List, Tuple, Union
@@ -159,7 +159,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             self.set_uri(view_to_uri(view))
         self._auto_complete_triggered_manually = False
         self._change_count_on_last_save = -1
-        self._code_lenses_debouncer = Debouncer()
+        self._code_lenses_debouncer_async = DebouncerNonThreadSafe(async_thread=True)
         self._registration = SettingsRegistration(view.settings(), on_change=on_change)
         self._setup()
 
@@ -319,8 +319,8 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         if self.view.is_primary():
             for sv in self.session_views_async():
                 sv.on_text_changed_async(change_count, changes)
-        self._code_lenses_debouncer.debounce(
-            self._do_code_lenses_async, timeout_ms=self.code_lenses_debounce_time, async_thread=True)
+        self._code_lenses_debouncer_async.debounce(
+            self._do_code_lenses_async, timeout_ms=self.code_lenses_debounce_time)
         if not different:
             return
         self._clear_highlight_regions()

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -27,6 +27,7 @@ from .core.settings import userprefs
 from .core.signature_help import SigHelp
 from .core.types import basescope2languageid
 from .core.types import debounced
+from .core.types import Debouncer
 from .core.types import FEATURES_TIMEOUT
 from .core.types import SettingsRegistration
 from .core.typing import Any, Callable, Optional, Dict, Generator, Iterable, List, Tuple, Union
@@ -158,6 +159,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             self.set_uri(view_to_uri(view))
         self._auto_complete_triggered_manually = False
         self._change_count_on_last_save = -1
+        self._code_lenses_debouncer = Debouncer()
         self._registration = SettingsRegistration(view.settings(), on_change=on_change)
         self._setup()
 
@@ -317,6 +319,8 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         if self.view.is_primary():
             for sv in self.session_views_async():
                 sv.on_text_changed_async(change_count, changes)
+        self._code_lenses_debouncer.debounce(
+            self._do_code_lenses_async, timeout_ms=self.code_lenses_debounce_time, async_thread=True)
         if not different:
             return
         self._clear_highlight_regions()
@@ -324,8 +328,6 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             self._when_selection_remains_stable_async(self._do_highlights_async, current_region,
                                                       after_ms=self.highlights_debounce_time)
         self.do_signature_help_async(manual=False)
-        self._when_selection_remains_stable_async(self._do_code_lenses_async, current_region,
-                                                  after_ms=self.code_lenses_debounce_time)
 
     def get_uri(self) -> str:
         return self._uri


### PR DESCRIPTION
Updating of code lenses should IMO not be tied to selection update as document can get modified programmatically in which case selection might not change.

There is also another weird case where I've noticed this issue during "Undo" and that one has deeper roots... When undoing removal of a line, `on_text_changed_async` is quickly called twice and on the first call selection is `different` from the stored one but on the second call, it's not. That results in `_when_selection_remains_stable_async` not being triggered (first time because region no longer matches in `debounced` and second time because `different` is `False` so we return early from `on_text_changed_async`). This is an issue that should still be fixed but it's fairly minor and probably doesn't even effect `_do_highlights_async` much.

That said, switching to `Debouncer` class avoids the above issue affecting code lenses.

(I guess we might be a bit concerned about using locks in more places but I think and hope that it's not really that expensive. Especially as `Debouncer` is only holding the lock to update a single property.)

Fixes #2136