### PR TITLE
Add "Refactor" entry to the "Edit" main menu

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -36,6 +36,26 @@
           {
             "command": "lsp_refactor",
             "args": {"id": 4}
+          },
+          {
+            "command": "lsp_refactor",
+            "args": {"id": 5}
+          },
+          {
+            "command": "lsp_refactor",
+            "args": {"id": 6}
+          },
+          {
+            "command": "lsp_refactor",
+            "args": {"id": 7}
+          },
+          {
+            "command": "lsp_refactor",
+            "args": {"id": 8}
+          },
+          {
+            "command": "lsp_refactor",
+            "args": {"id": 9}
           }
         ]
       },

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -7,12 +7,12 @@
         "caption": "-"
       },
       {
-        "caption": "LSP: Rename…",
-        "command": "lsp_symbol_rename"
-      },
-      {
         "caption": "LSP: Refactor",
         "children": [
+          {
+            "caption": "Rename…",
+            "command": "lsp_symbol_rename"
+          },
           {
             "command": "lsp_refactor",
             "args": {"id": 0}

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -7,6 +7,10 @@
         "caption": "-"
       },
       {
+        "command": "lsp_refactor",
+        "args": {"id": -1}
+      },
+      {
         "caption": "LSP: Refactor",
         "children": [
           {

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -11,6 +11,31 @@
         "command": "lsp_symbol_rename"
       },
       {
+        "caption": "LSP: Refactor",
+        "children": [
+          {
+            "command": "lsp_refactor",
+            "args": {"id": 0}
+          },
+          {
+            "command": "lsp_refactor",
+            "args": {"id": 1}
+          },
+          {
+            "command": "lsp_refactor",
+            "args": {"id": 2}
+          },
+          {
+            "command": "lsp_refactor",
+            "args": {"id": 3}
+          },
+          {
+            "command": "lsp_refactor",
+            "args": {"id": 4}
+          }
+        ]
+      },
+      {
         "caption": "LSP: Format File",
         "command": "lsp_format_document"
       },

--- a/boot.py
+++ b/boot.py
@@ -4,6 +4,7 @@ import sublime_plugin
 
 # Please keep this list sorted (Edit -> Sort Lines)
 from .plugin.code_actions import LspCodeActionsCommand
+from .plugin.code_actions import LspRefactorCommand
 from .plugin.code_lens import LspCodeLensCommand
 from .plugin.color import LspColorPresentationCommand
 from .plugin.completion import LspCommitCompletionWithOppositeInsertMode

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -80,9 +80,13 @@ class CodeActionsManager:
             # Filter out non "quickfix" code actions unless "only_kinds" is provided.
             if only_kinds:
                 if manual and only_kinds == [CodeActionKind.Refactor]:
+                    refactor_actions = [
+                        cast(CodeAction, a) for a in actions
+                        if not is_command(a) and kinds_include_kind([CodeActionKind.Refactor], a.get('kind'))
+                    ]
                     self.refactor_actions_cache.extend(
-                        [(session.config.name, cast(CodeAction, a)) for a in actions
-                            if not is_command(a) and kinds_include_kind([CodeActionKind.Refactor], a.get('kind'))])
+                        [(session.config.name, a) for a in refactor_actions] if len(refactor_actions) <= 10 else
+                        [(session.config.name, a) for a in refactor_actions if not a.get('disabled')])
                 return [
                     a for a in actions
                     if not is_command(a) and kinds_include_kind(only_kinds, a.get('kind')) and not a.get('disabled')

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -364,9 +364,7 @@ class LspRefactorCommand(LspTextCommand):
         return len(actions_manager.refactor_actions_cache) > id and self._is_cache_valid()
 
     def description(self, id: int, event: Optional[dict] = None, point: Optional[int] = None) -> Optional[str]:
-        if id == -1:
-            return None
-        if len(actions_manager.refactor_actions_cache) > id:
+        if id > -1 and len(actions_manager.refactor_actions_cache) > id:
             return actions_manager.refactor_actions_cache[id][1]['title']
 
     def run(self, edit: sublime.Edit, id: int, event: Optional[dict] = None, point: Optional[int] = None) -> None:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -337,7 +337,6 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
             },
             "dataSupport": True,
             "disabledSupport": True,
-            "isPreferredSupport": True,
             "resolveSupport": {
                 "properties": [
                     "edit"

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -336,7 +336,7 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
                 }
             },
             "dataSupport": True,
-            "disabledSupport": True,
+            "isPreferredSupport": True,
             "resolveSupport": {
                 "properties": [
                     "edit"

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -336,6 +336,7 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
                 }
             },
             "dataSupport": True,
+            "disabledSupport": True,
             "isPreferredSupport": True,
             "resolveSupport": {
                 "properties": [


### PR DESCRIPTION
Here's another experiment of mine. It can dynamically show up to 5 "Refactor" code actions in the "Edit" main menu, without the need to open the quick panel overlay.

I haven't tested with actions from multiple sessions at the same time, but I think it should work™.

Closes #1846 (?)

![refactor](https://user-images.githubusercontent.com/6579999/207783107-91bd09d2-0779-45a0-90f7-8bd9040479b9.gif)
