### PR TITLE
Auto-restart on server crashing, up to 5 times

### DIFF
--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -85,8 +85,6 @@ class WindowConfigManager(object):
         Signal that a session has crashed.
 
         Returns True if the session should be restarted automatically.
-        Returns False if the session should not be restarted automatically,
-        in this case the counter is reset.
         """
         now = datetime.now()
         if config_name not in self._crashes:

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -93,19 +93,8 @@ class WindowConfigManager(object):
         self._crashes[config_name].append(now)
         timeout = now - RETRY_COUNT_TIMEDELTA
         crash_count = len([crash for crash in self._crashes[config_name] if crash > timeout])
-        msg = "".join((
-            "session for config {} crashed ",
-            "({} / {} times in the last {} seconds), ",
-            "exit code {}, exception: {}",
-        )).format(
-            config_name,
-            crash_count,
-            RETRY_MAX_COUNT,
-            RETRY_COUNT_TIMEDELTA.total_seconds(),
-            exit_code,
-            exception
-        )
-        printf(msg)
+        printf("{} crashed ({} / {} times in the last {} seconds), exit code {}, exception: {}".format(
+            config_name, crash_count, RETRY_MAX_COUNT, RETRY_COUNT_TIMEDELTA.total_seconds(), exit_code, exception))
         return crash_count < RETRY_MAX_COUNT
 
     def _disable_for_session(self, config_name: str) -> None:

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -3,10 +3,10 @@ from .logging import exception_log
 from .types import ClientConfig
 from .typing import Generator, List, Optional, Set, Dict, Deque
 from .workspace import enable_in_project, disable_in_project
+from collections import deque
+from datetime import datetime, timedelta
 import sublime
 import urllib.parse
-from datetime import datetime, timedelta
-from collections import deque
 
 
 RETRY_MAX_COUNT = 5

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -100,11 +100,7 @@ class WindowConfigManager(object):
             "({} / {} times in the last {} seconds)"
         )).format(config_name, crash_count, RETRY_MAX_COUNT, RETRY_COUNT_TIMEDELTA.total_seconds())
         debug(msg)
-        if crash_count >= RETRY_MAX_COUNT:
-            # CRASH_MAX_COUNT crashes in _CRASH_COUNT_TIMEDELTA
-            del self._crashes[config_name]
-            return False
-        return True
+        return crash_count < RETRY_MAX_COUNT
 
     def _disable_for_session(self, config_name: str) -> None:
         self._disabled_for_session.add(config_name)

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -98,7 +98,14 @@ class WindowConfigManager(object):
             "session for config {} crashed ",
             "({} / {} times in the last {} seconds), ",
             "exit code {}, exception: {}",
-        )).format(config_name, crash_count, RETRY_MAX_COUNT, RETRY_COUNT_TIMEDELTA.total_seconds(), exit_code, exception)
+        )).format(
+            config_name,
+            crash_count,
+            RETRY_MAX_COUNT,
+            RETRY_COUNT_TIMEDELTA.total_seconds(),
+            exit_code,
+            exception
+        )
         printf(msg)
         return crash_count < RETRY_MAX_COUNT
 

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -87,11 +87,10 @@ class WindowConfigManager(object):
 
         Returns True if the session should be restarted automatically.
         """
-        now = datetime.now()
         if config_name not in self._crashes:
-            self._crashes[config_name] = deque([now], maxlen=RETRY_MAX_COUNT)
-        else:
-            self._crashes[config_name].append(now)
+            self._crashes[config_name] = deque(maxlen=RETRY_MAX_COUNT)
+        now = datetime.now()
+        self._crashes[config_name].append(now)
         timeout = now - RETRY_COUNT_TIMEDELTA
         crash_count = len([crash for crash in self._crashes[config_name] if crash > timeout])
         msg = "".join((

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -81,7 +81,7 @@ class WindowConfigManager(object):
             disable_in_project(self._window, config_name)
         self.update(config_name)
 
-    def record_crash(self, config_name: str) -> bool:
+    def record_crash(self, config_name: str, exit_code: int, exception: Optional[Exception]) -> bool:
         """
         Signal that a session has crashed.
 
@@ -95,10 +95,10 @@ class WindowConfigManager(object):
         timeout = now - RETRY_COUNT_TIMEDELTA
         crash_count = len([crash for crash in self._crashes[config_name] if crash > timeout])
         msg = "".join((
-            "session for config {} crashed. ",
-            "({} / {} times in the last {} seconds)"
-        )).format(config_name, crash_count, RETRY_MAX_COUNT, RETRY_COUNT_TIMEDELTA.total_seconds())
-        debug(msg)
+            "session for config {} crashed ",
+            "({} / {} times in the last {} seconds), ",
+            "exit code {}, exception: {}",
+        )).format(config_name, crash_count, RETRY_MAX_COUNT, RETRY_COUNT_TIMEDELTA.total_seconds(), exit_code, exception)
         printf(msg)
         return crash_count < RETRY_MAX_COUNT
 

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -1,5 +1,6 @@
 from .logging import debug
 from .logging import exception_log
+from .logging import printf
 from .types import ClientConfig
 from .typing import Generator, List, Optional, Set, Dict, Deque
 from .workspace import enable_in_project, disable_in_project
@@ -98,6 +99,7 @@ class WindowConfigManager(object):
             "({} / {} times in the last {} seconds)"
         )).format(config_name, crash_count, RETRY_MAX_COUNT, RETRY_COUNT_TIMEDELTA.total_seconds())
         debug(msg)
+        printf(msg)
         return crash_count < RETRY_MAX_COUNT
 
     def _disable_for_session(self, config_name: str) -> None:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -951,7 +951,7 @@ class AbstractPlugin(metaclass=ABCMeta):
 
         If the session hasn't crashed, a shutdown message will be send immediately
         after this method returns. In this case exit_code and exception are None.
-        If the session has crashed, the exit_code is not zero or the exception is not None.
+        If the session has crashed, the exit_code or the exception is not None.
 
         This API is triggered on async thread.
         """

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -951,7 +951,7 @@ class AbstractPlugin(metaclass=ABCMeta):
 
         If the session hasn't crashed, a shutdown message will be send immediately
         after this method returns. In this case exit_code and exception are None.
-        If the session has crashed, the exit_code or the exception is not None.
+        If the session has crashed, the exit_code and an optional exception are provided.
 
         This API is triggered on async thread.
         """

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -943,15 +943,17 @@ class AbstractPlugin(metaclass=ABCMeta):
         """
         pass
 
-    def on_session_end_async(self, exit_code: int, exception: Optional[Exception]) -> None:
+    def on_session_end_async(self, exit_code: Optional[int], exception: Optional[Exception]) -> None:
         """
         Notifies about the session ending (also if the session has crashed). Provides an opportunity to clean up
         any stored state or delete references to the session or plugin instance that would otherwise prevent the
-        instance from being garbage-collected. If the plugin hasn't crashed, a shutdown message will be send immediately
-        after this method returns.
-        This API is triggered on async thread.
+        instance from being garbage-collected.
 
-        If the session ended with an error, the exit_code is not zero or the exception is not None.
+        If the session hasn't crashed, a shutdown message will be send immediately
+        after this method returns. In this case exit_code and exception are None.
+        If the session has crashed, the exit_code is not zero or the exception is not None.
+
+        This API is triggered on async thread.
         """
         pass
 
@@ -1851,7 +1853,7 @@ class Session(TransportCallbacks):
             return
         self.exiting = True
         if self._plugin:
-            self._plugin.on_session_end_async(0, None)
+            self._plugin.on_session_end_async(None, None)
             self._plugin = None
         for sv in self.session_views_async():
             for status_key in self._status_messages.keys():

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -396,14 +396,15 @@ class WindowManager(Manager):
             restart = self._config_manager.record_crash(config.name, exit_code, exception)
             if not restart:
                 msg = "".join((
-                    "{0} exited with status code {1}. ",
-                    "Do you want to restart it? If you choose Cancel, it will be disabled for this window for the ",
+                msg = "".join((
+                    "The {0} server has crashed 5 times in the last 3 minutes.\n\n",
+                    "You can try to Restart it or you can choose Cancel to disable it for this window for the ",
                     "duration of the current session. ",
                     "Re-enable by running \"LSP: Enable Language Server In Project\" from the Command Palette."
-                )).format(config.name, exit_code)
+                )).format(config.name)
                 if exception:
                     msg += "\n\n--- Error: ---\n{}".format(str(exception))
-                restart = sublime.ok_cancel_dialog(msg, "Restart {}".format(config.name))
+                restart = sublime.ok_cancel_dialog(msg, "Restart")
             if restart:
                 for listener in self._listeners:
                     self.register_listener_async(listener)

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -396,12 +396,11 @@ class WindowManager(Manager):
             restart = self._config_manager.record_crash(config.name, exit_code, exception)
             if not restart:
                 msg = "".join((
-                    "The {0} server has crashed {1} times in the last {2} seconds.\n",
-                    "Exit code: {3}\n\n",
+                    "The {0} server has crashed {1} times in the last {2} seconds.\n\n",
                     "You can try to Restart it or you can choose Cancel to disable it for this window for the ",
                     "duration of the current session. ",
                     "Re-enable by running \"LSP: Enable Language Server In Project\" from the Command Palette."
-                )).format(config.name, RETRY_MAX_COUNT, int(RETRY_COUNT_TIMEDELTA.total_seconds()), exit_code)
+                )).format(config.name, RETRY_MAX_COUNT, int(RETRY_COUNT_TIMEDELTA.total_seconds()))
                 if exception:
                     msg += "\n\n--- Error: ---\n{}".format(str(exception))
                 restart = sublime.ok_cancel_dialog(msg, "Restart")

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -393,7 +393,7 @@ class WindowManager(Manager):
             listener.on_session_shutdown_async(session)
         if exit_code != 0 or exception:
             config = session.config
-            restart = self._config_manager.record_crash(config.name)
+            restart = self._config_manager.record_crash(config.name, exit_code, exception)
             if not restart:
                 msg = "".join((
                     "{0} exited with status code {1}. ",

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -393,15 +393,18 @@ class WindowManager(Manager):
             listener.on_session_shutdown_async(session)
         if exit_code != 0 or exception:
             config = session.config
-            msg = "".join((
-                "{0} exited with status code {1}. ",
-                "Do you want to restart it? If you choose Cancel, it will be disabled for this window for the ",
-                "duration of the current session. ",
-                "Re-enable by running \"LSP: Enable Language Server In Project\" from the Command Palette."
-            )).format(config.name, exit_code)
-            if exception:
-                msg += "\n\n--- Error: ---\n{}".format(str(exception))
-            if sublime.ok_cancel_dialog(msg, "Restart {}".format(config.name)):
+            restart = self._config_manager.record_crash(config.name)
+            if not restart:
+                msg = "".join((
+                    "{0} exited with status code {1}. ",
+                    "Do you want to restart it? If you choose Cancel, it will be disabled for this window for the ",
+                    "duration of the current session. ",
+                    "Re-enable by running \"LSP: Enable Language Server In Project\" from the Command Palette."
+                )).format(config.name, exit_code)
+                if exception:
+                    msg += "\n\n--- Error: ---\n{}".format(str(exception))
+                restart = sublime.ok_cancel_dialog(msg, "Restart {}".format(config.name))
+            if restart:
                 for listener in self._listeners:
                     self.register_listener_async(listener)
             else:

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -1,5 +1,5 @@
 from ...third_party import WebsocketServer  # type: ignore
-from .configurations import WindowConfigManager
+from .configurations import WindowConfigManager, RETRY_MAX_COUNT, RETRY_COUNT_TIMEDELTA
 from .diagnostics_storage import is_severity_included
 from .logging import debug
 from .logging import exception_log
@@ -396,12 +396,12 @@ class WindowManager(Manager):
             restart = self._config_manager.record_crash(config.name, exit_code, exception)
             if not restart:
                 msg = "".join((
-                msg = "".join((
-                    "The {0} server has crashed 5 times in the last 3 minutes.\n\n",
+                    "The {0} server has crashed {1} times in the last {2} seconds.\n",
+                    "Exit code: {3}\n\n",
                     "You can try to Restart it or you can choose Cancel to disable it for this window for the ",
                     "duration of the current session. ",
                     "Re-enable by running \"LSP: Enable Language Server In Project\" from the Command Palette."
-                )).format(config.name)
+                )).format(config.name, RETRY_MAX_COUNT, int(RETRY_COUNT_TIMEDELTA.total_seconds()), exit_code)
                 if exception:
                     msg += "\n\n--- Error: ---\n{}".format(str(exception))
                 restart = sublime.ok_cancel_dialog(msg, "Restart")


### PR DESCRIPTION
This PR aims to do two things:
- [x] BREAKING: Provide the exit code to the LSP-* helper plugins. That allows for special actions on certain exit codes. (E.g. jdtls is known to crash with code -13 if the workspace cache is corrupted.)
- [x] Auto restart servers a few times before asking the user what to do

Open questions:
- Where should the state about crashed servers be stored? (WindowManager, ClientConfig, ...)
- How often do we attempt to restart the server? When is the counter reset?
  (e.g. Increase the counter if the last crash was <30s apart, else reset the counter. If the counter reaches 5, ask the user and reset the counter?)