### PR TITLE
fix completion documentation being parsed as markdown twice

### DIFF
--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -68,13 +68,13 @@ class LspResolveDocsCommand(LspTextCommand):
             if not self.view.is_valid():
                 return
             if self.view.is_popup_visible():
-                update_lsp_popup(self.view, minihtml_content, md=True)
+                update_lsp_popup(self.view, minihtml_content, md=False)
             else:
                 show_lsp_popup(
                     self.view,
                     minihtml_content,
                     flags=sublime.COOPERATE_WITH_AUTO_COMPLETE,
-                    md=True,
+                    md=False,
                     on_navigate=self._on_navigate)
 
         sublime.set_timeout(run_main)

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -878,7 +878,7 @@ class AbstractPlugin(metaclass=ABCMeta):
         :param      params:         A ConfigurationItem for which configuration is requested.
         :param      configuration:  The pre-resolved configuration for given params using the settings object or None.
 
-        :returns The resolved configuration for given params.
+        :returns: The resolved configuration for given params.
         """
         return configuration
 


### PR DESCRIPTION
Based on investigation in https://github.com/sublimelsp/LSP-pyright/pull/207.

I believe this is correct since `minihtml_content` is built from parts that should have already gone through mdpopups markdown parsing but I might have missed something.