### PR TITLE
when going to definition scroll to start of the region, not end

### DIFF
--- a/plugin/core/open.py
+++ b/plugin/core/open.py
@@ -117,10 +117,10 @@ def center_selection(v: sublime.View, r: Range) -> sublime.View:
     if window:
         window.focus_view(v)
     if int(sublime.version()) >= 4124:
-        v.show_at_center(selection, animate=False)
+        v.show_at_center(selection.begin(), animate=False)
     else:
         # TODO: remove later when a stable build lands
-        v.show_at_center(selection)  # type: ignore
+        v.show_at_center(selection.begin())  # type: ignore
     return v
 
 


### PR DESCRIPTION
Noticed that on "Goto definition", when the region of the definition spans many lines, ST scrolls to the end of the region rather than the start.

Imagine triggering "Goto definition" on a symbol that jumps to the constructor of that symbol and that constructor spans many lines. Focusing on the end of the constructor implementation is rather confusing and also it's not where the selection/cursor is in this case.