### PR TITLE
Add "Source Action" entry to the "Edit" main menu

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -7,8 +7,53 @@
         "caption": "-"
       },
       {
-        "command": "lsp_refactor",
+        "command": "lsp_source_action",
         "args": {"id": -1}
+      },
+      {
+        "caption": "LSP: Source Action",
+        "children": [
+          {
+            "command": "lsp_source_action",
+            "args": {"id": 0}
+          },
+          {
+            "command": "lsp_source_action",
+            "args": {"id": 1}
+          },
+          {
+            "command": "lsp_source_action",
+            "args": {"id": 2}
+          },
+          {
+            "command": "lsp_source_action",
+            "args": {"id": 3}
+          },
+          {
+            "command": "lsp_source_action",
+            "args": {"id": 4}
+          },
+          {
+            "command": "lsp_source_action",
+            "args": {"id": 5}
+          },
+          {
+            "command": "lsp_source_action",
+            "args": {"id": 6}
+          },
+          {
+            "command": "lsp_source_action",
+            "args": {"id": 7}
+          },
+          {
+            "command": "lsp_source_action",
+            "args": {"id": 8}
+          },
+          {
+            "command": "lsp_source_action",
+            "args": {"id": 9}
+          }
+        ]
       },
       {
         "caption": "LSP: Refactor",
@@ -60,12 +105,17 @@
         ]
       },
       {
-        "caption": "LSP: Format File",
-        "command": "lsp_format_document"
-      },
-      {
-        "caption": "LSP: Format Selection",
-        "command": "lsp_format_document_range"
+        "caption": "LSP: Format",
+        "children": [
+          {
+            "caption": "Format File",
+            "command": "lsp_format_document"
+          },
+          {
+            "caption": "Format Selection",
+            "command": "lsp_format_document_range"
+          }
+        ]
       }
     ]
   },

--- a/boot.py
+++ b/boot.py
@@ -5,6 +5,7 @@ import sublime_plugin
 # Please keep this list sorted (Edit -> Sort Lines)
 from .plugin.code_actions import LspCodeActionsCommand
 from .plugin.code_actions import LspRefactorCommand
+from .plugin.code_actions import LspSourceActionCommand
 from .plugin.code_lens import LspCodeLensCommand
 from .plugin.color import LspColorPresentationCommand
 from .plugin.completion import LspCommitCompletionWithOppositeInsertMode

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -353,6 +353,7 @@ class LspCodeActionsCommand(LspTextCommand):
 
 
 class LspMenuActionCommand(LspTextCommand, metaclass=ABCMeta):
+    """Handles a particular kind of code actions with the purpose to list them as items in a submenu."""
 
     capability = 'codeActionProvider'
 

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -84,18 +84,15 @@ class CodeActionsManager:
         def response_filter(session: Session, actions: List[CodeActionOrCommand]) -> List[CodeActionOrCommand]:
             # Filter out non "quickfix" code actions unless "only_kinds" is provided.
             if only_kinds:
+                code_actions = [cast(CodeAction, a) for a in actions if not is_command(a) and not a.get('disabled')]
                 if manual and only_kinds == MENU_ACTIONS_KINDS:
-                    code_actions = [cast(CodeAction, a) for a in actions if not is_command(a) and not a.get('disabled')]
                     for action in code_actions:
                         kind = action.get('kind')
                         if kinds_include_kind([CodeActionKind.Refactor], kind):
                             self.refactor_actions_cache.append((session.config.name, action))
                         elif kinds_include_kind([CodeActionKind.Source], kind):
                             self.source_actions_cache.append((session.config.name, action))
-                return [
-                    a for a in actions
-                    if not is_command(a) and kinds_include_kind(only_kinds, a.get('kind')) and not a.get('disabled')
-                ]
+                return [action for action in code_actions if kinds_include_kind(only_kinds, action.get('kind'))]
             if manual:
                 return [a for a in actions if not a.get('disabled')]
             # On implicit (selection change) request, only return commands and quick fix kinds.

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -17,12 +17,15 @@ from .core.views import first_selection_region
 from .core.views import format_code_actions_for_quick_panel
 from .core.views import text_document_code_action_params
 from .save_command import LspSaveCommand, SaveTask
+from abc import ABCMeta
+from abc import abstractmethod
 from functools import partial
 import sublime
 
 ConfigName = str
 CodeActionOrCommand = Union[CodeAction, Command]
 CodeActionsByConfigName = Tuple[ConfigName, List[CodeActionOrCommand]]
+MENU_ACTIONS_KINDS = [CodeActionKind.Refactor, CodeActionKind.Source]
 
 
 def is_command(action: CodeActionOrCommand) -> TypeGuard[Command]:
@@ -34,8 +37,9 @@ class CodeActionsManager:
 
     def __init__(self) -> None:
         self._response_cache = None  # type: Optional[Tuple[str, Promise[List[CodeActionsByConfigName]]]]
-        self.refactor_actions_key = None  # type: Optional[str]
+        self.menu_actions_cache_key = None  # type: Optional[str]
         self.refactor_actions_cache = []  # type: List[Tuple[str, CodeAction]]
+        self.source_actions_cache = []  # type: List[Tuple[str, CodeAction]]
 
     def request_for_region_async(
         self,
@@ -51,7 +55,7 @@ class CodeActionsManager:
         """
         listener = windows.listener_for_view(view)
         if not listener:
-            self.refactor_actions_key = None
+            self.menu_actions_cache_key = None
             return Promise.resolve([])
         location_cache_key = None
         use_cache = not manual
@@ -63,9 +67,10 @@ class CodeActionsManager:
                     return task
                 else:
                     self._response_cache = None
-        elif only_kinds == [CodeActionKind.Refactor]:
-            self.refactor_actions_key = "{}#{}:{}".format(view.buffer_id(), view.change_count(), region)
+        elif only_kinds == MENU_ACTIONS_KINDS:
+            self.menu_actions_cache_key = "{}#{}:{}".format(view.buffer_id(), view.change_count(), region)
             self.refactor_actions_cache.clear()
+            self.source_actions_cache.clear()
 
         def request_factory(session: Session) -> Optional[Request]:
             diagnostics = []  # type: List[Diagnostic]
@@ -79,12 +84,14 @@ class CodeActionsManager:
         def response_filter(session: Session, actions: List[CodeActionOrCommand]) -> List[CodeActionOrCommand]:
             # Filter out non "quickfix" code actions unless "only_kinds" is provided.
             if only_kinds:
-                if manual and only_kinds == [CodeActionKind.Refactor]:
-                    self.refactor_actions_cache.extend([
-                        (session.config.name, cast(CodeAction, a)) for a in actions
-                        if not is_command(a) and kinds_include_kind([CodeActionKind.Refactor], a.get('kind')) and
-                        not a.get('disabled')
-                    ])
+                if manual and only_kinds == MENU_ACTIONS_KINDS:
+                    code_actions = [cast(CodeAction, a) for a in actions if not is_command(a) and not a.get('disabled')]
+                    for action in code_actions:
+                        kind = action.get('kind')
+                        if kinds_include_kind([CodeActionKind.Refactor], kind):
+                            self.refactor_actions_cache.append((session.config.name, action))
+                        elif kinds_include_kind([CodeActionKind.Source], kind):
+                            self.source_actions_cache.append((session.config.name, action))
                 return [
                     a for a in actions
                     if not is_command(a) and kinds_include_kind(only_kinds, a.get('kind')) and not a.get('disabled')
@@ -348,32 +355,37 @@ class LspCodeActionsCommand(LspTextCommand):
             sublime.error_message("{}: {}".format(session_name, str(response)))
 
 
-class LspRefactorCommand(LspTextCommand):
+class LspMenuActionCommand(LspTextCommand, metaclass=ABCMeta):
 
     capability = 'codeActionProvider'
+
+    @property
+    @abstractmethod
+    def actions_cache(self) -> List[Tuple[str, CodeAction]]:
+        ...
 
     def is_enabled(self, id: int, event: Optional[dict] = None, point: Optional[int] = None) -> bool:
         if not super().is_enabled(event, point):
             return False
-        return -1 < id < len(actions_manager.refactor_actions_cache)
+        return -1 < id < len(self.actions_cache)
 
     def is_visible(self, id: int, event: Optional[dict] = None, point: Optional[int] = None) -> bool:
         if id == -1:
             if super().is_enabled(event, point):
-                sublime.set_timeout_async(self._request_refactor_actions_async)
+                sublime.set_timeout_async(partial(self._request_menu_actions_async, event))
             return False
-        return id < len(actions_manager.refactor_actions_cache) and self._is_cache_valid()
+        return id < len(self.actions_cache) and self._is_cache_valid(event)
 
     def description(self, id: int, event: Optional[dict] = None, point: Optional[int] = None) -> Optional[str]:
-        if -1 < id < len(actions_manager.refactor_actions_cache):
-            return actions_manager.refactor_actions_cache[id][1]['title']
+        if -1 < id < len(self.actions_cache):
+            return self.actions_cache[id][1]['title']
 
     def run(self, edit: sublime.Edit, id: int, event: Optional[dict] = None, point: Optional[int] = None) -> None:
-        sublime.set_timeout_async(partial(self.run_async, id))
+        sublime.set_timeout_async(partial(self.run_async, id, event))
 
-    def run_async(self, id: int) -> None:
-        if self._is_cache_valid():
-            config_name, action = actions_manager.refactor_actions_cache[id]
+    def run_async(self, id: int, event: Optional[dict]) -> None:
+        if self._is_cache_valid(event):
+            config_name, action = self.actions_cache[id]
             session = self.session_by_name(config_name)
             if session:
                 session.run_code_action_async(action, progress=True) \
@@ -383,15 +395,33 @@ class LspRefactorCommand(LspTextCommand):
         if isinstance(response, Error):
             sublime.error_message("{}: {}".format(session_name, str(response)))
 
-    def _is_cache_valid(self) -> bool:
-        v = self.view
-        region = first_selection_region(v)
+    def _is_cache_valid(self, event: Optional[dict]) -> bool:
+        region = self._get_region(event)
         if region is None:
             return False
-        return actions_manager.refactor_actions_key == "{}#{}:{}".format(v.buffer_id(), v.change_count(), region)
+        v = self.view
+        return actions_manager.menu_actions_cache_key == "{}#{}:{}".format(v.buffer_id(), v.change_count(), region)
 
-    def _request_refactor_actions_async(self) -> None:
-        region = first_selection_region(self.view)
-        if region is None:
-            return
-        actions_manager.request_for_region_async(self.view, region, [], [CodeActionKind.Refactor], True)
+    def _get_region(self, event: Optional[dict]) -> Optional[sublime.Region]:
+        if event is not None and self.applies_to_context_menu(event):
+            return sublime.Region(self.view.window_to_text((event['x'], event['y'])))
+        return first_selection_region(self.view)
+
+    def _request_menu_actions_async(self, event: Optional[dict]) -> None:
+        region = self._get_region(event)
+        if region is not None:
+            actions_manager.request_for_region_async(self.view, region, [], MENU_ACTIONS_KINDS, True)
+
+
+class LspRefactorCommand(LspMenuActionCommand):
+
+    @property
+    def actions_cache(self) -> List[Tuple[str, CodeAction]]:
+        return actions_manager.refactor_actions_cache
+
+
+class LspSourceActionCommand(LspMenuActionCommand):
+
+    @property
+    def actions_cache(self) -> List[Tuple[str, CodeAction]]:
+        return actions_manager.source_actions_cache


### PR DESCRIPTION
Same as #2141, but for "Source Action".

I also moved "Format File" and "Format Selection" into a submenu.

![edit-menu](https://user-images.githubusercontent.com/6579999/209099908-8f6f8884-cba2-4998-89a2-e52debd66207.png)

Note that no diagnostics are sent when requesting the "source" and "refactor" actions, but I would expect those actions to not depend on diagnostics, so I think this should be okay.

It would be good if someone could test it with a server that also provides "source" actions.

---

And I've experimented a little bit with the context menu, but I'm not happy with how it turns out if the same submenus for "Refactor" and "Source Action" are applied to the context menu. Because those menu items for the submenus cannot be hidden if they contain no items. That means that they will always be present in the context menu, even if no LSP is running (for example for basic `.txt` files).

The following example demonstrates this, (here also with the "Goto..." commands grouped into a submenu):
![menu](https://user-images.githubusercontent.com/6579999/209100803-18a1b36c-4900-4bac-a00c-6937a69577c4.png)

Furthermore, in a quick test it didn't work reliably for me from the context menu, even though (or maybe because) I think I properly took into account that the region for the code actions request should be derived from the mouse cursor / menu position, and not from the selection when triggered from the context menu. (I think this is also a bug currently existing in the `lsp_code_action` command, which doesn't work from the context menu if the selection/caret is at another position)

Due to these reasons the context menu is unchanged for now.

Closes #2066 