### PR TITLE
Improve type annotations

### DIFF
--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -16,7 +16,8 @@ from .core.views import entire_content_region
 from .core.views import first_selection_region
 from .core.views import format_code_actions_for_quick_panel
 from .core.views import text_document_code_action_params
-from .save_command import LspSaveCommand, SaveTask
+from .save_command import LspSaveCommand
+from .save_command import SaveTask
 from abc import ABCMeta
 from abc import abstractmethod
 from functools import partial

--- a/plugin/code_lens.py
+++ b/plugin/code_lens.py
@@ -1,4 +1,6 @@
-from .core.protocol import CodeLens, CodeLensExtended, Error
+from .core.protocol import CodeLens
+from .core.protocol import CodeLensExtended
+from .core.protocol import Error
 from .core.typing import List, Tuple, Dict, Iterable, Generator, Union, cast
 from .core.registry import LspTextCommand
 from .core.registry import windows

--- a/plugin/color.py
+++ b/plugin/color.py
@@ -4,6 +4,7 @@ from .core.protocol import ColorPresentation
 from .core.protocol import ColorPresentationParams
 from .core.protocol import Request
 from .core.registry import LspTextCommand
+from .core.typing import cast
 from .core.typing import List
 from .core.views import range_to_region
 from .core.views import text_document_identifier
@@ -19,11 +20,11 @@ class LspColorPresentationCommand(LspTextCommand):
         if session:
             self._version = self.view.change_count()
             self._range = color_information['range']
-            params = {
+            params = cast(ColorPresentationParams, {
                 'textDocument': text_document_identifier(self.view),
                 'color': color_information['color'],
                 'range': self._range
-            }  # type: ColorPresentationParams
+            })
             session.send_request_async(Request.colorPresentation(params, self.view), self._handle_response_async)
 
     def want_event(self) -> bool:

--- a/plugin/color.py
+++ b/plugin/color.py
@@ -4,7 +4,6 @@ from .core.protocol import ColorPresentation
 from .core.protocol import ColorPresentationParams
 from .core.protocol import Request
 from .core.registry import LspTextCommand
-from .core.typing import cast
 from .core.typing import List
 from .core.views import range_to_region
 from .core.views import text_document_identifier
@@ -20,11 +19,11 @@ class LspColorPresentationCommand(LspTextCommand):
         if session:
             self._version = self.view.change_count()
             self._range = color_information['range']
-            params = cast(ColorPresentationParams, {
+            params = {
                 'textDocument': text_document_identifier(self.view),
                 'color': color_information['color'],
                 'range': self._range
-            })
+            }  # type: ColorPresentationParams
             session.send_request_async(Request.colorPresentation(params, self.view), self._handle_response_async)
 
     def want_event(self) -> bool:

--- a/plugin/core/edit.py
+++ b/plugin/core/edit.py
@@ -1,7 +1,10 @@
 from .logging import debug
 from .open import open_file
 from .promise import Promise
-from .protocol import UINT_MAX, TextEdit as LspTextEdit, Position, WorkspaceEdit
+from .protocol import Position
+from .protocol import TextEdit
+from .protocol import UINT_MAX
+from .protocol import WorkspaceEdit
 from .typing import List, Dict, Optional, Tuple
 from functools import partial
 import sublime
@@ -37,7 +40,7 @@ def parse_range(range: Position) -> Tuple[int, int]:
     return range['line'], min(UINT_MAX, range['character'])
 
 
-def parse_text_edit(text_edit: LspTextEdit, version: Optional[int] = None) -> TextEditTuple:
+def parse_text_edit(text_edit: TextEdit, version: Optional[int] = None) -> TextEditTuple:
     return (
         parse_range(text_edit['range']['start']),
         parse_range(text_edit['range']['end']),

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -5861,15 +5861,15 @@ class Request:
         self.progress = progress  # type: Union[bool, str]
 
     @classmethod
-    def initialize(cls, params: Mapping[str, Any]) -> 'Request':
+    def initialize(cls, params: InitializeParams) -> 'Request':
         return Request("initialize", params)
 
     @classmethod
-    def complete(cls, params: Mapping[str, Any], view: sublime.View) -> 'Request':
+    def complete(cls, params: CompletionParams, view: sublime.View) -> 'Request':
         return Request("textDocument/completion", params, view)
 
     @classmethod
-    def signatureHelp(cls, params: Mapping[str, Any], view: sublime.View) -> 'Request':
+    def signatureHelp(cls, params: SignatureHelpParams, view: sublime.View) -> 'Request':
         return Request("textDocument/signatureHelp", params, view)
 
     @classmethod
@@ -5877,7 +5877,7 @@ class Request:
         return Request("textDocument/codeAction", params, view)
 
     @classmethod
-    def documentColor(cls, params: Mapping[str, Any], view: sublime.View) -> 'Request':
+    def documentColor(cls, params: DocumentColorParams, view: sublime.View) -> 'Request':
         return Request('textDocument/documentColor', params, view)
 
     @classmethod
@@ -5885,7 +5885,7 @@ class Request:
         return Request('textDocument/colorPresentation', params, view)
 
     @classmethod
-    def willSaveWaitUntil(cls, params: Mapping[str, Any], view: sublime.View) -> 'Request':
+    def willSaveWaitUntil(cls, params: WillSaveTextDocumentParams, view: sublime.View) -> 'Request':
         return Request("textDocument/willSaveWaitUntil", params, view)
 
     @classmethod
@@ -5893,23 +5893,23 @@ class Request:
         return Request("textDocument/documentSymbol", params, view, progress=True)
 
     @classmethod
-    def documentHighlight(cls, params: Mapping[str, Any], view: sublime.View) -> 'Request':
+    def documentHighlight(cls, params: DocumentHighlightParams, view: sublime.View) -> 'Request':
         return Request("textDocument/documentHighlight", params, view)
 
     @classmethod
-    def documentLink(cls, params: Mapping[str, Any], view: sublime.View) -> 'Request':
+    def documentLink(cls, params: DocumentLinkParams, view: sublime.View) -> 'Request':
         return Request("textDocument/documentLink", params, view)
 
     @classmethod
-    def semanticTokensFull(cls, params: Mapping[str, Any], view: sublime.View) -> 'Request':
+    def semanticTokensFull(cls, params: SemanticTokensParams, view: sublime.View) -> 'Request':
         return Request("textDocument/semanticTokens/full", params, view)
 
     @classmethod
-    def semanticTokensFullDelta(cls, params: Mapping[str, Any], view: sublime.View) -> 'Request':
+    def semanticTokensFullDelta(cls, params: SemanticTokensDeltaParams, view: sublime.View) -> 'Request':
         return Request("textDocument/semanticTokens/full/delta", params, view)
 
     @classmethod
-    def semanticTokensRange(cls, params: Mapping[str, Any], view: sublime.View) -> 'Request':
+    def semanticTokensRange(cls, params: SemanticTokensRangeParams, view: sublime.View) -> 'Request':
         return Request("textDocument/semanticTokens/range", params, view)
 
     @classmethod
@@ -5927,6 +5927,18 @@ class Request:
     @classmethod
     def resolveInlayHint(cls, params: InlayHint, view: sublime.View) -> 'Request':
         return Request('inlayHint/resolve', params, view)
+
+    @classmethod
+    def rename(cls, params: RenameParams, view: sublime.View, progress: bool = False) -> 'Request':
+        return Request('textDocument/rename', params, view, progress)
+
+    @classmethod
+    def prepareRename(cls, params: PrepareRenameParams, view: sublime.View, progress: bool = False) -> 'Request':
+        return Request('textDocument/prepareRename', params, view, progress)
+
+    @classmethod
+    def selectionRange(cls, params: SelectionRangeParams) -> 'Request':
+        return Request('textDocument/selectionRange', params)
 
     @classmethod
     def workspaceSymbol(cls, params: WorkspaceSymbolParams) -> 'Request':
@@ -6003,35 +6015,35 @@ class Notification:
         return Notification("initialized", {})
 
     @classmethod
-    def didOpen(cls, params: dict) -> 'Notification':
+    def didOpen(cls, params: DidOpenTextDocumentParams) -> 'Notification':
         return Notification("textDocument/didOpen", params)
 
     @classmethod
-    def didChange(cls, params: dict) -> 'Notification':
+    def didChange(cls, params: DidChangeTextDocumentParams) -> 'Notification':
         return Notification("textDocument/didChange", params)
 
     @classmethod
-    def willSave(cls, params: dict) -> 'Notification':
+    def willSave(cls, params: WillSaveTextDocumentParams) -> 'Notification':
         return Notification("textDocument/willSave", params)
 
     @classmethod
-    def didSave(cls, params: dict) -> 'Notification':
+    def didSave(cls, params: DidSaveTextDocumentParams) -> 'Notification':
         return Notification("textDocument/didSave", params)
 
     @classmethod
-    def didClose(cls, params: dict) -> 'Notification':
+    def didClose(cls, params: DidCloseTextDocumentParams) -> 'Notification':
         return Notification("textDocument/didClose", params)
 
     @classmethod
-    def didChangeConfiguration(cls, params: dict) -> 'Notification':
+    def didChangeConfiguration(cls, params: DidChangeTextDocumentParams) -> 'Notification':
         return Notification("workspace/didChangeConfiguration", params)
 
     @classmethod
-    def didChangeWatchedFiles(cls, params: dict) -> 'Notification':
+    def didChangeWatchedFiles(cls, params: DidChangeWatchedFilesParams) -> 'Notification':
         return Notification("workspace/didChangeWatchedFiles", params)
 
     @classmethod
-    def didChangeWorkspaceFolders(cls, params: dict) -> 'Notification':
+    def didChangeWorkspaceFolders(cls, params: DidChangeWorkspaceFoldersParams) -> 'Notification':
         return Notification("workspace/didChangeWorkspaceFolders", params)
 
     @classmethod

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -6035,7 +6035,7 @@ class Notification:
         return Notification("textDocument/didClose", params)
 
     @classmethod
-    def didChangeConfiguration(cls, params: DidChangeTextDocumentParams) -> 'Notification':
+    def didChangeConfiguration(cls, params: DidChangeConfigurationParams) -> 'Notification':
         return Notification("workspace/didChangeConfiguration", params)
 
     @classmethod

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1347,12 +1347,11 @@ class Session(TransportCallbacks):
         if self.should_notify_did_change_workspace_folders():
             added, removed = diff(self._workspace_folders, folders)
             if added or removed:
-                change_event = {
-                    "added": [a.to_lsp() for a in added],
-                    "removed": [r.to_lsp() for r in removed]
-                }  # type: WorkspaceFoldersChangeEvent
                 params = {
-                    "event": change_event
+                    "event": {
+                        "added": [a.to_lsp() for a in added],
+                        "removed": [r.to_lsp() for r in removed]
+                    }
                 }  # type: DidChangeWorkspaceFoldersParams
                 self.send_notification(Notification.didChangeWorkspaceFolders(params))
         if self._supports_workspace_folders():

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -59,7 +59,6 @@ from .protocol import TokenFormat
 from .protocol import WindowClientCapabilities
 from .protocol import WorkspaceClientCapabilities
 from .protocol import WorkspaceEdit
-from .protocol import WorkspaceFoldersChangeEvent
 from .settings import client_configs
 from .settings import globalprefs
 from .transports import Transport

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -504,9 +504,9 @@ def did_change_text_document_params(
     view: sublime.View, version: int, changes: Optional[Iterable[sublime.TextChange]] = None
 ) -> DidChangeTextDocumentParams:
     content_changes = []  # type: List[TextDocumentContentChangeEvent]
-    result = cast(DidChangeTextDocumentParams, {
+    result = {
         "textDocument": versioned_text_document_identifier(view, version), "contentChanges": content_changes
-    })
+    }  # type: DidChangeTextDocumentParams
     if changes is None:
         # TextDocumentSyncKind.Full
         content_changes.append({"text": entire_content(view)})
@@ -526,9 +526,9 @@ def will_save_text_document_params(
 def did_save_text_document_params(
     view: sublime.View, include_text: bool, uri: Optional[DocumentUri] = None
 ) -> DidSaveTextDocumentParams:
-    result = cast(DidSaveTextDocumentParams, {
+    result = {
         "textDocument": text_document_identifier(uri if uri is not None else view)
-    })
+    }  # type: DidSaveTextDocumentParams
     if include_text:
         result["text"] = entire_content(view)
     return result

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -505,7 +505,8 @@ def did_change_text_document_params(
 ) -> DidChangeTextDocumentParams:
     content_changes = []  # type: List[TextDocumentContentChangeEvent]
     result = {
-        "textDocument": versioned_text_document_identifier(view, version), "contentChanges": content_changes
+        "textDocument": versioned_text_document_identifier(view, version),
+        "contentChanges": content_changes
     }  # type: DidChangeTextDocumentParams
     if changes is None:
         # TextDocumentSyncKind.Full

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -13,6 +13,11 @@ from .protocol import CompletionItemTag
 from .protocol import Diagnostic
 from .protocol import DiagnosticRelatedInformation
 from .protocol import DiagnosticSeverity
+from .protocol import DidChangeTextDocumentParams
+from .protocol import DidCloseTextDocumentParams
+from .protocol import DidOpenTextDocumentParams
+from .protocol import DidSaveTextDocumentParams
+from .protocol import DocumentColorParams
 from .protocol import DocumentHighlightKind
 from .protocol import DocumentUri
 from .protocol import ExperimentalTextDocumentRangeParams
@@ -25,9 +30,15 @@ from .protocol import Point
 from .protocol import Position
 from .protocol import Range
 from .protocol import Request
+from .protocol import SelectionRangeParams
 from .protocol import SymbolKind
+from .protocol import TextDocumentContentChangeEvent
 from .protocol import TextDocumentIdentifier
+from .protocol import TextDocumentItem
 from .protocol import TextDocumentPositionParams
+from .protocol import TextDocumentSaveReason
+from .protocol import VersionedTextDocumentIdentifier
+from .protocol import WillSaveTextDocumentParams
 from .settings import userprefs
 from .types import ClientConfig
 from .typing import Callable, Optional, Dict, Any, Iterable, List, Union, Tuple, cast
@@ -448,7 +459,7 @@ def entire_content_range(view: sublime.View) -> Range:
     return region_to_range(view, entire_content_region(view))
 
 
-def text_document_item(view: sublime.View, language_id: str) -> Dict[str, Any]:
+def text_document_item(view: sublime.View, language_id: str) -> TextDocumentItem:
     return {
         "uri": uri_from_view(view),
         "languageId": language_id,
@@ -457,7 +468,7 @@ def text_document_item(view: sublime.View, language_id: str) -> Dict[str, Any]:
     }
 
 
-def versioned_text_document_identifier(view: sublime.View, version: int) -> Dict[str, Any]:
+def versioned_text_document_identifier(view: sublime.View, version: int) -> VersionedTextDocumentIdentifier:
     return {"uri": uri_from_view(view), "version": version}
 
 
@@ -474,11 +485,11 @@ def text_document_range_params(view: sublime.View, location: int,
     }
 
 
-def did_open_text_document_params(view: sublime.View, language_id: str) -> Dict[str, Any]:
+def did_open_text_document_params(view: sublime.View, language_id: str) -> DidOpenTextDocumentParams:
     return {"textDocument": text_document_item(view, language_id)}
 
 
-def render_text_change(change: sublime.TextChange) -> Dict[str, Any]:
+def render_text_change(change: sublime.TextChange) -> TextDocumentContentChangeEvent:
     # Note: cannot use protocol.Range because these are "historic" points.
     return {
         "range": {
@@ -489,10 +500,13 @@ def render_text_change(change: sublime.TextChange) -> Dict[str, Any]:
     }
 
 
-def did_change_text_document_params(view: sublime.View, version: int,
-                                    changes: Optional[Iterable[sublime.TextChange]] = None) -> Dict[str, Any]:
-    content_changes = []  # type: List[Dict[str, Any]]
-    result = {"textDocument": versioned_text_document_identifier(view, version), "contentChanges": content_changes}
+def did_change_text_document_params(
+    view: sublime.View, version: int, changes: Optional[Iterable[sublime.TextChange]] = None
+) -> DidChangeTextDocumentParams:
+    content_changes = []  # type: List[TextDocumentContentChangeEvent]
+    result = cast(DidChangeTextDocumentParams, {
+        "textDocument": versioned_text_document_identifier(view, version), "contentChanges": content_changes
+    })
     if changes is None:
         # TextDocumentSyncKind.Full
         content_changes.append({"text": entire_content(view)})
@@ -503,21 +517,24 @@ def did_change_text_document_params(view: sublime.View, version: int,
     return result
 
 
-def will_save_text_document_params(view_or_uri: Union[DocumentUri, sublime.View], reason: int) -> Dict[str, Any]:
+def will_save_text_document_params(
+    view_or_uri: Union[DocumentUri, sublime.View], reason: TextDocumentSaveReason
+) -> WillSaveTextDocumentParams:
     return {"textDocument": text_document_identifier(view_or_uri), "reason": reason}
 
 
 def did_save_text_document_params(
     view: sublime.View, include_text: bool, uri: Optional[DocumentUri] = None
-) -> Dict[str, Any]:
-    identifier = text_document_identifier(uri if uri is not None else view)
-    result = {"textDocument": identifier}  # type: Dict[str, Any]
+) -> DidSaveTextDocumentParams:
+    result = cast(DidSaveTextDocumentParams, {
+        "textDocument": text_document_identifier(uri if uri is not None else view)
+    })
     if include_text:
         result["text"] = entire_content(view)
     return result
 
 
-def did_close_text_document_params(uri: DocumentUri) -> Dict[str, Any]:
+def did_close_text_document_params(uri: DocumentUri) -> DidCloseTextDocumentParams:
     return {"textDocument": text_document_identifier(uri)}
 
 
@@ -530,11 +547,11 @@ def did_change(view: sublime.View, version: int,
     return Notification.didChange(did_change_text_document_params(view, version, changes))
 
 
-def will_save(uri: DocumentUri, reason: int) -> Notification:
+def will_save(uri: DocumentUri, reason: TextDocumentSaveReason) -> Notification:
     return Notification.willSave(will_save_text_document_params(uri, reason))
 
 
-def will_save_wait_until(view: sublime.View, reason: int) -> Request:
+def will_save_wait_until(view: sublime.View, reason: TextDocumentSaveReason) -> Request:
     return Request.willSaveWaitUntil(will_save_text_document_params(view, reason), view)
 
 
@@ -579,7 +596,7 @@ def text_document_range_formatting(view: sublime.View, region: sublime.Region) -
     }, view, progress=True)
 
 
-def selection_range_params(view: sublime.View) -> Dict[str, Any]:
+def selection_range_params(view: sublime.View) -> SelectionRangeParams:
     return {
         "textDocument": text_document_identifier(view),
         "positions": [position(view, r.b) for r in view.sel()]
@@ -845,7 +862,7 @@ def lsp_color_to_phantom(view: sublime.View, color_info: ColorInformation) -> su
     return sublime.Phantom(region, lsp_color_to_html(color_info), sublime.LAYOUT_INLINE)
 
 
-def document_color_params(view: sublime.View) -> Dict[str, Any]:
+def document_color_params(view: sublime.View) -> DocumentColorParams:
     return {"textDocument": text_document_identifier(view)}
 
 

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -1,5 +1,6 @@
+from .protocol import WorkspaceFolder as LspWorkspaceFolder
 from .types import diff
-from .typing import Any, Dict, List, Union
+from .typing import Any, List, Union
 from .url import filename_to_uri
 import sublime
 import os
@@ -40,7 +41,7 @@ class WorkspaceFolder:
             return self.name == other.name and self.path == other.path
         return False
 
-    def to_lsp(self) -> Dict[str, str]:
+    def to_lsp(self) -> LspWorkspaceFolder:
         return {"name": self.name, "uri": self.uri()}
 
     def uri(self) -> str:

--- a/plugin/document_link.py
+++ b/plugin/document_link.py
@@ -1,7 +1,9 @@
 from .core.logging import debug
 from .core.open import open_file_uri
 from .core.open import open_in_browser
-from .core.protocol import DocumentLink, Request
+from .core.protocol import DocumentLink
+from .core.protocol import Request
+from .core.protocol import URI
 from .core.registry import get_position
 from .core.registry import LspTextCommand
 from .core.typing import Optional
@@ -54,7 +56,7 @@ class LspOpenLinkCommand(LspTextCommand):
         if target is not None:
             self.open_target(target)
 
-    def open_target(self, target: str) -> None:
+    def open_target(self, target: URI) -> None:
         if target.startswith("file:"):
             window = self.view.window()
             if window:

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -8,14 +8,18 @@ from .core.promise import Promise
 from .core.protocol import CompletionItem
 from .core.protocol import CompletionItemKind
 from .core.protocol import CompletionList
+from .core.protocol import CompletionParams
 from .core.protocol import Diagnostic
 from .core.protocol import DiagnosticSeverity
 from .core.protocol import DocumentHighlight
 from .core.protocol import DocumentHighlightKind
+from .core.protocol import DocumentHighlightParams
+from .core.protocol import DocumentUri
 from .core.protocol import Error
 from .core.protocol import Request
 from .core.protocol import SignatureHelp
 from .core.protocol import SignatureHelpContext
+from .core.protocol import SignatureHelpParams
 from .core.protocol import SignatureHelpTriggerKind
 from .core.registry import best_session
 from .core.registry import get_position
@@ -31,6 +35,7 @@ from .core.types import DebouncerNonThreadSafe
 from .core.types import FEATURES_TIMEOUT
 from .core.types import SettingsRegistration
 from .core.typing import Any, Callable, Optional, Dict, Generator, Iterable, List, Tuple, Union
+from .core.typing import cast
 from .core.url import parse_uri
 from .core.url import view_to_uri
 from .core.views import diagnostic_severity
@@ -329,10 +334,10 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
                                                       after_ms=self.highlights_debounce_time)
         self.do_signature_help_async(manual=False)
 
-    def get_uri(self) -> str:
+    def get_uri(self) -> DocumentUri:
         return self._uri
 
-    def set_uri(self, new_uri: str) -> None:
+    def set_uri(self, new_uri: DocumentUri) -> None:
         self._uri = new_uri
         self.view.settings().set("lsp_uri", self._uri)
 
@@ -537,11 +542,11 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
                 context_params["triggerCharacter"] = last_char
             if self._sighelp:
                 context_params["activeSignatureHelp"] = self._sighelp.active_signature_help()
-            params = {
+            params = cast(SignatureHelpParams, {
                 "textDocument": position_params["textDocument"],
                 "position": position_params["position"],
                 "context": context_params
-            }
+            })
             language_map = session.markdown_language_id_to_st_syntax_map()
             request = Request.signatureHelp(params, self.view)
             session.send_request_async(request, lambda resp: self._on_signature_help(resp, pos, language_map))
@@ -724,7 +729,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         point = region.b
         session = self.session_async("documentHighlightProvider", point)
         if session:
-            params = text_document_position_params(self.view, point)
+            params = cast(DocumentHighlightParams, text_document_position_params(self.view, point))
             request = Request.documentHighlight(params, self.view)
             session.send_request_async(request, self._on_highlights)
 
@@ -766,9 +771,9 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
 
             def completion_request() -> Promise[ResolvedCompletions]:
                 config_name = session.config.name
-                return session.send_request_task(
-                    Request.complete(text_document_position_params(self.view, location), self.view)
-                ).then(lambda response: (response, config_name))
+                params = cast(CompletionParams, text_document_position_params(self.view, location))
+                request = Request.complete(params, self.view)
+                return session.send_request_task(request).then(lambda response: (response, config_name))
 
             completion_promises.append(completion_request())
 

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -542,11 +542,11 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
                 context_params["triggerCharacter"] = last_char
             if self._sighelp:
                 context_params["activeSignatureHelp"] = self._sighelp.active_signature_help()
-            params = cast(SignatureHelpParams, {
+            params = {
                 "textDocument": position_params["textDocument"],
                 "position": position_params["position"],
                 "context": context_params
-            })
+            }  # type: SignatureHelpParams
             language_map = session.markdown_language_id_to_st_syntax_map()
             request = Request.signatureHelp(params, self.view)
             session.send_request_async(request, lambda resp: self._on_signature_help(resp, pos, language_map))

--- a/plugin/edit.py
+++ b/plugin/edit.py
@@ -22,7 +22,7 @@ def temporary_setting(settings: sublime.Settings, key: str, val: Any) -> Generat
 
 class LspApplyDocumentEditCommand(sublime_plugin.TextCommand):
 
-    def run(self, edit: Any, changes: Optional[List[TextEditTuple]] = None) -> None:
+    def run(self, edit: sublime.Edit, changes: Optional[List[TextEditTuple]] = None) -> None:
         # Apply the changes in reverse, so that we don't invalidate the range
         # of any change that we haven't applied yet.
         if not changes:
@@ -46,7 +46,7 @@ class LspApplyDocumentEditCommand(sublime_plugin.TextCommand):
                 else:
                     self.apply_change(region, replacement, edit)
 
-    def apply_change(self, region: sublime.Region, replacement: str, edit: Any) -> None:
+    def apply_change(self, region: sublime.Region, replacement: str, edit: sublime.Edit) -> None:
         if region.empty():
             self.view.insert(edit, region.a, replacement)
         else:

--- a/plugin/formatting.py
+++ b/plugin/formatting.py
@@ -1,6 +1,7 @@
 from .core.edit import parse_text_edit
 from .core.promise import Promise
 from .core.protocol import Error
+from .core.protocol import TextDocumentSaveReason
 from .core.protocol import TextEdit
 from .core.registry import LspTextCommand
 from .core.sessions import Session
@@ -61,7 +62,7 @@ class WillSaveWaitTask(SaveTask):
 
     def _will_save_wait_until_async(self, session: Session) -> None:
         session.send_request_async(
-            will_save_wait_until(self._task_runner.view, reason=1),  # TextDocumentSaveReason.Manual
+            will_save_wait_until(self._task_runner.view, reason=TextDocumentSaveReason.Manual),
             self._on_response,
             lambda error: self._on_response(None))
 

--- a/plugin/goto_diagnostic.py
+++ b/plugin/goto_diagnostic.py
@@ -1,5 +1,9 @@
-from .core.diagnostics_storage import ParsedUri, is_severity_included
-from .core.protocol import Diagnostic, DocumentUri, DiagnosticSeverity, Location
+from .core.diagnostics_storage import is_severity_included
+from .core.diagnostics_storage import ParsedUri
+from .core.protocol import Diagnostic
+from .core.protocol import DiagnosticSeverity
+from .core.protocol import DocumentUri
+from .core.protocol import Location
 from .core.registry import windows
 from .core.sessions import Session
 from .core.settings import userprefs
@@ -7,9 +11,14 @@ from .core.types import ClientConfig
 from .core.typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple, Union
 from .core.url import parse_uri, unparse_uri
 from .core.views import DIAGNOSTIC_KINDS
-from .core.views import MissingUriError, uri_from_view, get_uri_and_position_from_location, to_encoded_filename
+from .core.views import diagnostic_severity
 from .core.views import format_diagnostic_for_html
-from .core.views import diagnostic_severity, format_diagnostic_source_and_code, format_severity
+from .core.views import format_diagnostic_source_and_code
+from .core.views import format_severity
+from .core.views import get_uri_and_position_from_location
+from .core.views import MissingUriError
+from .core.views import to_encoded_filename
+from .core.views import uri_from_view
 from abc import ABCMeta
 from abc import abstractmethod
 from collections import Counter, OrderedDict

--- a/plugin/inlay_hint.py
+++ b/plugin/inlay_hint.py
@@ -1,4 +1,8 @@
-from .core.protocol import InlayHintLabelPart, MarkupContent, Point, InlayHint, Request
+from .core.protocol import InlayHint
+from .core.protocol import InlayHintLabelPart
+from .core.protocol import MarkupContent
+from .core.protocol import Point
+from .core.protocol import Request
 from .core.registry import LspTextCommand
 from .core.sessions import Session
 from .core.typing import cast, Optional, Union

--- a/plugin/locationpicker.py
+++ b/plugin/locationpicker.py
@@ -1,6 +1,8 @@
 from .core.logging import debug
-from .core.protocol import DocumentUri, Location, Position
+from .core.protocol import DocumentUri
+from .core.protocol import Location
 from .core.protocol import LocationLink
+from .core.protocol import Position
 from .core.sessions import Session
 from .core.typing import Union, List, Optional, Tuple
 from .core.views import get_uri_and_position_from_location

--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -123,11 +123,11 @@ class LspSymbolRenameCommand(LspTextCommand):
         if not session:
             return
         position_params = text_document_position_params(self.view, position)
-        params = cast(RenameParams, {
+        params = {
             "textDocument": position_params["textDocument"],
             "position": position_params["position"],
             "newName": new_name,
-        })
+        }  # type: RenameParams
         request = Request.rename(params, self.view, progress=True)
         session.send_request(request, partial(self._on_rename_result_async, session))
 

--- a/plugin/selection_range.py
+++ b/plugin/selection_range.py
@@ -1,16 +1,16 @@
 from .core.protocol import Request
+from .core.protocol import SelectionRange
 from .core.registry import get_position
 from .core.registry import LspTextCommand
-from .core.sessions import method_to_capability
-from .core.typing import Any, Dict, Optional, List, Tuple
+from .core.typing import Any, Optional, List, Tuple
 from .core.views import range_to_region
 from .core.views import selection_range_params
 import sublime
 
 
 class LspExpandSelectionCommand(LspTextCommand):
-    method = 'textDocument/selectionRange'
-    capability = method_to_capability(method)[0]
+
+    capability = 'selectionRangeProvider'
 
     def __init__(self, view: sublime.View) -> None:
         super().__init__(view)
@@ -34,11 +34,11 @@ class LspExpandSelectionCommand(LspTextCommand):
             params = selection_range_params(self.view)
             self._regions.extend(self.view.sel())
             self._change_count = self.view.change_count()
-            session.send_request(Request(self.method, params), self.on_result, self.on_error)
+            session.send_request(Request.selectionRange(params), self.on_result, self.on_error)
         elif fallback:
             self._run_builtin_expand_selection("No {} found".format(self.capability))
 
-    def on_result(self, params: Any) -> None:
+    def on_result(self, params: Optional[List[SelectionRange]]) -> None:
         if self._change_count != self.view.change_count():
             return
         if params:
@@ -61,7 +61,7 @@ class LspExpandSelectionCommand(LspTextCommand):
         self._status_message("{}, reverting to built-in Expand Selection".format(fallback_reason))
         self.view.run_command("expand_selection", {"to": "smart"})
 
-    def _smallest_containing(self, region: sublime.Region, param: Dict[str, Any]) -> Tuple[int, int]:
+    def _smallest_containing(self, region: sublime.Region, param: SelectionRange) -> Tuple[int, int]:
         r = range_to_region(param["range"], self.view)
         # Test for *strict* containment
         if r.contains(region) and (r.a < region.a or r.b > region.b):


### PR DESCRIPTION
This PR should improve some type annotations, mostly by replacing `Dict[str, Any]` or similar with the actual LSP types for request or response parameters. (Plus a little bit of cleanup for imports in a few files, to use one line per import.)

No claim for completeness.