### PR TITLE
Don't use "escapeall" extension when formatting with mdpopups

### DIFF
--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -721,12 +721,6 @@ def minihtml(
             "markdown_extensions": [
                 "markdown.extensions.admonition",
                 {
-                    "pymdownx.escapeall": {
-                        "hardbreak": True,
-                        "nbsp": False
-                    }
-                },
-                {
                     "pymdownx.magiclink": {
                         # links are displayed without the initial ftp://, http://, https://, or ftps://.
                         "hide_protocol": True,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -396,5 +396,11 @@ class ViewsTest(DeferrableTestCase):
     def test_escaped_newline_in_markdown(self) -> None:
         self.assertEqual(
             minihtml(self.view, {"kind": "markdown", "value": "hello\\\nworld"}, FORMAT_MARKUP_CONTENT),
-            "<p>hello<br />\nworld</p>"
+            "<p>hello\\\nworld</p>"
+        )
+
+    def test_single_backslash_in_markdown(self) -> None:
+        self.assertEqual(
+            minihtml(self.view, {"kind": "markdown", "value": "A\\B"}, FORMAT_MARKUP_CONTENT),
+            "<p>A\\B</p>"
         )


### PR DESCRIPTION
The motivation is provided in #2158 but basically [both](https://github.com/sublimelsp/LSP-css/pull/16) [issues](https://github.com/sublimelsp/LSP/pull/1591) that we had that needed this extension don't seem to manifest itself anymore and there is a new #2151 issue that it causes.

Fixes #2151