### PR TITLE
Use "plaintext" language ID for plain text files

### DIFF
--- a/language-ids.sublime-settings
+++ b/language-ids.sublime-settings
@@ -98,21 +98,21 @@
     "text.html.markdown.rmarkdown": "r", // https://github.com/REditorSupport/sublime-ide-r
     "text.html.ngx": "html", // https://github.com/princemaple/ngx-html-syntax
     "text.jinja": "html", // https://github.com/Sublime-Instincts/BetterJinja
-    "text.plain": "txt",
-    "text.plain.buildpacks": "txt", // https://github.com/SublimeText/AFileIcon
-    "text.plain.eslint": "txt", // https://github.com/SublimeText/AFileIcon
-    "text.plain.fastq": "txt", // https://github.com/SublimeText/AFileIcon
-    "text.plain.license": "txt", // https://github.com/SublimeText/AFileIcon
-    "text.plain.lnk": "txt", // https://github.com/SublimeText/AFileIcon
-    "text.plain.log": "txt", // https://github.com/SublimeText/AFileIcon
-    "text.plain.nodejs": "txt", // https://github.com/SublimeText/AFileIcon
-    "text.plain.pcb": "txt", // https://github.com/SublimeText/AFileIcon
-    "text.plain.ps": "txt", // https://github.com/SublimeText/AFileIcon
-    "text.plain.python": "txt", // https://github.com/SublimeText/AFileIcon
-    "text.plain.readme": "txt", // https://github.com/SublimeText/AFileIcon
-    "text.plain.ruby": "txt", // https://github.com/SublimeText/AFileIcon
-    "text.plain.sketch": "txt", // https://github.com/SublimeText/AFileIcon
-    "text.plain.visualstudio": "txt", // https://github.com/SublimeText/AFileIcon
+    "text.plain": "plaintext",
+    "text.plain.buildpacks": "plaintext", // https://github.com/SublimeText/AFileIcon
+    "text.plain.eslint": "plaintext", // https://github.com/SublimeText/AFileIcon
+    "text.plain.fastq": "plaintext", // https://github.com/SublimeText/AFileIcon
+    "text.plain.license": "plaintext", // https://github.com/SublimeText/AFileIcon
+    "text.plain.lnk": "plaintext", // https://github.com/SublimeText/AFileIcon
+    "text.plain.log": "plaintext", // https://github.com/SublimeText/AFileIcon
+    "text.plain.nodejs": "plaintext", // https://github.com/SublimeText/AFileIcon
+    "text.plain.pcb": "plaintext", // https://github.com/SublimeText/AFileIcon
+    "text.plain.ps": "plaintext", // https://github.com/SublimeText/AFileIcon
+    "text.plain.python": "plaintext", // https://github.com/SublimeText/AFileIcon
+    "text.plain.readme": "plaintext", // https://github.com/SublimeText/AFileIcon
+    "text.plain.ruby": "plaintext", // https://github.com/SublimeText/AFileIcon
+    "text.plain.sketch": "plaintext", // https://github.com/SublimeText/AFileIcon
+    "text.plain.visualstudio": "plaintext", // https://github.com/SublimeText/AFileIcon
     "text.plist": "xml", // https://bitbucket.org/fschwehn/sublime_plist
     "text.xml.plist": "xml", // https://github.com/SublimeText/PackageDev
     "text.xml.plist.textmate.preferences": "xml", // https://github.com/SublimeText/PackageDev

--- a/tests/test_server_requests.py
+++ b/tests/test_server_requests.py
@@ -130,14 +130,14 @@ class ServerRequests(TextDocumentTestCase):
                     {"method": "workspace/didChangeWorkspaceFolders", "id": "asdf"},
                     {"method": "textDocument/didOpen", "id": "1"},
                     {"method": "textDocument/willSaveWaitUntil", "id": "2",
-                     "registerOptions": {"documentSelector": [{"language": "txt"}]}},
+                     "registerOptions": {"documentSelector": [{"language": "plaintext"}]}},
                     {"method": "textDocument/didChange", "id": "adsf",
                      "registerOptions": {"syncKind": TextDocumentSyncKind.Full, "documentSelector": [
-                       {"language": "txt"}
+                       {"language": "plaintext"}
                      ]}},
                     {"method": "textDocument/completion", "id": "myCompletionRegistrationId",
                      "registerOptions": {"triggerCharacters": ["!", "@", "#"], "documentSelector": [
-                       {"language": "txt"}
+                       {"language": "plaintext"}
                      ]}}
                 ]
             },
@@ -206,7 +206,7 @@ class ServerRequestsWithAutoCompleteSelector(TextDocumentTestCase):
                     # Note that the triggerCharacters are disabled in the configuration.
                     {"method": "textDocument/completion", "id": "anotherCompletionRegistrationId",
                      "registerOptions": {"triggerCharacters": ["!", "@", "#"], "documentSelector": [
-                       {"language": "txt"}
+                       {"language": "plaintext"}
                      ]}}
                 ]
             },

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -59,7 +59,7 @@ class TestDocumentSelector(unittest.TestCase):
         return view
 
     def test_language(self) -> None:
-        selector = DocumentSelector([{"language": "txt"}])
+        selector = DocumentSelector([{"language": "plaintext"}])
         view = self._make_view("Packages/Text/Plain text.tmLanguage", "foobar.txt")
         self.assertTrue(selector.matches(view))
         view = self._make_view("Packages/Python/Python.sublime-syntax", "hello.py")


### PR DESCRIPTION
This change is required for LSP-cspell to work in plaintext files.

ref to spec https://github.com/microsoft/language-server-protocol/pull/1577