### PR TITLE
docs: fsautocomplete config - remove redundant argument

### DIFF
--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -129,7 +129,7 @@ Follow installation instructions on [LSP-elm](https://github.com/sublimelsp/LSP-
         "clients": {
             "fsautocomplete": {
                 "enabled": true,
-                "command": ["fsautocomplete", "--background-service-enabled"],
+                "command": ["fsautocomplete"],
                 "selector": "source.fsharp",
                 "initializationOptions": {
                     "AutomaticWorkspaceInit": true


### PR DESCRIPTION
this is default now

The argument is not available anymore. 