### PR TITLE
Make Document Symbols behavior more consistent with built-in Goto Symbol

### DIFF
--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -196,34 +196,26 @@ SUBLIME_KIND_SCOPES = {
     sublime.KIND_VARIABLE: "entity.name.constant | constant.other | support.constant | variable.other | variable.parameter | variable.other.member | variable.other.readwrite.member"  # noqa: E501
 }  # type: Dict[SublimeKind, str]
 
-SYMBOL_KIND_SCOPES = {
-    SymbolKind.File: "string",
-    SymbolKind.Module: "entity.name.namespace",
-    SymbolKind.Namespace: "entity.name.namespace",
-    SymbolKind.Package: "entity.name.namespace",
-    SymbolKind.Class: "entity.name.class",
-    SymbolKind.Method: "entity.name.function",
-    SymbolKind.Property: "variable.other.member",
-    SymbolKind.Field: "variable.other.member",
-    SymbolKind.Constructor: "entity.name.function.constructor",
-    SymbolKind.Enum: "entity.name.enum",
-    SymbolKind.Interface: "entity.name.interface",
-    SymbolKind.Function: "entity.name.function",
-    SymbolKind.Variable: "variable.other",
-    SymbolKind.Constant: "variable.other.constant",
-    SymbolKind.String: "string",
-    SymbolKind.Number: "constant.numeric",
-    SymbolKind.Boolean: "constant.language.boolean",
-    SymbolKind.Array: "meta.sequence",
-    SymbolKind.Object: "meta.mapping",
-    SymbolKind.Key: "meta.mapping.key string",
-    SymbolKind.Null: "constant.language.null",
-    SymbolKind.EnumMember: "constant.other.enum",
-    SymbolKind.Struct: "entity.name.struct",
-    SymbolKind.Event: "entity.name.function",
-    SymbolKind.Operator: "keyword.operator",
-    SymbolKind.TypeParameter: "variable.parameter.type"
-}  # type: Dict[SymbolKind, str]
+# Recommended colors to use by themes for each symbol kind, based on the kind_container specialization class described
+# at https://www.sublimetext.com/docs/themes.html#quick-panel
+SUBLIME_KIND_ID_COLOR_SCOPES = {
+    sublime.KIND_ID_KEYWORD: "region.pinkish",
+    sublime.KIND_ID_TYPE: "region.purplish",
+    sublime.KIND_ID_FUNCTION: "region.redish",
+    sublime.KIND_ID_NAMESPACE: "region.bluish",
+    sublime.KIND_ID_NAVIGATION: "region.yellowish",
+    sublime.KIND_ID_MARKUP: "region.orangish",
+    sublime.KIND_ID_VARIABLE: "region.cyanish",
+    sublime.KIND_ID_SNIPPET: "region.greenish",
+    sublime.KIND_ID_COLOR_REDISH: "region.redish",
+    sublime.KIND_ID_COLOR_ORANGISH: "region.orangish",
+    sublime.KIND_ID_COLOR_YELLOWISH: "region.yellowish",
+    sublime.KIND_ID_COLOR_GREENISH: "region.greenish",
+    sublime.KIND_ID_COLOR_CYANISH: "region.cyanish",
+    sublime.KIND_ID_COLOR_BLUISH: "region.bluish",
+    sublime.KIND_ID_COLOR_PURPLISH: "region.purplish",
+    sublime.KIND_ID_COLOR_PINKISH: "region.pinkish"
+}  # type: Dict[int, str]
 
 DOCUMENT_HIGHLIGHT_KINDS = {
     DocumentHighlightKind.Text: "text",

--- a/plugin/symbols.py
+++ b/plugin/symbols.py
@@ -115,13 +115,13 @@ class LspDocumentSymbolsCommand(LspTextCommand):
                         selected_index = i
                     else:
                         break
+            self.view.run_command("lsp_selection_clear")
             window.show_quick_panel(
                 panel_items,
                 self.on_symbol_selected,
                 sublime.KEEP_OPEN_ON_FOCUS_LOST,
                 selected_index,
                 self.on_highlighted)
-            self.view.run_command("lsp_selection_clear")
 
     def handle_response_error(self, error: Any) -> None:
         self.view.settings().erase(SUPPRESS_INPUT_SETTING_KEY)

--- a/plugin/symbols.py
+++ b/plugin/symbols.py
@@ -4,8 +4,8 @@ from .core.registry import LspTextCommand
 from .core.sessions import print_to_status_bar
 from .core.typing import Any, List, Optional, Tuple, Dict, Generator, Union, cast
 from .core.views import range_to_region
+from .core.views import SUBLIME_KIND_ID_COLOR_SCOPES
 from .core.views import SublimeKind
-from .core.views import SYMBOL_KIND_SCOPES
 from .core.views import SYMBOL_KINDS
 from .core.views import text_document_identifier
 from contextlib import contextmanager
@@ -21,12 +21,8 @@ def unpack_lsp_kind(kind: SymbolKind) -> SublimeKind:
     return SYMBOL_KINDS.get(kind, sublime.KIND_AMBIGUOUS)
 
 
-def format_symbol_kind(kind: SymbolKind) -> str:
-    return SYMBOL_KINDS.get(kind, (None, None, str(kind)))[2]
-
-
-def get_symbol_scope_from_lsp_kind(kind: SymbolKind) -> str:
-    return SYMBOL_KIND_SCOPES.get(kind, "comment")
+def get_symbol_color_scope_from_lsp_kind(kind: SymbolKind) -> str:
+    return SUBLIME_KIND_ID_COLOR_SCOPES.get(unpack_lsp_kind(kind)[0], "comment")
 
 
 def symbol_information_to_quick_panel_item(
@@ -188,7 +184,7 @@ class LspDocumentSymbolsCommand(LspTextCommand):
         lsp_kind = item["kind"]
         self.regions.append((range_to_region(item['range'], self.view),
                              range_to_region(item['selectionRange'], self.view),
-                             get_symbol_scope_from_lsp_kind(lsp_kind)))
+                             get_symbol_color_scope_from_lsp_kind(lsp_kind)))
         name = item['name']
         with _additional_name(names, name):
             st_kind, st_icon, st_display_type = unpack_lsp_kind(lsp_kind)
@@ -215,7 +211,7 @@ class LspDocumentSymbolsCommand(LspTextCommand):
         quick_panel_items = []  # type: List[sublime.QuickPanelItem]
         for item in items:
             self.regions.append((range_to_region(item['location']['range'], self.view),
-                                 None, get_symbol_scope_from_lsp_kind(item['kind'])))
+                                 None, get_symbol_color_scope_from_lsp_kind(item['kind'])))
             quick_panel_item = symbol_information_to_quick_panel_item(item, show_file_name=False)
             quick_panel_items.append(quick_panel_item)
         return quick_panel_items


### PR DESCRIPTION
Some suggestions for the "LSP: Goto Symbol..." feature to follow ST's "Goto Symbol..." more closely (the current implementation is closer to what VSCode does, though, but I don't think that matters much).

* If the server response is of type SymbolInformation (deprecated), then adjust the outline color for highlighted items to use the color from the symbol item kind (which is defined by the theme, but there is a strong recommendation in the [theme docs](https://www.sublimetext.com/docs/themes.html#quick-panel) under `kind_container`, and the built-in themes follow those recommendation), rather than the scope color from the color scheme for the symbol. By using the theme's kind color the outline matches the icon color in the quick panel.
* If the server response is of type DocumentSymbol, i.e. it has a `selectionRange`, select that range when a quick panel item is selected and even when highlighted, similar to ST's built-in "Goto Symbol". I had previously questioned the current behavior of the empty selection at https://github.com/sublimelsp/LSP/pull/1031#discussion_r429376293, but I think to select the given "selectionRange" should be fine if we differentiate based on response type. The full `range` isn't highlighted anymore for this response type now, and according to the LSP specs it seems to be intended to highlight items in a permanent outline view (which doesn't exist in ST):
  > This information is typically used to determine if the clients cursor is inside the symbol to reveal in the symbol in the UI.
* Minor code cleanup: remove unused `format_symbol_kind` function, replace `if len(some_list) > 0:` by `if some_list:`