### PR TITLE
trigger "on_server_response_async" also for "initialize" response

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
           python-version: '3.8'
       - run: sudo apt update
       - run: sudo apt install --no-install-recommends -y x11-xserver-utils
-      - run: pip3 install mypy==0.971 flake8==5.0.4 pyright==1.1.271 yapf==0.31.0 --user
+      - run: pip3 install mypy==0.971 flake8==5.0.4 pyright==1.1.290 yapf==0.31.0 --user
       - run: echo "$HOME/.local/bin" >> $GITHUB_PATH
       # - run: mypy -p plugin
       - run: flake8 plugin tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
           python-version: '3.8'
       - run: sudo apt update
       - run: sudo apt install --no-install-recommends -y x11-xserver-utils
-      - run: pip3 install mypy==0.971 flake8==5.0.4 pyright==1.1.290 yapf==0.31.0 --user
+      - run: pip3 install mypy==0.971 flake8==5.0.4 pyright==1.1.289 yapf==0.31.0 --user
       - run: echo "$HOME/.local/bin" >> $GITHUB_PATH
       # - run: mypy -p plugin
       - run: flake8 plugin tests

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -5987,6 +5987,7 @@ class Error(Exception):
 
 T = TypeVar('T', bound=Union[None, bool, int, Uint, float, str, Mapping[str, Any], Iterable[Any]])
 
+
 class Response(Generic[T]):
 
     __slots__ = ('request_id', 'result')

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -1,5 +1,5 @@
 from .typing import Enum, IntEnum, IntFlag, StrEnum
-from .typing import Any, Dict, Iterable, List, Literal, Mapping, NotRequired, Optional, TypedDict, Union
+from .typing import Any, Dict, Generic, Iterable, List, Literal, Mapping, NotRequired, Optional, TypedDict, TypeVar, Union  # noqa: E501
 import sublime
 
 INT_MAX = 2**31 - 1
@@ -5985,11 +5985,13 @@ class Error(Exception):
         return Error(ErrorCodes.InternalError, str(ex))
 
 
-class Response:
+T = TypeVar('T', bound=Union[None, bool, int, Uint, float, str, Mapping[str, Any], Iterable[Any]])
+
+class Response(Generic[T]):
 
     __slots__ = ('request_id', 'result')
 
-    def __init__(self, request_id: Any, result: Union[None, Mapping[str, Any], Iterable[Any]]) -> None:
+    def __init__(self, request_id: Any, result: T) -> None:
         self.request_id = request_id
         self.result = result
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -36,7 +36,9 @@ from .protocol import ExecuteCommandParams
 from .protocol import FailureHandlingKind
 from .protocol import FileEvent
 from .protocol import GeneralClientCapabilities
+from .protocol import InitializeError
 from .protocol import InitializeParams
+from .protocol import InitializeResult
 from .protocol import InsertTextMode
 from .protocol import Location
 from .protocol import LocationLink
@@ -1373,13 +1375,16 @@ class Session(TransportCallbacks):
         self.send_request_async(
             Request.initialize(params), self._handle_initialize_success, self._handle_initialize_error)
 
-    def _handle_initialize_success(self, result: Any) -> None:
+    def _handle_initialize_success(self, result: InitializeResult) -> None:
         self.capabilities.assign(result.get('capabilities', dict()))
         if self._workspace_folders and not self._supports_workspace_folders():
             self._workspace_folders = self._workspace_folders[:1]
         self.state = ClientStates.READY
         if self._plugin_class is not None:
             self._plugin = self._plugin_class(weakref.ref(self))
+            # We've missed calling the "on_server_response_async" API as plugin was not created yet.
+            # Handle it now and use fake request ID since it shouldn't matter.
+            self._plugin.on_server_response_async('initialize', Response(-1, result))
         self.send_notification(Notification.initialized())
         self._maybe_send_did_change_configuration()
         execute_commands = self.get_capability('executeCommandProvider.commands')
@@ -1407,7 +1412,7 @@ class Session(TransportCallbacks):
             self._init_callback(self, False)
             self._init_callback = None
 
-    def _handle_initialize_error(self, result: Any) -> None:
+    def _handle_initialize_error(self, result: InitializeError) -> None:
         self._initialize_error = (result.get('code', -1), Exception(result.get('message', 'Error initializing server')))
         # Init callback called after transport is closed to avoid pre-mature GC of Session.
         self.end_async()

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -259,8 +259,8 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         for sb, diagnostics in self._diagnostics_async():
             intersections = []  # type: List[Diagnostic]
             for diagnostic, candidate in diagnostics:
-                # Checking against points is inclusive unlike checking whether region intersects another
-                # region which is exclusive (at region end) and we want an inclusive behavior in this case.
+                # Checking against points is inclusive unlike checking whether region intersects another region
+                # which is exclusive (at region end) and we want an inclusive behavior in this case.
                 if region.contains(candidate.a) or region.contains(candidate.b):
                     covering = covering.cover(candidate)
                     intersections.append(diagnostic)

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ per-file-ignores =
 deps =
     ; mypy==0.971
     flake8==5.0.4
-    pyright==1.1.271
+    pyright==1.1.290
 commands =
     # mypy disabled as it doesn't currently support cyclic definitions - https://github.com/python/mypy/issues/731
     ; mypy plugin

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ per-file-ignores =
 deps =
     ; mypy==0.971
     flake8==5.0.4
-    pyright==1.1.290
+    pyright==1.1.289
 commands =
     # mypy disabled as it doesn't currently support cyclic definitions - https://github.com/python/mypy/issues/731
     ; mypy plugin


### PR DESCRIPTION
We didn't trigger `AbstractPlugin.on_server_response_async` for the `initialize` response because plugin instance is created a bit later, from the initialize handler. Have exception for that case and trigger it manually from the handler.

I'm contemplating using it in LSP-rome to show server version that is provided in initialize response.

Also making `Repsonse` type Generic and more accurate. Not really doing much to improve anything. Just makes it easier to annotate in `on_server_response_async`.