### PR TITLE
feat(API): allow setting additional text in permanent server status

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1140,6 +1140,7 @@ class Session(TransportCallbacks):
         self._logger = logger
         self._response_handlers = {}  # type: Dict[int, Tuple[Request, Callable, Optional[Callable[[Any], None]]]]
         self.config = config
+        self.config_status_message = ''
         self.manager = weakref.ref(manager)
         self.window = manager.window
         self.state = ClientStates.STARTING
@@ -1204,6 +1205,16 @@ class Session(TransportCallbacks):
             if sv.view == view:
                 return sv
         return None
+
+    def set_config_status_async(self, message: str) -> None:
+        """
+        Sets the message that is shown in parenthesis within the permanent language server status.
+
+        :param message: The message
+        """
+        self.config_status_message = message.strip()
+        for sv in self.session_views_async():
+            self.config.set_view_status(sv.view, message)
 
     def set_window_status_async(self, key: str, message: str) -> None:
         self._status_messages[key] = message

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -802,7 +802,7 @@ class ClientConfig:
 
     def set_view_status(self, view: sublime.View, message: str) -> None:
         if sublime.load_settings("LSP.sublime-settings").get("show_view_status"):
-            status = "{}: {}".format(self.name, message) if message else self.name
+            status = "{} ({})".format(self.name, message) if message else self.name
             view.set_status(self.status_key, status)
 
     def erase_view_status(self, view: sublime.View) -> None:

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -265,7 +265,6 @@ class WindowManager(Manager):
                     sublime.set_timeout_async(self._dequeue_listener_async)
                     return self._window.status_message(message)
                 cwd = plugin_class.on_pre_start(self._window, initiating_view, workspace_folders, config)
-            config.set_view_status(initiating_view, "starting...")
             session = Session(self, self._create_logger(config.name), workspace_folders, config, plugin_class)
             if cwd:
                 transport_cwd = cwd  # type: Optional[str]

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -265,6 +265,7 @@ class WindowManager(Manager):
                     sublime.set_timeout_async(self._dequeue_listener_async)
                     return self._window.status_message(message)
                 cwd = plugin_class.on_pre_start(self._window, initiating_view, workspace_folders, config)
+            config.set_view_status(initiating_view, "starting...")
             session = Session(self, self._create_logger(config.name), workspace_folders, config, plugin_class)
             if cwd:
                 transport_cwd = cwd  # type: Optional[str]

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -57,7 +57,7 @@ class SessionView:
             session_buffer.add_session_view(self)
         self._session_buffer = session_buffer
         session.register_session_view_async(self)
-        session.config.set_view_status(self._view, "")
+        session.config.set_view_status(self._view, session.config_status_message)
         if self._session.has_capability(self.HOVER_PROVIDER_KEY):
             self._increment_hover_count()
         self._clear_auto_complete_triggers(settings)


### PR DESCRIPTION
This allows a plugin to call `Session.set_config_status_async` which would add extra text in parenthesis in the server's permanent status. For example can add server version info like:

![Screenshot 2023-01-21 at 23 00 06](https://user-images.githubusercontent.com/153197/213888589-b254d103-5c64-4b8e-84c8-a564b7e896b6.png)

It could also be used to show whether workspace-local or global server is used or anything else.