### PR TITLE
Implement type hierarchy request

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -28,6 +28,10 @@
                 "caption": "Show Call Hierarchy"
             },
             {
+                "command": "lsp_type_hierarchy",
+                "caption": "Show Type Hierarchy"
+            },
+            {
                 "command": "lsp_symbol_rename",
                 "caption": "Rename…"
             },

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -154,4 +154,8 @@
         "caption": "LSP: Show Call Hierarchy",
         "command": "lsp_call_hierarchy"
     },
+    {
+        "caption": "LSP: Show Type Hierarchy",
+        "command": "lsp_type_hierarchy"
+    },
 ]

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -194,6 +194,12 @@
     //     "command": "lsp_call_hierarchy",
     //     "context": [{"key": "lsp.session_with_capability", "operand": "callHierarchyProvider"}]
     // },
+    // Show Type Hierarchy
+    // {
+    //     "keys": ["UNBOUND"],
+    //     "command": "lsp_type_hierarchy",
+    //     "context": [{"key": "lsp.session_with_capability", "operand": "typeHierarchyProvider"}]
+    // },
     // Expand Selection (a replacement for ST's "Expand Selection")
     // {
     //     "keys": ["primary+shift+a"],

--- a/boot.py
+++ b/boot.py
@@ -78,6 +78,8 @@ from .plugin.tooling import LspDumpBufferCapabilities
 from .plugin.tooling import LspDumpWindowConfigs
 from .plugin.tooling import LspParseVscodePackageJson
 from .plugin.tooling import LspTroubleshootServerCommand
+from .plugin.type_hierarchy import LspTypeHierarchyCommand
+from .plugin.type_hierarchy import LspTypeHierarchyToggleCommand
 
 
 def _get_final_subclasses(derived: List[Type], results: List[Type]) -> None:

--- a/docs/src/keyboard_shortcuts.md
+++ b/docs/src/keyboard_shortcuts.md
@@ -32,6 +32,7 @@ Refer to the [Customization section](customization.md#keyboard-shortcuts-key-bin
 | Run Refactor Action | unbound | `lsp_code_actions` (with args: `{"only_kinds": ["refactor"]}`)
 | Run Source Action | unbound | `lsp_code_actions` (with args: `{"only_kinds": ["source"]}`)
 | Show Call Hierarchy | unbound | `lsp_call_hierarchy`
+| Show Type Hierarchy | unbound | `lsp_type_hierarchy`
 | Signature Help | <kbd>ctrl</kbd> <kbd>alt</kbd> <kbd>space</kbd> | `lsp_signature_help_show`
 | Toggle Diagnostics Panel | <kbd>ctrl</kbd> <kbd>alt</kbd> <kbd>m</kbd> | `lsp_show_diagnostics_panel`
 | Toggle Log Panel | unbound | `lsp_toggle_server_panel`

--- a/plugin/core/paths.py
+++ b/plugin/core/paths.py
@@ -1,0 +1,69 @@
+from .protocol import DocumentUri
+from .sessions import Session
+from .typing import Iterable, Optional, Tuple
+from .views import parse_uri
+from pathlib import Path
+
+
+def simple_path(session: Optional[Session], uri: DocumentUri) -> str:
+    scheme, path = parse_uri(uri)
+    if not session or scheme != 'file':
+        return path
+    simple_path = simple_project_path([Path(folder.path) for folder in session.get_workspace_folders()], Path(path))
+    return str(simple_path) if simple_path else path
+
+
+def project_path(project_folders: Iterable[Path], file_path: Path) -> Optional[Path]:
+    """
+    The project path of `/path/to/project/file` in the project `/path/to/project` is `file`.
+    """
+    folder_path = split_project_path(project_folders, file_path)
+    if folder_path is None:
+        return None
+    _, file = folder_path
+    return file
+
+
+def simple_project_path(project_folders: Iterable[Path], file_path: Path) -> Optional[Path]:
+    """
+    The simple project path of `/path/to/project/file` in the project `/path/to/project` is `project/file`.
+    """
+    folder_path = split_project_path(project_folders, file_path)
+    if folder_path is None:
+        return None
+    folder, file = folder_path
+    return folder.name / file
+
+
+def resolve_simple_project_path(project_folders: Iterable[Path], file_path: Path) -> Optional[Path]:
+    """
+    The inverse of `simple_project_path()`.
+    """
+    parts = file_path.parts
+    folder_name = parts[0]
+    for folder in project_folders:
+        if folder.name == folder_name:
+            return folder / Path(*parts[1:])
+    return None
+
+
+def project_base_dir(project_folders: Iterable[Path], file_path: Path) -> Optional[Path]:
+    """
+    The project base dir of `/path/to/project/file` in the project `/path/to/project` is `/path/to`.
+    """
+    folder_path = split_project_path(project_folders, file_path)
+    if folder_path is None:
+        return None
+    folder, _ = folder_path
+    return folder.parent
+
+
+def split_project_path(project_folders: Iterable[Path], file_path: Path) -> Optional[Tuple[Path, Path]]:
+    abs_path = file_path.resolve()
+    for folder in project_folders:
+        try:
+            rel_path = abs_path.relative_to(folder)
+        except ValueError:
+            continue
+        return folder, rel_path
+    return None

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -5925,6 +5925,18 @@ class Request:
         return Request("callHierarchy/outgoingCalls", params, None)
 
     @classmethod
+    def prepareTypeHierarchy(cls, params: TypeHierarchyPrepareParams, view: sublime.View) -> 'Request':
+        return Request("textDocument/prepareTypeHierarchy", params, view, progress=True)
+
+    @classmethod
+    def supertypes(cls, params: TypeHierarchySupertypesParams) -> 'Request':
+        return Request("typeHierarchy/supertypes", params, None)
+
+    @classmethod
+    def subtypes(cls, params: TypeHierarchySubtypesParams) -> 'Request':
+        return Request("typeHierarchy/subtypes", params, None)
+
+    @classmethod
     def resolveCompletionItem(cls, params: CompletionItem, view: sublime.View) -> 'Request':
         return Request("completionItem/resolve", params, view)
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -396,6 +396,9 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
         },
         "callHierarchy": {
             "dynamicRegistration": True
+        },
+        "typeHierarchy": {
+            "dynamicRegistration": True
         }
     }  # type: TextDocumentClientCapabilities
     workspace_capabilites = {

--- a/plugin/goto_diagnostic.py
+++ b/plugin/goto_diagnostic.py
@@ -1,5 +1,8 @@
 from .core.diagnostics_storage import is_severity_included
 from .core.diagnostics_storage import ParsedUri
+from .core.paths import project_base_dir
+from .core.paths import project_path
+from .core.paths import simple_project_path
 from .core.protocol import Diagnostic
 from .core.protocol import DiagnosticSeverity
 from .core.protocol import DocumentUri
@@ -8,7 +11,7 @@ from .core.registry import windows
 from .core.sessions import Session
 from .core.settings import userprefs
 from .core.types import ClientConfig
-from .core.typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple, Union
+from .core.typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 from .core.url import parse_uri, unparse_uri
 from .core.views import DIAGNOSTIC_KINDS
 from .core.views import diagnostic_severity
@@ -313,59 +316,3 @@ def truncate_message(diagnostic: Diagnostic, max_lines: int = 6) -> Diagnostic:
     diagnostic = diagnostic.copy()
     diagnostic["message"] = "\n".join(lines[:max_lines - 1]) + " …\n"
     return diagnostic
-
-
-def project_path(project_folders: Iterable[Path], file_path: Path) -> Optional[Path]:
-    """
-    The project path of `/path/to/project/file` in the project `/path/to/project` is `file`.
-    """
-    folder_path = split_project_path(project_folders, file_path)
-    if folder_path is None:
-        return None
-    _, file = folder_path
-    return file
-
-
-def simple_project_path(project_folders: Iterable[Path], file_path: Path) -> Optional[Path]:
-    """
-    The simple project path of `/path/to/project/file` in the project `/path/to/project` is `project/file`.
-    """
-    folder_path = split_project_path(project_folders, file_path)
-    if folder_path is None:
-        return None
-    folder, file = folder_path
-    return folder.name / file
-
-
-def resolve_simple_project_path(project_folders: Iterable[Path], file_path: Path) -> Optional[Path]:
-    """
-    The inverse of `simple_project_path()`.
-    """
-    parts = file_path.parts
-    folder_name = parts[0]
-    for folder in project_folders:
-        if folder.name == folder_name:
-            return folder / Path(*parts[1:])
-    return None
-
-
-def project_base_dir(project_folders: Iterable[Path], file_path: Path) -> Optional[Path]:
-    """
-    The project base dir of `/path/to/project/file` in the project `/path/to/project` is `/path/to`.
-    """
-    folder_path = split_project_path(project_folders, file_path)
-    if folder_path is None:
-        return None
-    folder, _ = folder_path
-    return folder.parent
-
-
-def split_project_path(project_folders: Iterable[Path], file_path: Path) -> Optional[Tuple[Path, Path]]:
-    abs_path = file_path.resolve()
-    for folder in project_folders:
-        try:
-            rel_path = abs_path.relative_to(folder)
-        except ValueError:
-            continue
-        return folder, rel_path
-    return None

--- a/plugin/type_hierarchy.py
+++ b/plugin/type_hierarchy.py
@@ -2,8 +2,6 @@ from .core.paths import simple_path
 from .core.promise import Promise
 from .core.protocol import TypeHierarchyItem
 from .core.protocol import TypeHierarchyPrepareParams
-from .core.protocol import TypeHierarchySubtypesParams
-from .core.protocol import TypeHierarchySupertypesParams
 from .core.protocol import Request
 from .core.registry import new_tree_view_sheet
 from .core.registry import get_position
@@ -48,11 +46,9 @@ class TypeHierarchyDataProvider(TreeDataProvider):
         if not session:
             return Promise.resolve([])
         if self.direction == TypeHierarchyDirection.Supertypes:
-            params = cast(TypeHierarchySupertypesParams, {'item': element})
-            return session.send_request_task(Request.supertypes(params)).then(self._ensure_list)
+            return session.send_request_task(Request.supertypes({'item': element})).then(self._ensure_list)
         elif self.direction == TypeHierarchyDirection.Subtypes:
-            params = cast(TypeHierarchySubtypesParams, {'item': element})
-            return session.send_request_task(Request.subtypes(params)).then(self._ensure_list)
+            return session.send_request_task(Request.subtypes({'item': element})).then(self._ensure_list)
         return Promise.resolve([])
 
     def get_tree_item(self, element: TypeHierarchyItem) -> TreeItem:
@@ -116,7 +112,7 @@ class LspTypeHierarchyCommand(LspTextCommand):
                 'session_name': session.config.name,
                 'direction': TypeHierarchyDirection.Subtypes,
                 'root_elements': response
-            }, tooltip="Show subtypes"))
+            }, tooltip="Show Subtypes"))
         new_tree_view_sheet(self._window, "Type Hierarchy", data_provider, header)
         data_provider.get_children(None).then(partial(open_first, self._window, session.config.name))
 


### PR DESCRIPTION
The type hierarchy specs/interface is very similar to call hierarchy, so `type_hierarchy.py` is basically a copy/paste of `call_hierarchy.py`. I'm unsure whether there should be added another abstraction layer, with `LspHierarchyDataProvider(TreeDataProvider)`, `LspHierarchyCommand`, and `LspHierarchyToggleCommand`, from which call hierarchy & type hierarchy can derive, but then you need to pass a lot of strings and the protocol types in `__init__`. And there is a bit of difference between the call and type hierarchy responses, in that type hierarchy always returns `TypeHierarchyItem[]` directly, but call hierarchy uses wrapper classes `CallHierarchyOutgoingCall[]` / `CallHierarchyIncomingCall[]` with `from`/`to` fields. That could make a generic implementation a bit awkward.
(I assume another abstraction layer would be the preferred choice, but I just wanted to wait for opinions about this first)

I also moved the generic utility functions for filepaths from `goto_diagnostic.py` into its own file `core/paths.py`.

A server which supports type hierarchy is clangd.