### PR TITLE
fix stale state or lack of updates on changing branches

### DIFF
--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -866,18 +866,6 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
                 sv.on_reload_async()
         self._on_view_updated_async()
 
-    def _on_view_updated_async(self) -> None:
-        different, current_region = self._update_stored_region_async()
-        self._code_lenses_debouncer_async.debounce(
-            self._do_code_lenses_async, timeout_ms=self.code_lenses_debounce_time)
-        if not different:
-            return
-        self._clear_highlight_regions()
-        if userprefs().document_highlight_style:
-            self._when_selection_remains_stable_async(self._do_highlights_async, current_region,
-                                                      after_ms=self.highlights_debounce_time)
-        self.do_signature_help_async(manual=False)
-
     # --- Private utility methods --------------------------------------------------------------------------------------
 
     def _when_selection_remains_stable_async(self, f: Callable[[], None], r: sublime.Region, after_ms: int) -> None:
@@ -912,6 +900,18 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
                 if isinstance(listener, DocumentSyncListener):
                     debug("also registering", listener)
                     listener.on_load_async()
+
+    def _on_view_updated_async(self) -> None:
+        different, current_region = self._update_stored_region_async()
+        self._code_lenses_debouncer_async.debounce(
+            self._do_code_lenses_async, timeout_ms=self.code_lenses_debounce_time)
+        if not different:
+            return
+        self._clear_highlight_regions()
+        if userprefs().document_highlight_style:
+            self._when_selection_remains_stable_async(self._do_highlights_async, current_region,
+                                                      after_ms=self.highlights_debounce_time)
+        self.do_signature_help_async(manual=False)
 
     def _update_stored_region_async(self) -> Tuple[bool, sublime.Region]:
         """

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -909,8 +909,8 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             return
         self._clear_highlight_regions()
         if userprefs().document_highlight_style:
-            self._when_selection_remains_stable_async(self._do_highlights_async, current_region,
-                                                      after_ms=self.highlights_debounce_time)
+            self._when_selection_remains_stable_async(
+                self._do_highlights_async, current_region, after_ms=self.highlights_debounce_time)
         self.do_signature_help_async(manual=False)
 
     def _update_stored_region_async(self) -> Tuple[bool, sublime.Region]:

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -320,19 +320,10 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             yield sv.session_buffer
 
     def on_text_changed_async(self, change_count: int, changes: Iterable[sublime.TextChange]) -> None:
-        different, current_region = self._update_stored_region_async()
         if self.view.is_primary():
             for sv in self.session_views_async():
                 sv.on_text_changed_async(change_count, changes)
-        self._code_lenses_debouncer_async.debounce(
-            self._do_code_lenses_async, timeout_ms=self.code_lenses_debounce_time)
-        if not different:
-            return
-        self._clear_highlight_regions()
-        if userprefs().document_highlight_style:
-            self._when_selection_remains_stable_async(self._do_highlights_async, current_region,
-                                                      after_ms=self.highlights_debounce_time)
-        self.do_signature_help_async(manual=False)
+        self._on_view_updated_async()
 
     def get_uri(self) -> DocumentUri:
         return self._uri
@@ -867,11 +858,25 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         if self.view.is_primary():
             for sv in self.session_views_async():
                 sv.on_revert_async()
+        self._on_view_updated_async()
 
     def reload_async(self) -> None:
         if self.view.is_primary():
             for sv in self.session_views_async():
                 sv.on_reload_async()
+        self._on_view_updated_async()
+
+    def _on_view_updated_async(self) -> None:
+        different, current_region = self._update_stored_region_async()
+        self._code_lenses_debouncer_async.debounce(
+            self._do_code_lenses_async, timeout_ms=self.code_lenses_debounce_time)
+        if not different:
+            return
+        self._clear_highlight_regions()
+        if userprefs().document_highlight_style:
+            self._when_selection_remains_stable_async(self._do_highlights_async, current_region,
+                                                      after_ms=self.highlights_debounce_time)
+        self.do_signature_help_async(manual=False)
 
     # --- Private utility methods --------------------------------------------------------------------------------------
 

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -902,9 +902,9 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
                     listener.on_load_async()
 
     def _on_view_updated_async(self) -> None:
-        different, current_region = self._update_stored_region_async()
         self._code_lenses_debouncer_async.debounce(
             self._do_code_lenses_async, timeout_ms=self.code_lenses_debounce_time)
+        different, current_region = self._update_stored_region_async()
         if not different:
             return
         self._clear_highlight_regions()

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -279,7 +279,9 @@ class SessionBuffer:
 
     def on_revert_async(self, view: sublime.View) -> None:
         self.pending_changes = None  # Don't bother with pending changes
-        self.session.send_notification(did_change(view, view.change_count(), None))
+        version = view.change_count()
+        self.session.send_notification(did_change(view, version, None))
+        sublime.set_timeout_async(lambda: self._on_after_change_async(view, version))
 
     on_reload_async = on_revert_async
 


### PR DESCRIPTION
When file has been "reloaded" by ST due to branch change or just modified externally then the requests that normally happen on file changes didn't run. That includes code lenses, symbol highlights, color boxes, semantic tokens, document link and inlay hints. That result in lack of those features until file was modified or stale state like with those code lenses for example:

![Screenshot 2023-01-28 at 22 44 56](https://user-images.githubusercontent.com/153197/215292917-8e13853a-a07d-4e88-9069-b11a645f7e34.png)
