### PR TITLE
fix log panel not scrolling on initial open

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -191,4 +191,4 @@ class Listener(sublime_plugin.EventListener):
             if panel_manager.is_panel_open(PanelName.Diagnostics):
                 sublime.set_timeout_async(wm.update_diagnostics_panel_async)
             elif panel_manager.is_panel_open(PanelName.Log):
-                sublime.set_timeout(panel_manager.update_log_panel)
+                sublime.set_timeout(lambda: panel_manager.update_log_panel(scroll_to_selection=True))

--- a/plugin/core/panels.py
+++ b/plugin/core/panels.py
@@ -55,10 +55,12 @@ class PanelManager:
     def is_panel_open(self, panel_name: str) -> bool:
         return self._window.is_valid() and self._window.active_panel() == "output.{}".format(panel_name)
 
-    def update_log_panel(self) -> None:
+    def update_log_panel(self, scroll_to_selection: bool = False) -> None:
         panel = self.ensure_log_panel()
         if panel and self.is_panel_open(PanelName.Log):
             panel.run_command("lsp_update_log_panel")
+            if scroll_to_selection:
+                panel.show(panel.sel(), animate=False)
 
     def ensure_panel(self, name: str, result_file_regex: str, result_line_regex: str,
                      syntax: str, context_menu: Optional[str] = None) -> Optional[sublime.View]:

--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -878,7 +878,8 @@ class View:
     def visible_region(self) -> Region:
         ...
 
-    def show(self, x: Union[Selection, Region, int], show_surrounds: bool = ...) -> None:
+    def show(self, x: Union[Selection, Region, int], show_surrounds: bool = True, keep_to_left: bool = False,
+             animate: bool = True) -> None:
         ...
 
     def show_at_center(self, x: Union[Selection, Region, int], animate: bool = True) -> None:


### PR DESCRIPTION
There was annoying issue with LSP Log Panel that meant that the content didn't scroll when opened initially.

I've experimented a bit with a simple plugin and noticed this this seems like a bug that triggers when:
 - panel view's `scroll_past_end` setting is set to `False`
 - and panel is shown with more than a screenfull of content inserted at the same time

The work around is to just trigger `view.show(view.sel(), animate=False)` after inserting text to scroll the view to the end (or wherever selection was set too if it's not the initial opening).