### PR TITLE
Optimize performance of handling huge completion payloads

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -10,7 +10,7 @@ from .plugin.code_lens import LspCodeLensCommand
 from .plugin.color import LspColorPresentationCommand
 from .plugin.completion import LspCommitCompletionWithOppositeInsertMode
 from .plugin.completion import LspResolveDocsCommand
-from .plugin.completion import LspSelectCompletionItemCommand
+from .plugin.completion import LspSelectCompletionCommand
 from .plugin.configuration import LspDisableLanguageServerGloballyCommand
 from .plugin.configuration import LspDisableLanguageServerInProjectCommand
 from .plugin.configuration import LspEnableLanguageServerGloballyCommand

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -90,7 +90,7 @@ class QueryCompletionsTask:
     def _resolve_completions_async(self, responses: List[ResolvedCompletions]) -> None:
         if self._resolved:
             return
-        LspResolveDocsCommand.completions = {}
+        LspSelectCompletionCommand.completions = {}
         items = []  # type: List[sublime.CompletionItem]
         errors = []  # type: List[Error]
         flags = 0  # int
@@ -117,7 +117,7 @@ class QueryCompletionsTask:
             elif isinstance(response, list):
                 response_items = response
             response_items = sorted(response_items, key=lambda item: item.get("sortText") or item["label"])
-            LspResolveDocsCommand.completions[session.config.name] = response_items
+            LspSelectCompletionCommand.completions[session.config.name] = response_items
             can_resolve_completion_items = session.has_capability('completionProvider.resolveProvider')
             config_name = session.config.name
             items.extend(
@@ -149,8 +149,6 @@ class QueryCompletionsTask:
 
 
 class LspResolveDocsCommand(LspTextCommand):
-
-    completions = {}  # type: Dict[SessionName, List[CompletionItem]]
 
     def run(self, edit: sublime.Edit, index: int, session_name: str, event: Optional[dict] = None) -> None:
 
@@ -218,8 +216,12 @@ class LspCommitCompletionWithOppositeInsertMode(LspTextCommand):
         LspCommitCompletionWithOppositeInsertMode.active = False
 
 
-class LspSelectCompletionItemCommand(LspTextCommand):
-    def run(self, edit: sublime.Edit, item: CompletionItem, session_name: str) -> None:
+class LspSelectCompletionCommand(LspTextCommand):
+
+    completions = {}  # type: Dict[SessionName, List[CompletionItem]]
+
+    def run(self, edit: sublime.Edit, index: int, session_name: str) -> None:
+        item = LspSelectCompletionCommand.completions[session_name][index]
         text_edit = item.get("textEdit")
         if text_edit:
             new_text = text_edit["newText"].replace("\r", "")

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -153,7 +153,7 @@ class LspResolveDocsCommand(LspTextCommand):
     def run(self, edit: sublime.Edit, index: int, session_name: str, event: Optional[dict] = None) -> None:
 
         def run_async() -> None:
-            item = self.completions[session_name][index]
+            item = LspSelectCompletionCommand.completions[session_name][index]
             session = self.session_by_name(session_name, 'completionProvider.resolveProvider')
             if session:
                 request = Request.resolveCompletionItem(item, self.view)

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -812,7 +812,7 @@ def make_command_link(
 
 def make_documentation_link(text: str, index: int, session_name: str, view_id: int) -> str:
     """A version of "make_command_link" optimized for specific use case to avoid slow json.dumps in the hot path."""
-    args = '{{"view_id": {}, "command": "lsp_resolve_docs", "args": {{"index": {}, "session_name": "{}"}}}}'.format(
+    args = '{{"view_id":{},"command":"lsp_resolve_docs","args":{{"index":{},"session_name":"{}"}}}}'.format(
         view_id, index, session_name)
     href = 'subl:lsp_run_text_command_helper {}'.format(args)
     return make_link(href, text)

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -1069,13 +1069,15 @@ def format_completion(
         oposite_insert_mode = 'Replace' if insert_mode == 'insert' else 'Insert'
         command_url = "subl:lsp_commit_completion_with_opposite_insert_mode"
         details.append("<a href='{}'>{}</a>".format(command_url, oposite_insert_mode))
-    completion = sublime.CompletionItem.command_completion(
-        trigger=trigger,
-        command='lsp_select_completion',
-        args={"index": index, "session_name": session_name},
-        annotation=annotation,
-        kind=kind,
-        details=" | ".join(details))
+    completion = sublime.CompletionItem(
+        trigger,
+        annotation,
+        # Not using "make_command_link" in a hot path to avoid slow json.dumps.
+        'subl:lsp_select_completion {{"index":{},"session_name":"{}"}}'.format(index, session_name),
+        sublime.COMPLETION_FORMAT_COMMAND,
+        kind,
+        details=" | ".join(details)
+    )
     if text_edit:
         completion.flags = sublime.COMPLETION_FLAG_KEEP_PREFIX
     return completion

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -814,7 +814,7 @@ def make_documentation_link(text: str, index: int, session_name: str, view_id: i
     """A version of "make_command_link" optimized for specific use case to avoid slow json.dumps in the hot path."""
     args = '{{"view_id": {}, "command": "lsp_resolve_docs", "args": {{"index": {}, "session_name": "{}"}}}}'.format(
         view_id, index, session_name)
-    href = 'subl:lsp_run_text_command_helper {}'.format(html.escape(args))
+    href = 'subl:lsp_run_text_command_helper {}'.format(args)
     return make_link(href, text)
 
 
@@ -1071,7 +1071,7 @@ def format_completion(
     if text_edit and 'insert' in text_edit and 'replace' in text_edit:
         insert_mode = userprefs().completion_insert_mode
         oposite_insert_mode = 'Replace' if insert_mode == 'insert' else 'Insert'
-        command_url = sublime.command_url("lsp_commit_completion_with_opposite_insert_mode")
+        command_url = "subl:lsp_commit_completion_with_opposite_insert_mode"
         details.append("<a href='{}'>{}</a>".format(command_url, oposite_insert_mode))
     completion = sublime.CompletionItem.command_completion(
         trigger=trigger,

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -1072,8 +1072,8 @@ def format_completion(
     completion = sublime.CompletionItem(
         trigger,
         annotation,
-        # Not using "make_command_link" in a hot path to avoid slow json.dumps.
-        'subl:lsp_select_completion {{"index":{},"session_name":"{}"}}'.format(index, session_name),
+        # Not using "sublime.format_command" in a hot path to avoid slow json.dumps.
+        'lsp_select_completion {{"index":{},"session_name":"{}"}}'.format(index, session_name),
         sublime.COMPLETION_FORMAT_COMMAND,
         kind,
         details=" | ".join(details)

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -810,12 +810,12 @@ def make_command_link(
     return make_link(sublime.command_url(cmd, args), text, class_name, tooltip)
 
 
-def make_documentation_link(text: str, index: int, session_name: str, view_id: int) -> str:
+def make_documentation_link(index: int, session_name: str, view_id: int) -> str:
     """A version of "make_command_link" optimized for specific use case to avoid slow json.dumps in the hot path."""
     args = '{{"view_id":{},"command":"lsp_resolve_docs","args":{{"index":{},"session_name":"{}"}}}}'.format(
         view_id, index, session_name)
     href = 'subl:lsp_run_text_command_helper {}'.format(args)
-    return make_link(href, text)
+    return make_link(href, 'More')
 
 
 class LspRunTextCommandHelperCommand(sublime_plugin.WindowCommand):
@@ -1048,7 +1048,7 @@ def format_completion(
     kind = COMPLETION_KINDS.get(completion_kind, sublime.KIND_AMBIGUOUS) if completion_kind else sublime.KIND_AMBIGUOUS
     details = []  # type: List[str]
     if can_resolve_completion_items or item.get('documentation'):
-        details.append(make_documentation_link("More", index, session_name, view_id))
+        details.append(make_documentation_link(index, session_name, view_id))
     if lsp_label_detail and (lsp_label + lsp_label_detail).startswith(lsp_filter_text):
         trigger = lsp_label + lsp_label_detail
         annotation = lsp_label_description or lsp_detail

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -810,6 +810,14 @@ def make_command_link(
     return make_link(sublime.command_url(cmd, args), text, class_name, tooltip)
 
 
+def make_documentation_link(text: str, index: int, session_name: str, view_id: int) -> str:
+    """A version of "make_command_link" optimized for specific use case to avoid slow json.dumps in the hot path."""
+    args = '{{"view_id": {}, "command": "lsp_resolve_docs", "args": {{"index": {}, "session_name": "{}"}}}}'.format(
+        view_id, index, session_name)
+    href = 'subl:lsp_run_text_command_helper {}'.format(html.escape(args))
+    return make_link(href, text)
+
+
 class LspRunTextCommandHelperCommand(sublime_plugin.WindowCommand):
     def run(self, view_id: int, command: str, args: Optional[Dict[str, Any]] = None) -> None:
         view = sublime.View(view_id)
@@ -1040,8 +1048,7 @@ def format_completion(
     kind = COMPLETION_KINDS.get(completion_kind, sublime.KIND_AMBIGUOUS) if completion_kind else sublime.KIND_AMBIGUOUS
     details = []  # type: List[str]
     if can_resolve_completion_items or item.get('documentation'):
-        details.append(make_command_link(
-            'lsp_resolve_docs', "More", {'index': index, 'session_name': session_name}, view_id=view_id))
+        details.append(make_documentation_link("More", index, session_name, view_id))
     if lsp_label_detail and (lsp_label + lsp_label_detail).startswith(lsp_filter_text):
         trigger = lsp_label + lsp_label_detail
         annotation = lsp_label_description or lsp_detail

--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -63,6 +63,7 @@ INHIBIT_EXPLICIT_COMPLETIONS = ...  # type: int
 INHIBIT_REORDER = ...  # type: int
 DYNAMIC_COMPLETIONS = ...  # type: int
 COMPLETION_FLAG_KEEP_PREFIX = ...  # type: int
+COMPLETION_FORMAT_COMMAND = ...  # type: int
 DIALOG_CANCEL = ...  # type: int
 DIALOG_YES = ...  # type: int
 DIALOG_NO = ...  # type: int


### PR DESCRIPTION
A low-hanging fruit optimization that allows us to create `CompletionList` with drastically smaller payload.

Instead of serializing complete completion items and attaching those to `CompletionItem.args`, only attach an index of the item and lookup the item within the global completions list attached to the `LspSelectCompletionCommand` class (previously it was attached to the `LspResolveDocsCommand` class but moved to match the current use).

We did that already for the purpose of of accessing them for the `completionItem/resolve` request but there is no reason not to do that for the completion insertion also.

I've created a separate package at https://github.com/sublimelsp/LSP-performance-test which currently includes one performance test for testing the `format_completion` function. Comparing the `main` branch and this branch gives:

main: `Best of 3: 2.038291124999887 s`
this: `Best of 3: 1.1438355416667036 s`

so 56% improvement. (This is on a 50MB completions payload)

This is just testing the performance of this single function and that function is called on the async thread anyway so its performance is not that crucial. The main bottleneck that causes ST to lag is the act of returning that list to ST and transferring over process boundaries. That itself I haven't measured but it is also drastically improved since the payload of completion list is a lot smaller.

Notes:
 - `LspSelectCompletionItemCommand` renamed to `LspSelectCompletionCommand`. The purpose was to just make it shorter to micro-optimize the payload size but I'm not very attached to that and could revert it. Though since it should be only used internally, it shouldn't be an issue.
 - `get_insert_replace_support_html` inlined within `format_completion` to avoid getting `textEdit` twice (again, micro optimization). But there is not really a good reason for it being separate anyway.