### PR TITLE
check capabilities against buffer when requesting code actions

### DIFF
--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -75,8 +75,8 @@ class CodeActionsManager:
 
         def request_factory(sb: SessionBufferProtocol) -> Optional[Request]:
             diagnostics = []  # type: List[Diagnostic]
-            for sb, diags in session_buffer_diagnostics:
-                if sb == sb:
+            for diag_sb, diags in session_buffer_diagnostics:
+                if diag_sb == sb:
                     diagnostics = diags
                     break
             params = text_document_code_action_params(view, region, diagnostics, only_kinds, manual)

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -123,8 +123,8 @@ class CodeActionsManager:
             if not matching_kinds:
                 return None
             diagnostics = []  # type: List[Diagnostic]
-            for sb, diags in session_buffer_diagnostics:
-                if sb == sb:
+            for diag_sb, diags in session_buffer_diagnostics:
+                if diag_sb == sb:
                     diagnostics = diags
                     break
             params = text_document_code_action_params(view, region, diagnostics, matching_kinds, manual=False)

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -569,10 +569,10 @@ class SessionBufferProtocol(Protocol):
     ) -> None:
         ...
 
-    def get_capability(self, capability: str) -> Optional[Any]:
+    def get_capability(self, capability_path: str) -> Optional[Any]:
         ...
 
-    def has_capability(self, capability: str) -> bool:
+    def has_capability(self, capability_path: str) -> bool:
         ...
 
     def on_diagnostics_async(

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -76,7 +76,7 @@ from .types import DocumentSelector
 from .types import method_to_capability
 from .types import SettingsRegistration
 from .types import sublime_pattern_to_glob
-from .typing import Callable, cast, Dict, Any, Optional, List, Tuple, Generator, Iterable, Type, Protocol, Mapping, Set, TypeVar, Union  # noqa: E501
+from .typing import Callable, cast, Dict, Any, Optional, List, Tuple, Generator, Type, Protocol, Mapping, Set, TypeVar, Union  # noqa: E501
 from .url import filename_to_uri
 from .url import parse_uri
 from .version import __version__

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -299,12 +299,13 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
                             return
         self.view.erase_status(self.ACTIVE_DIAGNOSTIC)
 
+    def session_buffers_async(self, capability: Optional[str] = None) -> Generator[SessionBuffer, None, None]:
+        for sv in self.session_views_async():
+            if capability is None or sv.has_capability_async(capability):
+                yield sv.session_buffer
+
     def session_views_async(self) -> Generator[SessionView, None, None]:
         yield from self._session_views.values()
-
-    def session_buffers_async(self) -> Generator[SessionBuffer, None, None]:
-        for sv in self.session_views_async():
-            yield sv.session_buffer
 
     def on_text_changed_async(self, change_count: int, changes: Iterable[sublime.TextChange]) -> None:
         if self.view.is_primary():

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -236,8 +236,8 @@ class SessionBuffer:
         value = self.capabilities.get(capability_path)
         return value if value is not None else self.session.capabilities.get(capability_path)
 
-    def has_capability(self, capability: str) -> bool:
-        value = self.get_capability(capability)
+    def has_capability(self, capability_path: str) -> bool:
+        value = self.get_capability(capability_path)
         return value is not False and value is not None
 
     def text_sync_kind(self) -> TextDocumentSyncKind:


### PR DESCRIPTION
On getting code actions, instead of checking `Session` capabilities, check against `SessionBuffer` so that we take into account dynamic capabilities that might have been registered (for specific document selector rather than globally).

Fixes #2201