### PR TITLE
better grouping of default settings

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -5,10 +5,20 @@
   // Show permanent language server status in the status bar.
   "show_view_status": true,
 
+  // --- Document Formatting ------------------------------------------------------------
+
   // Run the server's formatProvider (if supported) on a file before saving.
   // This option is also supported in syntax-specific settings and/or in the
   // "settings" section of project files.
   "lsp_format_on_save": false,
+
+  // --- Code Actions -------------------------------------------------------------------
+
+  // Show code actions:
+  // "annotation" - show an annotation on the right when code actions are available.
+  // "bulb" - show a bulb in the gutter when code actions are available.
+  // "" - don't show code actions.
+  "show_code_actions": "annotation",
 
   // A dictionary of code action identifiers that should be triggered on save.
   //
@@ -31,14 +41,7 @@
   // formatting or WillSaveWaitUntil) are each allowed to run for.
   "on_save_task_timeout_ms": 2000,
 
-  // Open the diagnostics panel automatically on save when diagnostics level is
-  // equal to or less than:
-  // none: 0 (never open the panel automatically)
-  // error: 1
-  // warning: 2
-  // info: 3
-  // hint: 4
-  "show_diagnostics_panel_on_save": 0,
+  // --- Diagnostics --------------------------------------------------------------------
 
   // Show errors and warnings count in the status bar
   "show_diagnostics_count_in_view_status": false,
@@ -55,6 +58,15 @@
   // info: 3
   // hint: 4
   "show_diagnostics_severity_level": 4,
+
+  // Open the diagnostics panel automatically on save when diagnostics level is
+  // equal to or less than:
+  // none: 0 (never open the panel automatically)
+  // error: 1
+  // warning: 2
+  // info: 3
+  // hint: 4
+  "show_diagnostics_panel_on_save": 0,
 
   // Only show diagnostics in the panel with level equal to or less than:
   // error: 1
@@ -79,21 +91,6 @@
   // See also: "diagnostics_delay_ms".
   "diagnostics_additional_delay_auto_complete_ms": 0,
 
-  // Highlighting style of "highlights": accentuating nearby text entities that
-  // are related to the one under your cursor.
-  // Valid values are "background", "underline", "stippled", or "".
-  // When set to the empty string (""), no document highlighting is requested.
-  // See https://lsp.sublimetext.io/customization/#document-highlights for how to
-  // customize the color.
-  "document_highlight_style": "underline",
-
-  // Highlight style of the word or range for which a hover popup is shown.
-  // Valid values are "background", "underline", "stippled", or "".
-  // When set to the empty string (""), no highlighting is applied.
-  // See https://lsp.sublimetext.io/customization/#hover-highlights for how to
-  // customize the color.
-  "hover_highlight_style": "",
-
   // Highlight style of code diagnostics.
   // Can be a string, or a mapping of string->string for severity-based styling.
   // Valid string values are "box", "underline", "stippled", "squiggly" or "".
@@ -114,56 +111,32 @@
   // Valid values are "dot", "circle", "bookmark", "sign" or ""
   "diagnostics_gutter_marker": "sign",
 
-  // Highlight style of links to internal or external resources, like another text document
-  // or a web site. Link navigation is implemented via the popup on mouse hover.
-  // Valid values are:
-  // "underline"
-  // "none" - disables special highlighting, but still allows to navigate links in the hover popup
-  // "disabled" - disables highlighting and the hover popup for links
-  // Note that depending on the syntax and color scheme, some internet URLs may still be
-  // underlined via regular syntax highlighting.
-  "link_highlight_style": "underline",
-
-  // Enable semantic highlighting in addition to standard syntax highlighting (experimental!).
-  // Note: Must be supported by the language server and also requires a special rule in the
-  // color scheme to work. If you use none of the built-in color schemes from Sublime Text,
-  // please see the documentation under
-  //   https://lsp.sublimetext.io/customization/#semantic-highlighting
-  // for a description about how to configure your color scheme for semantic highlighting.
-  "semantic_highlighting": false,
-
-  // Show code actions:
-  // "annotation" - show an annotation on the right when code actions are available.
-  // "bulb" - show a bulb in the gutter when code actions are available.
-  // "" - don't show code actions.
-  "show_code_actions": "annotation",
-
-  // Show code lens:
-  // "annotation" - show an annotation on the right when code actions are available
-  // "phantom" - show a phantom on the top when code actions are available
-  "show_code_lens": "annotation",
-
-   // Show inlay hints in the editor. Inlay hints are short annotations within the code, which show variable types
-   // or parameter names.
-   // This is the default value used for new windows but can be overriden per-window using the `LSP: Toggle Inlay Hints`
-   // command from the Command Palette, Main Menu or a custom keybinding.
-  "show_inlay_hints": false,
-
-  // Show code actions in hover popup if available
-  "show_code_actions_in_hover": true,
-
   // Show diagnostics spanning multiple lines in the view (as outlines).
   // See also: "diagnostics_highlight_style".
   "show_multiline_diagnostics_highlights": true,
 
+  // --- Hover popup --------------------------------------------------------------------
+
+  // The maximum number of characters (approximately) before wrapping in the popup.
+  "popup_max_characters_width": 120,
+
+  // The maximum number of characters (approximately) before a scrollbar appears.
+  "popup_max_characters_height": 1000,
+
+  // Show code actions in hover popup if available
+  "show_code_actions_in_hover": true,
+
   // Show symbol action links in hover popup if available
   "show_symbol_action_links": true,
+
+  // --- Completions --------------------------------------------------------------------
 
   // Disable Sublime Text's snippet completions.
   "inhibit_snippet_completions": false,
 
-  // Disable Sublime Text's word completions. When set to `true`, this also disables Sublime Text's internal completion
-  // sorting algorithm and instead uses the sorting defined by the relevant language server.
+  // Disable Sublime Text's word completions. When set to `true`, this also disables
+  // Sublime Text's internal completion sorting algorithm and instead uses the sorting
+  // defined by the relevant language server.
   "inhibit_word_completions": true,
 
   // The mode used for inserting completions:
@@ -174,14 +147,58 @@
   // Note: Must be supported by the language server.
   "completion_insert_mode": "insert",
 
+  // --- Other --------------------------------------------------------------------------
+
   // Show symbol references in Sublime's quick panel instead of the bottom panel.
   "show_references_in_quick_panel": false,
 
-  // The maximum number of characters (approximately) before wrapping in the popup.
-  "popup_max_characters_width": 120,
+  // Show code lens:
+  // "annotation" - show an annotation on the right when code actions are available
+  // "phantom" - show a phantom on the top when code actions are available
+  "show_code_lens": "annotation",
 
-  // The maximum number of characters (approximately) before a scrollbar appears.
-  "popup_max_characters_height": 1000,
+   // Show inlay hints in the editor. Inlay hints are short annotations within the code,
+   // which show variable types or parameter names.
+   // This is the default value used for new windows but can be overriden per-window
+   // using the `LSP: Toggle Inlay Hints` command from the Command Palette, Main Menu
+   // or a custom keybinding.
+  "show_inlay_hints": false,
+
+  // Highlighting style of "highlights": accentuating nearby text entities that
+  // are related to the one under your cursor.
+  // Valid values are "background", "underline", "stippled", or "".
+  // When set to the empty string (""), no document highlighting is requested.
+  // See https://lsp.sublimetext.io/customization/#document-highlights for how to
+  // customize the color.
+  "document_highlight_style": "underline",
+
+  // Highlight style of the word or range for which a hover popup is shown.
+  // Valid values are "background", "underline", "stippled", or "".
+  // When set to the empty string (""), no highlighting is applied.
+  // See https://lsp.sublimetext.io/customization/#hover-highlights for how to
+  // customize the color.
+  "hover_highlight_style": "",
+
+  // Highlight style of links to internal or external resources, like another text
+  // document or a web site. Link navigation is implemented via the popup on mouse hover.
+  // Valid values are:
+  // "underline"
+  // "none" - disables special highlighting, but still allows to navigate links in the
+  //          hover popup
+  // "disabled" - disables highlighting and the hover popup for links
+  // Note that depending on the syntax and color scheme, some internet URLs may still be
+  // underlined via regular syntax highlighting.
+  "link_highlight_style": "underline",
+
+  // Enable semantic highlighting in addition to standard syntax highlighting.
+  // Note: Must be supported by the language server and also requires a special rule in
+  // the color scheme to work. If you use none of the built-in color schemes from Sublime
+  // Text then see the documentation at
+  // https://lsp.sublimetext.io/customization/#semantic-highlighting for a description
+  // about how to configure your color scheme for semantic highlighting.
+  "semantic_highlighting": false,
+
+  // --- Debugging ----------------------------------------------------------------------
 
   // Show verbose debug messages in the sublime console.
   "log_debug": false,
@@ -205,6 +222,13 @@
   // the panel instead. If you don't want a limit, set this to zero.
   "log_max_size": 8192,
 
+  // --- Server Configurations ----------------------------------------------------------
+
+  // NOTE: Instead of manually configuring the servers, consider using one of the
+  // existing helper packages for the language of your choice. The full list of
+  // those is available at https://lsp.sublimetext.io/language_servers/
+  //
+  //
   // User server configurations can be used to:
   // - partially override a configuration in the "default_clients", or
   // - create new configurations.
@@ -277,19 +301,6 @@
   // DO NOT MODIFY THIS SETTING!
   // Use "clients" to override settings instead!
   "default_clients": {
-    "rust-analyzer": {
-      "command": [
-        "rust-analyzer"
-      ],
-      "selector": "source.rust",
-    },
-    "clangd": {
-      "command": [
-        "clangd"
-      ],
-      "selector": "source.c | source.c++ | source.objc | source.objc++",
-      "auto_complete_selector": "punctuation.accessor | (meta.preprocessor.include string - punctuation.definition.string.end)",
-    },
     "erlang-ls": {
       "command": [
         "erlang_ls",
@@ -304,12 +315,6 @@
         "--stdio"
       ],
       "selector": "source.reason | source.ocaml",
-    },
-    "gopls": {
-      "command": [
-        "gopls"
-      ],
-      "selector": "source.go",
     },
     "polymer-ide": {
       "command": [

--- a/messages/1.23.0.txt
+++ b/messages/1.23.0.txt
@@ -1,8 +1,8 @@
 => 1.23.0
 
 --- WARNING ---
-To ensure that everything works properly after the LSP package is updated, it's strongly recommended to restart
-Sublime Text once it finished updating all packages.
+To ensure that everything works properly after LSP package is updated, it's strongly recommended to restart
+Sublime Text once it finishes updating all packages.
 --- WARNING ---
 
 # Breaking changes

--- a/messages/1.23.0.txt
+++ b/messages/1.23.0.txt
@@ -11,10 +11,10 @@ Sublime Text once it finishes updating all packages.
 - removed bundled `clangd` client config - install https://packagecontrol.io/packages/LSP-clangd instead
 - removed bundled `gopls` client config - install https://packagecontrol.io/packages/LSP-gopls instead
 
-If you had one of those configs enabled in your LSP Settings then it will no longer do anything. You can instead
+If you had one of those configs enabled in your LSP Settings then it will no longer do anything. You can
 restore the removed config from https://github.com/sublimelsp/LSP/pull/2206 into your LSP Settings but we
-instead recommend to install the relevant helper package instead which takes care of managing the server dependency
-and defines and documents all necessary settings that the server can use.
+instead recommend installing the relevant helper package which takes care of managing the server dependency
+and includes all necessary settings that the server can use.
 
 # Features
 

--- a/messages/1.23.0.txt
+++ b/messages/1.23.0.txt
@@ -1,0 +1,29 @@
+=> 1.23.0
+
+--- WARNING ---
+To ensure that everything works properly after the LSP package is updated, it's strongly recommended to restart
+Sublime Text once it finished updating all packages.
+--- WARNING ---
+
+# Breaking changes
+
+- removed bundled `rust-analyzer` client config - install https://packagecontrol.io/packages/LSP-rust-analyzer instead
+- removed bundled `clangd` client config - install https://packagecontrol.io/packages/LSP-clangd instead
+- removed bundled `gopls` client config - install https://packagecontrol.io/packages/LSP-gopls instead
+
+If you had one of those configs enabled in your LSP Settings then it will no longer do anything. You can instead
+restore the removed config from https://github.com/sublimelsp/LSP/pull/2206 into your LSP Settings but we
+instead recommend to install the relevant helper package instead which takes care of managing the server dependency
+and defines and documents all necessary settings that the server can use.
+
+# Features
+
+- ...
+
+# Fixes and Improvements
+
+- ...
+
+# Plugin API changes
+
+- ...


### PR DESCRIPTION
Did a bit of grouping of options to make default settings a bit more organized.

Also removed default configs for rust-analyzer, clangd and gopls since we have dedicated packages for those.

Improvement suggestions welcome.