### PR TITLE
Tweak completion formatting with labelDetails

### DIFF
--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -65,7 +65,14 @@ def format_completion(
         href = 'subl:lsp_run_text_command_helper {}'.format(args)
         details.append(make_link(href, 'More'))
     if lsp_label_detail and (lsp_label + lsp_label_detail).startswith(lsp_filter_text):
-        trigger = lsp_label + lsp_label_detail
+        if lsp_label_detail[0].isalnum() and lsp_label.startswith(lsp_filter_text):
+            # labelDetails.detail is likely a type annotation
+            # Don't append it to the trigger: https://github.com/sublimelsp/LSP/issues/2169
+            trigger = lsp_label
+            details.append(html.escape(lsp_label_detail))
+        else:
+            # labelDetails.detail is likely a function signature
+            trigger = lsp_label + lsp_label_detail
         annotation = lsp_label_description or lsp_detail
     elif lsp_label.startswith(lsp_filter_text):
         trigger = lsp_label

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -946,6 +946,33 @@ class FormatCompletionsUnitTests(TestCase):
             trigger='banner?()',
         )
 
+    def test_label_details_2(self) -> None:
+        self._verify_completion(
+            {
+                "label": "NaiveDateTime",
+                "labelDetails": {
+                    "detail": "struct",
+                    "description": "NaiveDateTime"
+                },
+            },
+            trigger='NaiveDateTime',
+            annotation='NaiveDateTime',
+            details='struct'
+        )
+
+    def test_label_details_3(self) -> None:
+        self._verify_completion(
+            {
+                "label": "NaiveDateTime",
+                "labelDetails": {
+                    "detail": " struct",
+                    "description": "NaiveDateTime"
+                },
+            },
+            trigger='NaiveDateTime struct',
+            annotation='NaiveDateTime'
+        )
+
     def test_filter_text_1(self) -> None:
         self._verify_completion(
             {


### PR DESCRIPTION
Workaround for and closes #2169.

I've put the `labelDetails.detail` into the ST "detail" field, if it starts with a letter (or number), which likely indicates that it is a type annotation. Because I think for example `NaiveDateTime struct` doesn't look very good in the "trigger". But, if the language server intentionally prepends a space, then keep it in the "trigger".

Open for discussion @princemaple