### PR TITLE
protect again invalid `auto_complete_triggers` values

### DIFF
--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -149,7 +149,7 @@ class SessionView:
         '''Remove all of our modifications to the view's "auto_complete_triggers"'''
         triggers = settings.get(self.AC_TRIGGERS_KEY)
         if isinstance(triggers, list):
-            triggers = [t for t in triggers if self.session.config.name != t.get("server", "")]
+            triggers = [t for t in triggers if isinstance(t, dict) and self.session.config.name != t.get("server", "")]
             settings.set(self.AC_TRIGGERS_KEY, triggers)
 
     def _setup_auto_complete_triggers(self, settings: sublime.Settings) -> None:

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -170,6 +170,8 @@ class SessionView:
             new_triggers = []  # type: List[Dict[str, str]]
             name = self.session.config.name
             for trigger in triggers:
+                if not isinstance(trigger, dict):
+                    continue
                 if trigger.get("server", "") == name and trigger.get("registration_id", "") == registration_id:
                     continue
                 new_triggers.append(trigger)


### PR DESCRIPTION
could crash with invalid user values: https://github.com/TerminalFi/LSP-copilot/issues/90