### PR TITLE
notify opened files immediately if there are pending diagnostics

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1255,7 +1255,7 @@ class Session(TransportCallbacks):
         self._session_buffers.add(sb)
         for data in self._registrations.values():
             data.check_applicable(sb)
-        # On next task as we need to wait let Session Buffer get registered in Session View.
+        # On next task as we need to let SessionBuffer get registered in SessionView.
         sublime.set_timeout_async(lambda: self._publish_diagnostics_to_session_buffer_async(sb))
 
     def _publish_diagnostics_to_session_buffer_async(self, sb: SessionBufferProtocol) -> None:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1268,7 +1268,6 @@ class Session(TransportCallbacks):
         visible_session_views, _ = self.session_views_by_visibility()
         sb.on_diagnostics_async(diagnostics, None, visible_session_views)
 
-
     def unregister_session_buffer_async(self, sb: SessionBufferProtocol) -> None:
         self._session_buffers.discard(sb)
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1255,8 +1255,7 @@ class Session(TransportCallbacks):
         self._session_buffers.add(sb)
         for data in self._registrations.values():
             data.check_applicable(sb)
-        # On next task as we need to let SessionBuffer get registered in SessionView.
-        sublime.set_timeout_async(lambda: self._publish_diagnostics_to_session_buffer_async(sb))
+        self._publish_diagnostics_to_session_buffer_async(sb)
 
     def _publish_diagnostics_to_session_buffer_async(self, sb: SessionBufferProtocol) -> None:
         uri = sb.get_uri()

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -127,7 +127,6 @@ class SessionBuffer:
         self._is_saving = False
         self._has_changed_during_save = False
         self._check_did_open(view)
-        self._session.register_session_buffer_async(self)
 
     @property
     def session(self) -> Session:

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -157,7 +157,7 @@ class SessionBuffer:
             self.session.send_notification(did_close(uri=self.last_known_uri))
             self.opened = False
 
-    def get_uri(self) -> Optional[str]:
+    def get_uri(self) -> Optional[DocumentUri]:
         for sv in self.session_views:
             return sv.get_uri()
         return None

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -53,6 +53,7 @@ class SessionView:
         if session_buffer is None:
             session_buffer = SessionBuffer(self, buffer_id, uri)
             self._session_buffers[key] = session_buffer
+            self._session.register_session_buffer_async(session_buffer)
         else:
             session_buffer.add_session_view(self)
         self._session_buffer = session_buffer

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -53,10 +53,11 @@ class SessionView:
         if session_buffer is None:
             session_buffer = SessionBuffer(self, buffer_id, uri)
             self._session_buffers[key] = session_buffer
+            self._session_buffer = session_buffer
             self._session.register_session_buffer_async(session_buffer)
         else:
+            self._session_buffer = session_buffer
             session_buffer.add_session_view(self)
-        self._session_buffer = session_buffer
         session.register_session_view_async(self)
         session.config.set_view_status(self._view, session.config_status_message)
         if self._session.has_capability(self.HOVER_PROVIDER_KEY):

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -219,7 +219,7 @@ class SessionView:
                 settings.erase(self.HOVER_PROVIDER_COUNT_KEY)
                 settings.set(self.SHOW_DEFINITIONS_KEY, True)
 
-    def get_uri(self) -> Optional[str]:
+    def get_uri(self) -> Optional[DocumentUri]:
         listener = self.listener()
         return listener.get_uri() if listener else None
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -79,7 +79,7 @@ class MockSessionBuffer:
         self.mock_uri = mock_uri
         self.mock_language_id = mock_language_id
 
-    def get_uri(self) -> Optional[str]:
+    def get_uri(self) -> Optional[DocumentUri]:
         return self.mock_uri
 
     def get_language_id(self) -> Optional[str]:


### PR DESCRIPTION
Diagnostics are stored in `Session` and there might exist diagnostics for not-yet-opened files so notify Session Buffers immediately about those when creating new buffers.

This fixes somewhat obscure bug for servers that don't implement `didOpen` but also makes diagnostics show more quickly after opening files for other servers (in case diagnostics were already reported for those files).

Fixes #2200