### PR TITLE
Clear pull diagnostics on file closed

### DIFF
--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -215,6 +215,8 @@ class SessionBuffer:
 
     def _on_before_destroy(self) -> None:
         self.remove_all_inlay_hints()
+        if self.has_capability("diagnosticProvider"):
+            self.session.m_textDocument_publishDiagnostics({'uri': self.last_known_uri, 'diagnostics': []})
         wm = self.session.manager()
         if wm:
             wm.on_diagnostics_updated()


### PR DESCRIPTION
With push diagnostics, some (most?) servers clear diagnostics for a file on `didClose`. At least this should be the case for servers which (are configured to) send diagnostics only for files that are opened in the editor, e.g. Pyright with default setting `"python.analysis.diagnosticMode": "openFilesOnly"`.

With pull diagnostics, at the moment we are always only in this diagnostics-for-open-files-only mode[^1], so I think it makes sense to clear diagnostics for a file when the last view of that file closes. Otherwise, they would still be shown in the diagnostics panel and Goto diagnostics quick panel. See also https://github.com/microsoft/language-server-protocol/issues/1542#issuecomment-1237778484, where it is mentioned that it might make sense to keep the diagnostics e.g. for the purpose to render markers in the sidebar. But we don't have such sidebar markers and I think for the panels it is more destracting to keep diagnostics around for closed files, because at the moment we only actively pull for opened files.

[^1]: technically not really, because the diagnostics response can still contain diagnostics for other URIs (via `relatedDocuments` field), but we only actively pull for diagnostics of opened files at the moment

With pull diagnostics, maybe we should introduce a configuration option (per server) whether diagnostics should be in "open-files-only" or "workspace" mode, and for the latter case send the [Workspace Diagnostics](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_diagnostic) request.

