### PR TITLE
Fix exception for null response id

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1105,7 +1105,7 @@ class Logger(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def incoming_response(self, request_id: int, params: Any, is_error: bool) -> None:
+    def incoming_response(self, request_id: Optional[int], params: Any, is_error: bool) -> None:
         pass
 
     @abstractmethod
@@ -2079,6 +2079,9 @@ class Session(TransportCallbacks):
                 self._logger.incoming_notification(method, result, res[0] is None)
                 return res
         elif "id" in payload:
+            if payload["id"] is None:
+                self._logger.incoming_response(None, payload.get("error"), True)
+                return (None, None, None, None, None)
             response_id = int(payload["id"])
             handler, method, result, is_error = self.response_handler(response_id, payload)
             self._logger.incoming_response(response_id, result, is_error)

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -548,7 +548,7 @@ class RequestTimeTracker:
     def start_tracking(self, request_id: int) -> None:
         self._start_times[request_id] = perf_counter()
 
-    def end_tracking(self, request_id) -> str:
+    def end_tracking(self, request_id: int) -> str:
         duration = '-'
         if request_id in self._start_times:
             start = self._start_times.pop(request_id)
@@ -613,11 +613,11 @@ class PanelLogger(Logger):
             return
         self.log(self._format_notification(" ->", method), params)
 
-    def incoming_response(self, request_id: int, params: Any, is_error: bool) -> None:
+    def incoming_response(self, request_id: Optional[int], params: Any, is_error: bool) -> None:
         if not userprefs().log_server:
             return
         direction = "<~~" if is_error else "<<<"
-        duration = self._request_time_tracker.end_tracking(request_id)
+        duration = self._request_time_tracker.end_tracking(request_id) if request_id is not None else "-"
         self.log(self._format_response(direction, request_id, duration), params)
 
     def incoming_request(self, request_id: Any, method: str, params: Any) -> None:
@@ -717,7 +717,7 @@ class RemoteLogger(Logger):
             'direction': self.DIRECTION_OUTGOING,
         })
 
-    def incoming_response(self, request_id: int, params: Any, is_error: bool) -> None:
+    def incoming_response(self, request_id: Optional[int], params: Any, is_error: bool) -> None:
         self._broadcast_json({
             'server': self._server_name,
             'id': request_id,

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -61,7 +61,7 @@ class MockLogger(Logger):
     def outgoing_notification(self, method: str, params: Any) -> None:
         pass
 
-    def incoming_response(self, request_id: int, params: Any, is_error: bool, blocking: bool) -> None:
+    def incoming_response(self, request_id: Optional[int], params: Any, is_error: bool, blocking: bool) -> None:
         pass
 
     def incoming_request(self, request_id: Any, method: str, params: Any) -> None:


### PR DESCRIPTION
This should fix an uncatched exception in case of server response with id `null`, which apparently is valid per LSP & JSON-RPC specs and is or was used by at least one server (https://github.com/JohnnyMorganz/luau-lsp/issues/161 - maybe in a bit inappropriate way, though).