### PR TITLE
Fix handling of folder_exclude_patterns in projects

### DIFF
--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -359,19 +359,10 @@ class WindowManager(Manager):
         if matches_pattern(path, settings.get("file_exclude_patterns")):
             return "matches a pattern in file_exclude_patterns"
         patterns = [sublime_pattern_to_glob(pattern, True) for pattern in settings.get("folder_exclude_patterns") or []]
-        project_data = self.window.project_data()
-        if project_data:
-            for folder in project_data.get('folders', []):
-                for pattern in folder.get('folder_exclude_patterns', []):
-                    if pattern.startswith('//'):
-                        patterns.append(sublime_pattern_to_glob(pattern, True, folder['path']))
-                    elif pattern.startswith('/'):
-                        patterns.append(sublime_pattern_to_glob(pattern, True))
-                    else:
-                        patterns.append(sublime_pattern_to_glob('//' + pattern, True, folder['path']))
-                        patterns.append(sublime_pattern_to_glob('//**/' + pattern, True, folder['path']))
         if matches_pattern(path, patterns):
             return "matches a pattern in folder_exclude_patterns"
+        if self._workspace.includes_excluded_path(path):
+            return "matches a project's folder_exclude_patterns"
         return None
 
     def on_post_exit_async(self, session: Session, exit_code: int, exception: Optional[Exception]) -> None:

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -69,7 +69,6 @@ class ProjectFolders(object):
             return
         for i, folder in enumerate(project_data.get('folders', [])):
             exclude_patterns = []
-            self._folders_exclude_patterns.append(exclude_patterns)
             # Use canoncial path from `window.folders` rather than potentially relative path from project data.
             path = folders[i]
             for pattern in folder.get('folder_exclude_patterns', []):
@@ -80,6 +79,7 @@ class ProjectFolders(object):
                 else:
                     exclude_patterns.append(sublime_pattern_to_glob('//' + pattern, True, path))
                     exclude_patterns.append(sublime_pattern_to_glob('//**/' + pattern, True, path))
+            self._folders_exclude_patterns.append(exclude_patterns)
 
     def update(self) -> bool:
         new_folders = self._window.folders()

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -106,7 +106,7 @@ class ProjectFolders(object):
                 continue
             exclude_patterns = self._folders_exclude_patterns[i]
             is_excluded = matches_pattern(file_path, exclude_patterns)
-            if is_excluded:
+            if not is_excluded:
                 break
         return is_excluded
 

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -4,6 +4,7 @@ from .core.promise import Promise
 from .core.protocol import CodeLens
 from .core.protocol import CodeLensExtended
 from .core.protocol import DiagnosticTag
+from .core.protocol import AnnotatedTextEdit
 from .core.protocol import DocumentUri
 from .core.protocol import Notification
 from .core.protocol import Request

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -4,7 +4,6 @@ from .core.promise import Promise
 from .core.protocol import CodeLens
 from .core.protocol import CodeLensExtended
 from .core.protocol import DiagnosticTag
-from .core.protocol import AnnotatedTextEdit
 from .core.protocol import DocumentUri
 from .core.protocol import Notification
 from .core.protocol import Request


### PR DESCRIPTION
ProjectFolders now holds a mapping of `folder_exclude_patterns` matching each of the workspace `folders`. This way we can do more targeted check to know whether path is not ignored in at least one of the folders.

I think this logic might be a bit hard to wrap the head around and not sure if the design of that fix is good.

Fixes #2171