### PR TITLE
don't send params for requests/notifications that don't expect them

### DIFF
--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -5985,12 +5985,14 @@ class Request(Generic[R]):
         return self.method + " " + str(self.params)
 
     def to_payload(self, id: int) -> Dict[str, Any]:
-        return {
+        payload = {
             "jsonrpc": "2.0",
             "id": id,
             "method": self.method,
-            "params": self.params
         }
+        if self.params is not None:
+            payload["params"] = self.params
+        return payload
 
 
 class Error(Exception):
@@ -6030,12 +6032,11 @@ class Response(Generic[T]):
         self.result = result
 
     def to_payload(self) -> Dict[str, Any]:
-        r = {
+        return {
             "id": self.request_id,
             "jsonrpc": "2.0",
             "result": self.result
         }
-        return r
 
 
 class Notification:
@@ -6090,11 +6091,13 @@ class Notification:
         return self.method + " " + str(self.params)
 
     def to_payload(self) -> Dict[str, Any]:
-        return {
+        payload = {
             "jsonrpc": "2.0",
             "method": self.method,
-            "params": self.params
         }
+        if self.params is not None:
+            payload["params"] = self.params
+        return payload
 
 
 class Point(object):

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -43,7 +43,7 @@ class RequestTests(unittest.TestCase):
         self.assertEqual(payload["jsonrpc"], "2.0")
         self.assertEqual(payload["id"], 1)
         self.assertEqual(payload["method"], "shutdown")
-        self.assertEqual(payload["params"], None)
+        self.assertNotIn('params', payload)
 
 
 class NotificationTests(unittest.TestCase):
@@ -62,4 +62,4 @@ class NotificationTests(unittest.TestCase):
         self.assertEqual(payload["jsonrpc"], "2.0")
         self.assertNotIn("id", payload)
         self.assertEqual(payload["method"], "exit")
-        self.assertEqual(payload["params"], None)
+        self.assertNotIn('params', payload)


### PR DESCRIPTION
Rome returns an error response if we include `params: null` in the `shutdown` request:

```
:: [21:44:43.399] --> LSP-rome shutdown (6): None
:: [21:44:50.131] <~~ LSP-rome (6) (duration: 6732ms): {'message': 'Unexpected params: null', 'code': -32602}
```

Spec says that the `shutdown` request and the `exit` notification have `params: void` which I guess means that the property should not be set. `params` is an optional property in the spec so this is valid per spec:

```ts
interface RequestMessage extends Message {

	/**
	 * The request id.
	 */
	id: integer | string;

	/**
	 * The method to be invoked.
	 */
	method: string;

	/**
	 * The method's params.
	 */
	params?: array | object;
}
```

In the spec there are some server-initiated requests like `workspace/codeLens/refresh` that have `params: none` specified. I wonder if that means that server is expected to set `null` for those or it's fine to also not set the property at all. But that's not strictly related to our issue.