### PR TITLE
handle `editor.action.rename` command for interoperability with VSCode

### DIFF
--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -259,7 +259,9 @@ class CodeActionOnSaveTask(SaveTask):
         for config_name, code_actions in responses:
             session = self._task_runner.session_by_name(config_name, 'codeActionProvider')
             if session:
-                tasks.extend([session.run_code_action_async(action, view, progress=False) for action in code_actions])
+                tasks.extend([
+                    session.run_code_action_async(action, progress=False, source_view=view) for action in code_actions
+                ])
         Promise.all(tasks).then(lambda _: self._on_code_actions_completed(document_version))
 
     def _on_code_actions_completed(self, previous_document_version: int) -> None:
@@ -346,7 +348,7 @@ class LspCodeActionsCommand(LspTextCommand):
             config_name, action = actions[index]
             session = self.session_by_name(config_name)
             if session:
-                session.run_code_action_async(action, self.view, progress=True) \
+                session.run_code_action_async(action, progress=True, source_view=self.view) \
                     .then(lambda response: self._handle_response_async(config_name, response))
 
         sublime.set_timeout_async(run_async)
@@ -410,7 +412,7 @@ class LspMenuActionCommand(LspWindowCommand, metaclass=ABCMeta):
             config_name, action = self.actions_cache[id]
             session = self.session_by_name(config_name)
             if session:
-                session.run_code_action_async(action, self.view, progress=True) \
+                session.run_code_action_async(action, progress=True, source_view=self.view) \
                     .then(lambda response: self._handle_response_async(config_name, response))
 
     def _handle_response_async(self, session_name: str, response: Any) -> None:

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -11,6 +11,7 @@ from .views import first_selection_region
 from .views import get_uri_and_position_from_location
 from .views import MissingUriError
 from .views import point_to_offset
+from .views import position_to_offset
 from .views import uri_from_view
 from .windows import WindowManager
 from .windows import WindowRegistry
@@ -310,11 +311,11 @@ def navigate_diagnostics(view: sublime.View, point: Optional[int], forward: bool
     # this view after/before the cursor
     op_func = operator.gt if forward else operator.lt
     for diagnostic in diagnostics:
-        diag_pos = point_to_offset(Point.from_lsp(diagnostic['range']['start']), view)
+        diag_pos = position_to_offset(diagnostic['range']['start'], view)
         if op_func(diag_pos, point):
             break
     else:
-        diag_pos = point_to_offset(Point.from_lsp(diagnostics[0]['range']['start']), view)
+        diag_pos = position_to_offset(diagnostics[0]['range']['start'], view)
     view.run_command('lsp_selection_set', {'regions': [(diag_pos, diag_pos)]})
     view.show_at_center(diag_pos)
     # We need a small delay before showing the popup to wait for the scrolling animation to finish. Otherwise ST would

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -1,7 +1,6 @@
 from .protocol import Diagnostic
 from .protocol import Location
 from .protocol import LocationLink
-from .protocol import Point
 from .sessions import AbstractViewListener
 from .sessions import Session
 from .tree_view import TreeDataProvider
@@ -10,7 +9,6 @@ from .typing import Optional, Any, Generator, Iterable, List, Union
 from .views import first_selection_region
 from .views import get_uri_and_position_from_location
 from .views import MissingUriError
-from .views import point_to_offset
 from .views import position_to_offset
 from .views import uri_from_view
 from .windows import WindowManager

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1593,7 +1593,7 @@ class Session(TransportCallbacks):
         )
 
     def run_code_action_async(
-        self, code_action: Union[Command, CodeAction], source_view: Optional[sublime.View], progress: bool
+        self, code_action: Union[Command, CodeAction], progress: bool, source_view: Optional[sublime.View] = None
     ) -> Promise:
         command = code_action.get("command")
         if isinstance(command, str):

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1548,7 +1548,7 @@ class Session(TransportCallbacks):
         return variables
 
     def execute_command(
-        self, command: ExecuteCommandParams, source_view: Optional[sublime.View], progress: bool
+        self, command: ExecuteCommandParams, progress: bool, source_view: Optional[sublime.View] = None
     ) -> Promise:
         """Run a command from any thread. Your .then() continuations will run in Sublime's worker thread."""
         if self._plugin:
@@ -1603,7 +1603,7 @@ class Session(TransportCallbacks):
             arguments = code_action.get('arguments', None)
             if isinstance(arguments, list):
                 command_params['arguments'] = arguments
-            return self.execute_command(command_params, source_view, progress)
+            return self.execute_command(command_params, progress, source_view)
         # At this point it cannot be a command anymore, it has to be a proper code action.
         # A code action can have an edit and/or command. Note that it can have *both*. In case both are present, we
         # must apply the edits before running the command.
@@ -1720,7 +1720,8 @@ class Session(TransportCallbacks):
             arguments = command.get("arguments")
             if arguments is not None:
                 execute_command['arguments'] = arguments
-            return promise.then(lambda _: self.execute_command(execute_command, source_view, progress=False))
+            return promise.then(
+                lambda _: self.execute_command(execute_command, progress=False, source_view=source_view))
         return promise
 
     def apply_workspace_edit_async(self, edit: WorkspaceEdit) -> Promise[None]:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1556,8 +1556,8 @@ class Session(TransportCallbacks):
             promise, resolve = task
             if self._plugin.on_pre_server_command(command, lambda: resolve(None)):
                 return promise
-        # Handle VSCode-specific command for triggering AC/sighelp
         command_name = command['command']
+        # Handle VSCode-specific command for triggering AC/sighelp
         if command_name == "editor.action.triggerSuggest" and source_view:
             # Triggered from set_timeout as suggestions popup doesn't trigger otherwise.
             sublime.set_timeout(lambda: source_view.run_command("auto_complete"))

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -339,6 +339,10 @@ def position(view: sublime.View, offset: int) -> Position:
     return offset_to_point(view, offset).to_lsp()
 
 
+def position_to_offset(position: Position, view: sublime.View) -> int:
+    return point_to_offset(Point.from_lsp(position), view)
+
+
 def get_symbol_kind_from_scope(scope_name: str) -> SublimeKind:
     best_kind = sublime.KIND_AMBIGUOUS
     best_kind_score = 0
@@ -351,9 +355,7 @@ def get_symbol_kind_from_scope(scope_name: str) -> SublimeKind:
 
 
 def range_to_region(range: Range, view: sublime.View) -> sublime.Region:
-    start = Point.from_lsp(range['start'])
-    end = Point.from_lsp(range['end'])
-    return sublime.Region(point_to_offset(start, view), point_to_offset(end, view))
+    return sublime.Region(position_to_offset(range['start'], view), position_to_offset(range['end'], view))
 
 
 def region_to_range(view: sublime.View, region: sublime.Region) -> Range:

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -697,7 +697,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         def run_async() -> None:
             session = self.session_by_name(config_name)
             if session:
-                session.run_code_action_async(actions[index], self.view, progress=True)
+                session.run_code_action_async(actions[index], progress=True, source_view=self.view)
 
         sublime.set_timeout_async(run_async)
 

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -697,7 +697,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         def run_async() -> None:
             session = self.session_by_name(config_name)
             if session:
-                session.run_code_action_async(actions[index], progress=True)
+                session.run_code_action_async(actions[index], self.view, progress=True)
 
         sublime.set_timeout_async(run_async)
 

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -35,7 +35,7 @@ class LspExecuteCommand(LspTextCommand):
                     return
                 self.handle_success_async(response, command_name)
 
-            session.execute_command(params, self.view, progress=True).then(handle_response)
+            session.execute_command(params, progress=True, source_view=self.view).then(handle_response)
 
     def handle_success_async(self, result: Any, command_name: str) -> None:
         """

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -1,10 +1,13 @@
 from .core.protocol import Error
 from .core.protocol import ExecuteCommandParams
 from .core.registry import LspTextCommand
-from .core.registry import windows
 from .core.typing import List, Optional, Any
 from .core.views import first_selection_region
-from .core.views import uri_from_view, offset_to_point, region_to_range, text_document_identifier, text_document_position_params  # noqa: E501
+from .core.views import offset_to_point
+from .core.views import region_to_range
+from .core.views import text_document_identifier
+from .core.views import text_document_position_params
+from .core.views import uri_from_view
 import sublime
 
 
@@ -19,18 +22,6 @@ class LspExecuteCommand(LspTextCommand):
             command_args: Optional[List[Any]] = None,
             session_name: Optional[str] = None,
             event: Optional[dict] = None) -> None:
-        # Handle VSCode-specific command for triggering AC/sighelp
-        if command_name == "editor.action.triggerSuggest":
-            # Triggered from set_timeout as suggestions popup doesn't trigger otherwise.
-            return sublime.set_timeout(lambda: self.view.run_command("auto_complete"))
-        if command_name == "editor.action.triggerParameterHints":
-
-            def run_async() -> None:
-                listener = windows.listener_for_view(self.view)
-                if listener:
-                    listener.do_signature_help_async(manual=False)
-
-            return sublime.set_timeout_async(run_async)
         session = self.session_by_name(session_name if session_name else self.session_name)
         if session and command_name:
             params = {"command": command_name}  # type: ExecuteCommandParams
@@ -44,7 +35,7 @@ class LspExecuteCommand(LspTextCommand):
                     return
                 self.handle_success_async(response, command_name)
 
-            session.execute_command(params, progress=True).then(handle_response)
+            session.execute_command(params, self.view, progress=True).then(handle_response)
 
     def handle_success_async(self, result: Any, command_name: str) -> None:
         """

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -377,6 +377,6 @@ class LspHoverCommand(LspTextCommand):
         def run_async() -> None:
             session = self.session_by_name(config_name)
             if session:
-                session.run_code_action_async(actions[index], progress=True)
+                session.run_code_action_async(actions[index], self.view, progress=True)
 
         sublime.set_timeout_async(run_async)

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -377,6 +377,6 @@ class LspHoverCommand(LspTextCommand):
         def run_async() -> None:
             session = self.session_by_name(config_name)
             if session:
-                session.run_code_action_async(actions[index], self.view, progress=True)
+                session.run_code_action_async(actions[index], progress=True, source_view=self.view)
 
         sublime.set_timeout_async(run_async)

--- a/plugin/inlay_hint.py
+++ b/plugin/inlay_hint.py
@@ -2,14 +2,13 @@ from .core.css import css
 from .core.protocol import InlayHint
 from .core.protocol import InlayHintLabelPart
 from .core.protocol import MarkupContent
-from .core.protocol import Point
 from .core.protocol import Request
 from .core.registry import LspTextCommand
 from .core.registry import LspWindowCommand
 from .core.sessions import Session
 from .core.settings import userprefs
 from .core.typing import cast, Optional, Union
-from .core.views import point_to_offset
+from .core.views import position_to_offset
 from .formatting import apply_text_edits_to_view
 import html
 import sublime
@@ -88,7 +87,7 @@ class LspInlayHintClickCommand(LspTextCommand):
 
 def inlay_hint_to_phantom(view: sublime.View, inlay_hint: InlayHint, session: Session) -> sublime.Phantom:
     position = inlay_hint["position"]
-    region = sublime.Region(point_to_offset(Point.from_lsp(position), view))
+    region = sublime.Region(position_to_offset(position, view))
     phantom_uuid = str(uuid.uuid4())
     content = get_inlay_hint_html(view, inlay_hint, session, phantom_uuid)
     p = sublime.Phantom(region, content, sublime.LAYOUT_INLINE)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -210,7 +210,7 @@ class TextDocumentTestCase(DeferrableTestCase):
     def await_run_code_action(self, code_action: Dict[str, Any]) -> Generator:
         promise = YieldPromise()
         sublime.set_timeout_async(
-            lambda: self.session.run_code_action_async(code_action, self.view, progress=False).then(
+            lambda: self.session.run_code_action_async(code_action, progress=False, source_view=self.view).then(
                 promise.fulfill))
         yield from self.await_promise(promise)
 

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -210,7 +210,7 @@ class TextDocumentTestCase(DeferrableTestCase):
     def await_run_code_action(self, code_action: Dict[str, Any]) -> Generator:
         promise = YieldPromise()
         sublime.set_timeout_async(
-            lambda: self.session.run_code_action_async(code_action, progress=False).then(
+            lambda: self.session.run_code_action_async(code_action, self.view, progress=False).then(
                 promise.fulfill))
         yield from self.await_promise(promise)
 

--- a/tests/test_single_document.py
+++ b/tests/test_single_document.py
@@ -347,7 +347,8 @@ class SingleDocumentTestCase(TextDocumentTestCase):
         sublime.set_timeout_async(
             lambda: self.session.execute_command(
                 {"command": "foo", "arguments": ["hello", "there", "general", "kenobi"]},
-                progress=False
+                progress=False,
+                source_view=self.view,
             ).then(promise.fulfill)
         )
         yield from self.await_promise(promise)


### PR DESCRIPTION
Added support for the `editor.action.rename` command since Volar and possibly other servers use it.

I had to move handling of VSCode-specific commands from `LspExecuteCommand` to `Session.execute_command` because when triggering a code action, the code doesn't go through the Text Command.

Since those VSCode-specific commands kinda required `View`, I'm passing it though to `execute_command` so that I don't have to use hacky way of "get any or active view for session".

Volar returns code actions like:

```json
  {
    "command": {
      "arguments": [
        "file:///usr/local/workspace/github/volar-vue2-test/pages/index.vue",
        {
          "character": 8,
          "line": 8
        }
      ],
      "command": "editor.action.rename",
      "title": ""
    },
    "data": {
      "original": {
        "edit": {
          "documentChanges": [
            {
              "edits": [
                {
                  "newText": "newFunction()",
                  "range": {
                    "end": {
                      "character": 15,
                      "line": 3
                    },
                    "start": {
                      "character": 8,
                      "line": 3
                    }
                  }
                },
                {
                  "newText": "function newFunction() {\nreturn 'Index';\n}\n\n",
                  "range": {
                    "end": {
                      "character": 0,
                      "line": 21
                    },
                    "start": {
                      "character": 0,
                      "line": 21
                    }
                  }
                }
              ],
              "textDocument": {
                "uri": "file:///usr/local/workspace/github/volar-vue2-test/pages/index.vue.js",
                "version": null
              }
            }
          ]
        }
      },
      "serviceId": "typescript",
      "type": "service",
      "uri": "file:///usr/local/workspace/github/volar-vue2-test/pages/index.vue",
      "version": 5
    }
```