### PR TITLE
fix regression causing `<br>` to show in code action annotation

### DIFF
--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -656,7 +656,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             if action_count > 1:
                 title = '{} code actions'.format(action_count)
             else:
-                title = "<br>".join(textwrap.wrap(first_action_title, width=30))
+                title = first_action_title
             code_actions_link = make_link('code-actions:', title)
             annotations = ["<div class=\"actions\" style=\"font-family:system\">{}</div>".format(code_actions_link)]
             annotation_color = self.view.style_for_scope("region.bluish markup.accent.codeaction.lsp")["foreground"]

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -53,7 +53,6 @@ from weakref import WeakValueDictionary
 import itertools
 import sublime
 import sublime_plugin
-import textwrap
 import weakref
 import webbrowser
 

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -652,10 +652,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             icon = 'Packages/LSP/icons/lightbulb.png'
             self._lightbulb_line = self.view.rowcol(regions[0].begin())[0]
         else:  # 'annotation'
-            if action_count > 1:
-                title = '{} code actions'.format(action_count)
-            else:
-                title = first_action_title
+            title = '{} code actions'.format(action_count) if action_count > 1 else first_action_title
             code_actions_link = make_link('code-actions:', title)
             annotations = ["<div class=\"actions\" style=\"font-family:system\">{}</div>".format(code_actions_link)]
             annotation_color = self.view.style_for_scope("region.bluish markup.accent.codeaction.lsp")["foreground"]


### PR DESCRIPTION
Regression caused by #2239 where I've switched from `make_command_link` to `make_link` where the latter does html escaping but former doesn't.

### Before

![Screenshot 2023-05-12 at 22 47 18](https://github.com/sublimelsp/LSP/assets/153197/342c8306-7944-4042-8d26-88ce6ae740f3)

### After

![Screenshot 2023-05-12 at 22 47 48](https://github.com/sublimelsp/LSP/assets/153197/073deacc-6ff8-4a5c-ac8a-49757d2b22df)

I've also removed text wrapping. It was rather aggressive at 30 characters. Since ST elides the text length itself to not overlap the code, I'm not sure we should be doing it. If for ascetic reasons we do want it then we should probably at least increase the number of characters.

Fixes #2245