### PR TITLE
Fix package storage path in a docstring description

### DIFF
--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -311,7 +311,7 @@ def get_storage_path() -> str:
 
     - on macOS: ~/Library/Application Support/Sublime Text
     - on Windows: %LocalAppData%/Sublime Text
-    - on Linux: $XDG_CONFIG_DIR/sublime-text
+    - on Linux: ~/.cache/sublime-text
     """
     return os.path.abspath(os.path.join(sublime.cache_path(), "..", "Package Storage"))
 

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -309,7 +309,7 @@ def get_storage_path() -> str:
     The "Package Storage" is a way to store server data without influencing the behavior of Sublime Text's "catalog".
     Its path is '$DATA/Package Storage', where $DATA means:
 
-    - on macOS: ~/Library/Application Support/Sublime Text
+    - on macOS: '~/Library/Application Support/Sublime Text'
     - on Windows: %LocalAppData%/Sublime Text
     - on Linux: ~/.cache/sublime-text
     """

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -310,7 +310,7 @@ def get_storage_path() -> str:
     Its path is '$DATA/Package Storage', where $DATA means:
 
     - on macOS: ~/Library/Application Support/Sublime Text
-    - on Windows: %AppData%/Sublime Text/Roaming
+    - on Windows: %LocalAppData%/Sublime Text
     - on Linux: $XDG_CONFIG_DIR/sublime-text
     """
     return os.path.abspath(os.path.join(sublime.cache_path(), "..", "Package Storage"))

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -309,7 +309,7 @@ def get_storage_path() -> str:
     The "Package Storage" is a way to store server data without influencing the behavior of Sublime Text's "catalog".
     Its path is '$DATA/Package Storage', where $DATA means:
 
-    - on macOS: '~/Library/Application Support/Sublime Text'
+    - on macOS: ~/Library/Application Support/Sublime Text
     - on Windows: %LocalAppData%/Sublime Text
     - on Linux: ~/.cache/sublime-text
     """


### PR DESCRIPTION
The `%AppData%/Sublime Text/Roaming` path from the docstring of the `get_storage_path` function doesn't exist.

Could someone confirm whether the paths on macOS and Linux are correct?