### PR TITLE
use class for diagnostic info instead of hardcoding color

### DIFF
--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -1008,7 +1008,8 @@ def format_diagnostic_for_html(config: ClientConfig, diagnostic: Diagnostic, bas
     if related_infos:
         info = "<br>".join(_format_diagnostic_related_info(config, info, base_dir) for info in related_infos)
         html += _html_element("pre", info, class_name="related_info", escape=False)
-    return _html_element("pre", html, class_name=DIAGNOSTIC_SEVERITY[diagnostic_severity(diagnostic) - 1][1])
+    severity_class = DIAGNOSTIC_SEVERITY[diagnostic_severity(diagnostic) - 1][1]
+    return _html_element("pre", html, class_name=severity_class, escape=False)
 
 
 def format_code_actions_for_quick_panel(

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -993,17 +993,14 @@ def format_diagnostic_for_html(config: ClientConfig, diagnostic: Diagnostic, bas
     code = diagnostic.get("code")
     source = diagnostic.get("source")
     if source or code is not None:
-        html += " "
+        meta_info = " "
         if source:
-            html += _html_element("span", source, class_name="color-muted")
+            meta_info += text2html(source)
         if code is not None:
-            html += _html_element("span", "(", class_name="color-muted")
             code_description = diagnostic.get("codeDescription")
-            if code_description:
-                html += make_link(code_description["href"], str(code))
-            else:
-                html += _html_element("span", str(code), class_name="color-muted")
-            html += _html_element("span", ")", class_name="color-muted")
+            meta_info += "({})".format(
+                make_link(code_description["href"], str(code)) if code_description else text2html(str(code)))
+        html += _html_element("span", meta_info, class_name="color-muted", escape=False)
     related_infos = diagnostic.get("relatedInformation")
     if related_infos:
         info = "<br>".join(_format_diagnostic_related_info(config, info, base_dir) for info in related_infos)

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -993,14 +993,14 @@ def format_diagnostic_for_html(config: ClientConfig, diagnostic: Diagnostic, bas
     code = diagnostic.get("code")
     source = diagnostic.get("source")
     if source or code is not None:
-        meta_info = " "
+        meta_info = ""
         if source:
             meta_info += text2html(source)
         if code is not None:
             code_description = diagnostic.get("codeDescription")
             meta_info += "({})".format(
                 make_link(code_description["href"], str(code)) if code_description else text2html(str(code)))
-        html += _html_element("span", meta_info, class_name="color-muted", escape=False)
+        html += " " + _html_element("span", meta_info, class_name="color-muted", escape=False)
     related_infos = diagnostic.get("relatedInformation")
     if related_infos:
         info = "<br>".join(_format_diagnostic_related_info(config, info, base_dir) for info in related_infos)

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -980,7 +980,7 @@ def _format_diagnostic_related_info(
     )
 
 
-def _html_element(name: str, text: str, class_name: Optional[str] = None, escape=True) -> str:
+def _html_element(name: str, text: str, class_name: Optional[str] = None, escape: bool = True) -> str:
     return '<{0}{2}>{1}</{0}>'.format(
         name,
         text2html(text) if escape else text,

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -1007,7 +1007,7 @@ def format_diagnostic_for_html(config: ClientConfig, diagnostic: Diagnostic, bas
     related_infos = diagnostic.get("relatedInformation")
     if related_infos:
         info = "<br>".join(_format_diagnostic_related_info(config, info, base_dir) for info in related_infos)
-        html += _html_element("pre", info, class_name="related_info", escape=False)
+        html += '<br>' + _html_element("pre", info, class_name="related_info", escape=False)
     severity_class = DIAGNOSTIC_SEVERITY[diagnostic_severity(diagnostic) - 1][1]
     return _html_element("pre", html, class_name=severity_class, escape=False)
 

--- a/plugin/goto_diagnostic.py
+++ b/plugin/goto_diagnostic.py
@@ -282,7 +282,7 @@ class DiagnosticInputHandler(sublime_plugin.ListInputHandler):
         if scheme == "file":
             self._preview = open_location(session, self._get_location(diagnostic), flags=sublime.TRANSIENT)
             base_dir = project_base_dir(map(Path, self.window.folders()), Path(path))
-        return diagnostic_html(self.view, session.config, truncate_message(diagnostic), base_dir)
+        return diagnostic_html(session.config, truncate_message(diagnostic), base_dir)
 
     def _get_location(self, diagnostic: Diagnostic) -> Location:
         return diagnostic_location(self.parsed_uri, diagnostic)
@@ -301,8 +301,7 @@ def open_location(session: Session, location: Location, flags: int = 0, group: i
     return session.window.open_file(file_name, flags=flags | sublime.ENCODED_POSITION, group=group)
 
 
-def diagnostic_html(view: sublime.View, config: ClientConfig, diagnostic: Diagnostic,
-                    base_dir: Optional[Path]) -> sublime.Html:
+def diagnostic_html(config: ClientConfig, diagnostic: Diagnostic, base_dir: Optional[Path]) -> sublime.Html:
     content = format_diagnostic_for_html(
         config, truncate_message(diagnostic), None if base_dir is None else str(base_dir))
     return sublime.Html('<style>{}</style><div class="diagnostics {}">{}</div>'.format(

--- a/popups.css
+++ b/popups.css
@@ -23,7 +23,7 @@
     border-radius: 0;
 }
 .color-muted {
-    color: color(var(--foreground) alpha(0.50));
+    color: color(var(--foreground) alpha(0.6));
 }
 .diagnostics {
     margin-bottom: 0.5rem;


### PR DESCRIPTION
Use `.color-muted` class instead of hardcoding color when showing diagnostic info.

Changed opacity of `.color-muted` from `0.5` to `0.6`. Should still be fine and is more consistent with other places.

Fixes #2255