### PR TITLE
Use regular font style in sighelp popup if already highlighted by color scheme

### DIFF
--- a/docs/src/customization.md
+++ b/docs/src/customization.md
@@ -220,6 +220,9 @@ The color scheme rule only works if the "background" color is (marginally) diffe
 | `variable.parameter.sighelp.lsp` | Function argument in the signature help popup |
 | `variable.parameter.sighelp.active.lsp` | Function argument which is currently highlighted in the signature help popup |
 
+!!! note
+    If the color scheme utilizes different (foreground) colors for the scopes of active and non-active parameters, the active parameter will not additionally be rendered with bold and underlined font style.
+
 ### Annotations
 
 | scope | description |


### PR DESCRIPTION
The signature help popup uses bold & underlined font style for the active parameter, which looks a bit ugly in my opinion.
With this PR, it will keep the regular font style if the color scheme already defines different colors for active and non-active parameters. This is the case for example [in my own color scheme](https://github.com/jwortmann/brackets-color-scheme/blob/54c4e4a429b07f824af3c11098ee612caa596f8f/Brackets%20Dark.sublime-color-scheme#L2154-L2163), (though I will probably adjust the colors a bit if the PR gets merged).

![sighelp](https://github.com/sublimelsp/LSP/assets/6579999/20fe311b-c563-4208-b9be-5917dadf8aa2)

Also the number of `View.style_for_scope` API calls is reduced by storing the results into variables and avoiding redundant calls.
