### PR TITLE
fix crash on checking excluded folders with missing project data

### DIFF
--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -63,7 +63,7 @@ class ProjectFolders(object):
         self._update_exclude_patterns(self.folders)
 
     def _update_exclude_patterns(self, folders: List[str]) -> None:
-        self._folders_exclude_patterns = []
+        self._folders_exclude_patterns = [[]] * len(folders)
         project_data = self._window.project_data()
         if not isinstance(project_data, dict):
             return
@@ -79,7 +79,7 @@ class ProjectFolders(object):
                 else:
                     exclude_patterns.append(sublime_pattern_to_glob('//' + pattern, True, path))
                     exclude_patterns.append(sublime_pattern_to_glob('//**/' + pattern, True, path))
-            self._folders_exclude_patterns.append(exclude_patterns)
+            self._folders_exclude_patterns[i] = exclude_patterns
 
     def update(self) -> bool:
         new_folders = self._window.folders()

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -63,6 +63,7 @@ class ProjectFolders(object):
         self._update_exclude_patterns(self.folders)
 
     def _update_exclude_patterns(self, folders: List[str]) -> None:
+        # Ensure that the number of patterns matches the number of folders so that accessing by index never throws.
         self._folders_exclude_patterns = [[]] * len(folders)
         project_data = self._window.project_data()
         if not isinstance(project_data, dict):


### PR DESCRIPTION
Ensure that the `_folders_exclude_patterns` list has same number of elements as `folders` so that accessing by index doesn't throw when `window.project_data()` is missing.

Fixes https://github.com/TerminalFi/LSP-copilot/issues/109