### PR TITLE
fix "Error rewriting command" warning triggered on startup

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -25,7 +25,6 @@ from .plugin.core.registry import LspExpandTreeItemCommand
 from .plugin.core.registry import LspNextDiagnosticCommand
 from .plugin.core.registry import LspOpenLocationCommand
 from .plugin.core.registry import LspPrevDiagnosticCommand
-from .plugin.core.registry import LspRecheckSessionsCommand
 from .plugin.core.registry import LspRestartServerCommand
 from .plugin.core.registry import windows
 from .plugin.core.sessions import AbstractPlugin

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -4,14 +4,24 @@ from .logging import printf
 from .types import ClientConfig
 from .typing import Generator, List, Optional, Set, Dict, Deque
 from .workspace import enable_in_project, disable_in_project
+from abc import ABCMeta
+from abc import abstractmethod
 from collections import deque
 from datetime import datetime, timedelta
+from weakref import WeakSet
 import sublime
 import urllib.parse
 
 
 RETRY_MAX_COUNT = 5
 RETRY_COUNT_TIMEDELTA = timedelta(minutes=3)
+
+
+class WindowConfigChangeListener(metaclass=ABCMeta):
+
+    @abstractmethod
+    def on_configs_changed(self, config_name: Optional[str] = None) -> None:
+        raise NotImplementedError()
 
 
 class WindowConfigManager(object):
@@ -21,7 +31,35 @@ class WindowConfigManager(object):
         self._disabled_for_session = set()  # type: Set[str]
         self._crashes = {}  # type: Dict[str, Deque[datetime]]
         self.all = {}  # type: Dict[str, ClientConfig]
-        self.update()
+        self._change_listeners = WeakSet()  # type: WeakSet[WindowConfigChangeListener]
+        self._reload_configs()
+
+    def _reload_configs(self, updated_config_name: Optional[str] = None) -> None:
+        project_settings = (self._window.project_data() or {}).get("settings", {}).get("LSP", {})
+        if updated_config_name is None:
+            self.all.clear()
+        for name, config in self._global_configs.items():
+            if updated_config_name and updated_config_name != name:
+                continue
+            overrides = project_settings.pop(name, None)
+            if isinstance(overrides, dict):
+                debug("applying .sublime-project override for", name)
+            else:
+                overrides = {}
+            if name in self._disabled_for_session:
+                overrides["enabled"] = False
+            self.all[name] = ClientConfig.from_config(config, overrides)
+        for name, c in project_settings.items():
+            if updated_config_name and updated_config_name != name:
+                continue
+            debug("loading project-only configuration", name)
+            try:
+                self.all[name] = ClientConfig.from_dict(name, c)
+            except Exception as ex:
+                exception_log("failed to load project-only configuration {}".format(name), ex)
+
+    def add_change_listener(self, listener: WindowConfigChangeListener) -> None:
+        self._change_listeners.add(listener)
 
     def get_configs(self) -> List[ClientConfig]:
         return sorted(self.all.values(), key=lambda config: config.name)
@@ -45,29 +83,9 @@ class WindowConfigManager(object):
             pass
 
     def update(self, updated_config_name: Optional[str] = None) -> None:
-        project_settings = (self._window.project_data() or {}).get("settings", {}).get("LSP", {})
-        if updated_config_name is None:
-            self.all.clear()
-        for name, config in self._global_configs.items():
-            if updated_config_name and updated_config_name != name:
-                continue
-            overrides = project_settings.pop(name, None)
-            if isinstance(overrides, dict):
-                debug("applying .sublime-project override for", name)
-            else:
-                overrides = {}
-            if name in self._disabled_for_session:
-                overrides["enabled"] = False
-            self.all[name] = ClientConfig.from_config(config, overrides)
-        for name, c in project_settings.items():
-            if updated_config_name and updated_config_name != name:
-                continue
-            debug("loading project-only configuration", name)
-            try:
-                self.all[name] = ClientConfig.from_dict(name, c)
-            except Exception as ex:
-                exception_log("failed to load project-only configuration {}".format(name), ex)
-        self._window.run_command("lsp_recheck_sessions", {'config_name': updated_config_name})
+        self._reload_configs(updated_config_name)
+        for listener in self._change_listeners:
+            listener.on_configs_changed(updated_config_name)
 
     def enable_config(self, config_name: str) -> None:
         if not self._reenable_disabled_for_session(config_name):
@@ -76,7 +94,7 @@ class WindowConfigManager(object):
 
     def disable_config(self, config_name: str, only_for_session: bool = False) -> None:
         if only_for_session:
-            self._disable_for_session(config_name)
+            self._disabled_for_session.add(config_name)
         else:
             disable_in_project(self._window, config_name)
         self.update(config_name)
@@ -96,9 +114,6 @@ class WindowConfigManager(object):
         printf("{} crashed ({} / {} times in the last {} seconds), exit code {}, exception: {}".format(
             config_name, crash_count, RETRY_MAX_COUNT, RETRY_COUNT_TIMEDELTA.total_seconds(), exit_code, exception))
         return crash_count < RETRY_MAX_COUNT
-
-    def _disable_for_session(self, config_name: str) -> None:
-        self._disabled_for_session.add(config_name)
 
     def _reenable_disabled_for_session(self, config_name: str) -> bool:
         try:

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -277,17 +277,6 @@ class LspRestartServerCommand(LspTextCommand):
         sublime.set_timeout_async(run_async)
 
 
-class LspRecheckSessionsCommand(sublime_plugin.WindowCommand):
-    def run(self, config_name: Optional[str] = None) -> None:
-
-        def run_async() -> None:
-            wm = windows.lookup(self.window)
-            if wm:
-                wm.restart_sessions_async(config_name)
-
-        sublime.set_timeout_async(run_async)
-
-
 def navigate_diagnostics(view: sublime.View, point: Optional[int], forward: bool = True) -> None:
     try:
         uri = uri_from_view(view)

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -1,5 +1,8 @@
 from ...third_party import WebsocketServer  # type: ignore
-from .configurations import WindowConfigManager, RETRY_MAX_COUNT, RETRY_COUNT_TIMEDELTA
+from .configurations import RETRY_COUNT_TIMEDELTA
+from .configurations import RETRY_MAX_COUNT
+from .configurations import WindowConfigChangeListener
+from .configurations import WindowConfigManager
 from .diagnostics_storage import is_severity_included
 from .logging import debug
 from .logging import exception_log
@@ -62,7 +65,7 @@ def set_diagnostics_count(view: sublime.View, errors: int, warnings: int) -> Non
         pass
 
 
-class WindowManager(Manager):
+class WindowManager(Manager, WindowConfigChangeListener):
 
     def __init__(self, window: sublime.Window, workspace: ProjectFolders, config_manager: WindowConfigManager) -> None:
         self._window = window
@@ -81,6 +84,7 @@ class WindowManager(Manager):
         self.total_warning_count = 0
         sublime.set_timeout(functools.partial(self._update_panel_main_thread, _NO_DIAGNOSTICS_PLACEHOLDER, []))
         self.panel_manager.ensure_log_panel()
+        self._config_manager.add_change_listener(self)
 
     @property
     def window(self) -> sublime.Window:
@@ -481,6 +485,11 @@ class WindowManager(Manager):
             region = sublime.Region(point, point)
             phantoms.append(sublime.Phantom(region, "({})".format(make_link(href, code)), sublime.LAYOUT_INLINE))
         self._panel_code_phantoms.update(phantoms)
+
+    # --- Implements WindowConfigChangeListener ------------------------------------------------------------------------
+
+    def on_configs_changed(self, config_name: Optional[str] = None) -> None:
+        sublime.set_timeout_async(lambda: self.restart_sessions_async(config_name))
 
 
 class WindowRegistry:


### PR DESCRIPTION
Fixes `Error rewriting command lsp_recheck_sessions. Encountered infinite loop` warning on startup.

The warning is a bit misleading. It triggers not due to an infinite loop but due to triggering a window command directly from `plugin_loaded`. Basically means that triggering this command on startup had no effect but that's fine because at that point there is no sessions yet so it wouldn't really do anything anyway.

This PR removes the `LspRecheckSessionsCommand` command in favor of a more explicit notification triggered from the `WindowConfigManager` to the `WindowManager` to let it know that sessions should be restarted (the approach with using `LspRecheckSessionsCommand` was just a hack around the fact that `WindowConfigManager` did not have access to `WindowManager`).

Also note that I've changed `WindowConfigManager` to not trigger sessions restart on `__init__` since it's unnecessary since there are no sessions yet. That's why most of the `update()` code was moved to `_reload_configs()` and called on init.