### PR TITLE
Take font style of sighelp active parameter from color scheme

### DIFF
--- a/docs/src/customization.md
+++ b/docs/src/customization.md
@@ -221,7 +221,8 @@ The color scheme rule only works if the "background" color is (marginally) diffe
 | `variable.parameter.sighelp.active.lsp` | Function argument which is currently highlighted in the signature help popup |
 
 !!! note
-    If the color scheme utilizes different (foreground) colors for the scopes of active and non-active parameters, the active parameter will not additionally be rendered with bold and underlined font style.
+    If there is no special rule for the active parameter in the color scheme, it will be rendered with bold and underlined font style.
+    But if the color scheme defines a different `"foreground"` color for the active parameter, the style follows the `"font_style"` property from the color scheme rule.
 
 ### Annotations
 

--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -1006,7 +1006,7 @@ class View:
     def transform_region_from(self, region: Region, change_id: Any) -> Region:
         ...
 
-    def style_for_scope(self, scope: str) -> Dict[str, str]:
+    def style_for_scope(self, scope: str) -> Dict[str, Any]:
         ...
 
 


### PR DESCRIPTION
Implements https://github.com/sublimelsp/LSP/pull/2259#issuecomment-1554831618.

It turned out we don't need the bugged "source_line" to decide whether there is a special color scheme rule for the active parameter. Instead, we can just compare the foreground colors.