### PR TITLE
Remove experimental hover range support from core

### DIFF
--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -6148,8 +6148,7 @@ CodeLensExtended = TypedDict('CodeLensExtended', {
 
 ExperimentalTextDocumentRangeParams = TypedDict('ExperimentalTextDocumentRangeParams', {
     'textDocument': TextDocumentIdentifier,
-    'position': Position,
-    'range': Range,
+    'position': Range,
 })
 
 CompletionItemDefaults = __CompletionList_itemDefaults_Type_1

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -6146,11 +6146,6 @@ CodeLensExtended = TypedDict('CodeLensExtended', {
     'session_name': str
 })
 
-ExperimentalTextDocumentRangeParams = TypedDict('ExperimentalTextDocumentRangeParams', {
-    'textDocument': TextDocumentIdentifier,
-    'position': Range,
-})
-
 CompletionItemDefaults = __CompletionList_itemDefaults_Type_1
 CompletionEditRange = __CompletionList_itemDefaults_editRange_Type_1
 

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -466,12 +466,10 @@ def text_document_position_params(view: sublime.View, location: int) -> TextDocu
     return {"textDocument": text_document_identifier(view), "position": position(view, location)}
 
 
-def text_document_range_params(view: sublime.View, location: int,
-                               region: sublime.Region) -> ExperimentalTextDocumentRangeParams:
+def text_document_range_params(view: sublime.View, region: sublime.Region) -> ExperimentalTextDocumentRangeParams:
     return {
         "textDocument": text_document_identifier(view),
-        "position": position(view, location),
-        "range": region_to_range(view, region)
+        "position": region_to_range(view, region),
     }
 
 

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -18,7 +18,6 @@ from .protocol import DidSaveTextDocumentParams
 from .protocol import DocumentColorParams
 from .protocol import DocumentHighlightKind
 from .protocol import DocumentUri
-from .protocol import ExperimentalTextDocumentRangeParams
 from .protocol import Location
 from .protocol import LocationLink
 from .protocol import MarkedString
@@ -464,13 +463,6 @@ def versioned_text_document_identifier(view: sublime.View, version: int) -> Vers
 
 def text_document_position_params(view: sublime.View, location: int) -> TextDocumentPositionParams:
     return {"textDocument": text_document_identifier(view), "position": position(view, location)}
-
-
-def text_document_range_params(view: sublime.View, region: sublime.Region) -> ExperimentalTextDocumentRangeParams:
-    return {
-        "textDocument": text_document_identifier(view),
-        "position": region_to_range(view, region),
-    }
 
 
 def did_open_text_document_params(view: sublime.View, language_id: str) -> DidOpenTextDocumentParams:

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -163,10 +163,10 @@ class LspHoverCommand(LspTextCommand):
     def _create_hover_request(
         self, session: Session, point: int
     ) -> Union[TextDocumentPositionParams, ExperimentalTextDocumentRangeParams]:
-        if session.get_capability('experimental.rangeHoverProvider'):
+        if session.get_capability('experimental.hoverRange'):
             region = first_selection_region(self.view)
             if region is not None and region.contains(point):
-                return text_document_range_params(self.view, point, region)
+                return text_document_range_params(self.view, region)
         return text_document_position_params(self.view, point)
 
     def _on_all_settled(

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -11,11 +11,9 @@ from .core.protocol import Hover
 from .core.protocol import Position
 from .core.protocol import Range
 from .core.protocol import Request
-from .core.protocol import TextDocumentPositionParams
 from .core.registry import LspTextCommand
 from .core.registry import windows
 from .core.sessions import AbstractViewListener
-from .core.sessions import Session
 from .core.sessions import SessionBufferProtocol
 from .core.settings import userprefs
 from .core.typing import List, Optional, Dict, Tuple, Sequence, Union


### PR DESCRIPTION
~~The implementation on the rust-analyzer side has changed so updating our code to follow.~~

~~ref: https://github.com/rust-lang/rust-analyzer/blob/7e19d99d4f0631b141d4d49a49cd5c504726cf9c/docs/dev/lsp-extensions.md#hover-range~~

Moving experimental functionality from here to respective packages:
 - https://github.com/sublimelsp/LSP-rust-analyzer/pull/98
 - https://github.com/scalameta/metals-sublime/pull/108