### PR TITLE
Replace dots in the trigger with a different character that is visually the same

### DIFF
--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -97,7 +97,7 @@ def format_completion(
         details.append("<a href='{}'>{}</a>".format(command_url, oposite_insert_mode))
     # https://github.com/sublimehq/sublime_text/issues/6033
     # replaces . with a different one that looks the same
-    trigger = trigger.replace(".", "ꓸ")
+    trigger = trigger.replace(".", "․")
     completion = sublime.CompletionItem(
         trigger,
         annotation,

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -95,6 +95,9 @@ def format_completion(
         oposite_insert_mode = 'Replace' if insert_mode == 'insert' else 'Insert'
         command_url = "subl:lsp_commit_completion_with_opposite_insert_mode"
         details.append("<a href='{}'>{}</a>".format(command_url, oposite_insert_mode))
+    # https://github.com/sublimehq/sublime_text/issues/6033
+    # replaces . with a different one that looks the same
+    trigger = trigger.replace(".", "ꓸ")
     completion = sublime.CompletionItem(
         trigger,
         annotation,


### PR DESCRIPTION
This helps cases with Sublime Text strips some completion items

Check the following issue for more details: https://github.com/sublimehq/sublime_text/issues/6033


Question:

1. trigger wont insert anything?
2. if it inserts something, where would this trick be used instead?