### PR TITLE
Fix a rare KeyError

### DIFF
--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -853,7 +853,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             view_id = view.id()
             if view_id == self_id:
                 continue
-            listeners = list(sublime_plugin.view_event_listeners[view_id])
+            listeners = list(sublime_plugin.view_event_listeners.get(view_id, []))
             for listener in listeners:
                 if isinstance(listener, DocumentSyncListener):
                     debug("also registering", listener)


### PR DESCRIPTION
I can reproduce this error in the console
```
Traceback (most recent call last):
  File "C:\Program Files\Sublime Text\Lib\python33\sublime_plugin.py", line 944, in on_activated_async
    run_view_callbacks('on_activated_async', view_id)
  File "C:\Program Files\Sublime Text\Lib\python33\sublime_plugin.py", line 714, in run_view_callbacks
    callback(*args)
  File "C:\Program Files\Sublime Text\Lib\python33\sublime_plugin.py", line 190, in exception_handler
    return event_handler(*args)
  File "C:\Users\jwortmann\AppData\Roaming\Sublime Text\Packages\LSP\plugin\documents.py", line 338, in on_activated_async
    self._register_async()
  File "C:\Users\jwortmann\AppData\Roaming\Sublime Text\Packages\LSP\plugin\documents.py", line 856, in _register_async
    listeners = list(sublime_plugin.view_event_listeners[view_id])
KeyError: 18
```
with the following steps on ST4143:
1. Create a folder with at least two files in it, and with content in the files that contain a symbol which will show up in ST's built-in "Goto Reference panel" - for example two Python files with a single line `print("hello")`
2. Open the folder in a fresh ST instance, open one file, invoke ST's "Goto Reference..." (no need to have a language server running or enabled) and click with <kbd>Ctrl</kbd> + *mouse click* (it doesn't happen with <kbd>Ctrl</kbd>+<kbd>Enter</kbd>) on the unopened file in the quick panel
3. The file opens in side-by-side mode and this error appears in the console - looks like it's some kind of race condition between LSP's `_register_async` and functionality from `sublime_plugin`