### PR TITLE
support client config with `tcp_port` but without `command`

### DIFF
--- a/docs/src/client_configuration.md
+++ b/docs/src/client_configuration.md
@@ -65,6 +65,8 @@ The vast majority of language servers can communicate over stdio. To use stdio, 
 
 Some language servers can also act as a TCP server accepting incoming TCP connections. So: the language server subprocess is started by this package, and the subprocess will then open a TCP listener port. The editor can then connect as a client and initiate the communication. To use this mode, set `tcp_port` to a positive number designating the port to connect to on `localhost`.
 
+Optionally in this case, you can omit the `command` setting if you don't want Sublime LSP to manage the language server process and you'll take care of it yourself. 
+
 ### TCP - localhost - editor acts as a TCP server
 
 Some _LSP servers_ instead expect the _LSP client_ to act as a _TCP server_. The _LSP server_ will then connect as a _TCP client_, after which the _LSP client_ is expected to initiate the communication. To use this mode, set `tcp_port` to a negative number designating the port to bind to for accepting new TCP connections.

--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -188,6 +188,8 @@ Follow installation instructions on [LSP-gopls](https://github.com/sublimelsp/LS
     }
     ```
 
+If you encounter high cpu load or any other issues you can try omitting the [command] line, and ensure the godot editor is running while you work in sublime.
+
 ## GraphQL
 
 Follow installation instructions on [LSP-graphql](https://github.com/sublimelsp/LSP-graphql).

--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -94,8 +94,8 @@ class JsonRpcProcessor(AbstractProcessor[Dict[str, Any]]):
 
 class ProcessTransport(Transport[T]):
 
-    def __init__(self, name: str, process: Optional[subprocess.Popen], socket: Optional[socket.socket], reader: IO[bytes],
-                 writer: IO[bytes], stderr: Optional[IO[bytes]], processor: AbstractProcessor[T],
+    def __init__(self, name: str, process: Optional[subprocess.Popen], socket: Optional[socket.socket],
+                 reader: IO[bytes], writer: IO[bytes], stderr: Optional[IO[bytes]], processor: AbstractProcessor[T],
                  callback_object: TransportCallbacks[T]) -> None:
         self._closed = False
         self._process = process
@@ -137,7 +137,7 @@ class ProcessTransport(Transport[T]):
         self.close()
         self._join_thread(self._writer_thread)
         self._join_thread(self._reader_thread)
-        
+
         if self._stderr_thread is not None:
             self._join_thread(self._stderr_thread)
 
@@ -168,7 +168,7 @@ class ProcessTransport(Transport[T]):
 
     def _end(self, exception: Optional[Exception]) -> None:
         exit_code = 0
-        if not exception:
+        if not exception and self._process:
             try:
                 # Allow the process to stop itself.
                 exit_code = self._process.wait(1)
@@ -279,7 +279,10 @@ def create_transport(config: TransportConfig, cwd: Optional[str],
     if not reader or not writer:
         raise RuntimeError('Failed initializing transport: reader: {}, writer: {}'.format(reader, writer))
     return ProcessTransport(
-        config.name, process, sock, reader, writer, None if process is None else process.stderr, json_rpc_processor, callback_object)  # type: ignore
+        config.name, process, sock, reader, writer,
+        None if process is None else process.stderr,
+        json_rpc_processor, callback_object
+    )  # type: ignore
 
 
 _subprocesses = weakref.WeakSet()  # type: weakref.WeakSet[subprocess.Popen]

--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -137,7 +137,9 @@ class ProcessTransport(Transport[T]):
         self.close()
         self._join_thread(self._writer_thread)
         self._join_thread(self._reader_thread)
-        self._join_thread(self._stderr_thread)
+        
+        if self._stderr_thread is not None:
+            self._join_thread(self._stderr_thread)
 
     def _read_loop(self) -> None:
         exception = None

--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -137,7 +137,6 @@ class ProcessTransport(Transport[T]):
         self.close()
         self._join_thread(self._writer_thread)
         self._join_thread(self._reader_thread)
-
         if self._stderr_thread is not None:
             self._join_thread(self._stderr_thread)
 

--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -95,8 +95,8 @@ class JsonRpcProcessor(AbstractProcessor[Dict[str, Any]]):
 class ProcessTransport(Transport[T]):
 
     def __init__(self, name: str, process: Optional[subprocess.Popen], socket: Optional[socket.socket],
-                 reader: IO[bytes], writer: IO[bytes], stderr: Optional[IO[bytes]], processor: AbstractProcessor[T],
-                 callback_object: TransportCallbacks[T]) -> None:
+                 reader: IO[bytes], writer: IO[bytes], stderr: Optional[IO[bytes]],
+                 processor: AbstractProcessor[T], callback_object: TransportCallbacks[T]) -> None:
         self._closed = False
         self._process = process
         self._stderr = stderr

--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -262,6 +262,9 @@ def create_transport(config: TransportConfig, cwd: Optional[str],
     else:
         if config.command:
             process = start_subprocess()
+        elif not config.tcp_port:
+            raise RuntimeError("Failed to provide command or tcp_port, at least one of them has to be configured")
+
         if config.tcp_port:
             sock = _connect_tcp(config.tcp_port)
             if sock is None:

--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -96,7 +96,8 @@ class ProcessTransport(Transport[T]):
 
     def __init__(self, name: str, process: Optional[subprocess.Popen], socket: Optional[socket.socket],
                  reader: IO[bytes], writer: IO[bytes], stderr: Optional[IO[bytes]],
-                 processor: AbstractProcessor[T], callback_object: TransportCallbacks[T]) -> None:
+                 processor: AbstractProcessor[T], callback_object: TransportCallbacks[T]
+                 ) -> None:
         self._closed = False
         self._process = process
         self._stderr = stderr
@@ -278,10 +279,10 @@ def create_transport(config: TransportConfig, cwd: Optional[str],
     if not reader or not writer:
         raise RuntimeError('Failed initializing transport: reader: {}, writer: {}'.format(reader, writer))
     return ProcessTransport(
-        config.name, process, sock, reader, writer,
+        config.name, process, sock, reader, writer,  # type: ignore
         None if process is None else process.stderr,
         json_rpc_processor, callback_object
-    )  # type: ignore
+    )
 
 
 _subprocesses = weakref.WeakSet()  # type: weakref.WeakSet[subprocess.Popen]

--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -110,8 +110,8 @@ class ProcessTransport(Transport[T]):
         self._reader_thread.start()
         self._writer_thread.start()
 
-        self._stderr = process.stderr if process is not None else None
-        if self._stderr is not None:
+        if process is not None:
+            self._stderr = process.stderr
             self._stderr_thread = threading.Thread(target=self._stderr_loop, name='{}-stderr'.format(name))
             self._stderr_thread.start()
 


### PR DESCRIPTION
https://github.com/sublimelsp/LSP/issues/2214

I have no idea if this is too hacky to be pulled, or what it breaks. It does work for my usecase tho. Would be cool if it doesn't find a server, it would just wait until one shows up instead of disabling the lsp until manually enabled again. Maybe i'll do it if I find it annoying enough.

If there would be small edits needed to be pulled I can totally do them, if there are fundamental issues I probably wont bother.