### PR TITLE
Fix CI failing on macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os:
+          - ubuntu-latest
+          # - macOS-latest  # re-enable after PC 4.0 release: https://github.com/wbond/package_control/issues/1612#issuecomment-1642465518
+          - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This disables unit tests on Mac for now.

See https://github.com/sublimelsp/LSP/pull/2304#issuecomment-1656873774 and the Package Control issue linked in that comment.