### PR TITLE
Align "Expand Selection" fallback behavior with "Goto Definition" and "Find References"

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -211,6 +211,7 @@
     // {
     //     "keys": ["primary+shift+a"],
     //     "command": "lsp_expand_selection",
+    //     "args": {"fallback": false},
     //     "context": [{"key": "lsp.session_with_capability", "operand": "selectionRangeProvider"}]
     // },
     // Fold around caret position - an optional "strict" argument can be used to configure whether

--- a/plugin/selection_range.py
+++ b/plugin/selection_range.py
@@ -17,15 +17,15 @@ class LspExpandSelectionCommand(LspTextCommand):
         self._regions = []  # type: List[sublime.Region]
         self._change_count = 0
 
-    def is_enabled(self, event: Optional[dict] = None, point: Optional[int] = None, fallback: bool = True) -> bool:
+    def is_enabled(self, event: Optional[dict] = None, point: Optional[int] = None, fallback: bool = False) -> bool:
         return fallback or super().is_enabled(event, point)
 
-    def is_visible(self, event: Optional[dict] = None, point: Optional[int] = None, fallback: bool = True) -> bool:
+    def is_visible(self, event: Optional[dict] = None, point: Optional[int] = None, fallback: bool = False) -> bool:
         if self.applies_to_context_menu(event):
             return self.is_enabled(event, point, fallback)
         return True
 
-    def run(self, edit: sublime.Edit, event: Optional[dict] = None, fallback: bool = True) -> None:
+    def run(self, edit: sublime.Edit, event: Optional[dict] = None, fallback: bool = False) -> None:
         position = get_position(self.view, event)
         if position is None:
             return


### PR DESCRIPTION
The "Expand Selection" command has a `fallback` argument, similar to "Goto Definition" and "Find References", which allows to invoke Sublime's built-in "Expand Selection" if there is no LSP result for the caret position or if the server doesn't have this capability. But for LSP's "Expand Selection" this fallback is enabled by default, while it is turned off for "Goto Definition" and "Find References". I did set the `fallback` to be enabled in #2124 to preserve former behavior of that functionality. But now I see no good reason why its fallback behavior should be different from the other commands, and I think it is confusing to see the context menu item for "Expand Selection" under the LSP submenu, even when there is no language server running at all (or if it doesn't have this capability), and also the main menu item not to be greyed out in that case. See also https://forum.sublimetext.com/t/is-there-a-tree-sitter-like-code-navigation-functionality-in-sublime/66442/6

I think it was originally enabled by default, because at the time of implementation there wasn't the `lsp.session_with_capability` "context" key for key bindings, if I understand the discussion in https://github.com/sublimelsp/LSP/pull/1092#discussion_r436267526 correctly. But now this shouldn't be needed anymore.

This PR changes the default value for "Expand Selection" to make the behaviors consistent, and so that the context menu item for this is not visible when there is no LSP running at all.

This could potentially still have an impact on existing key bindings, but only if there is a server which responds with no results for a given caret position while ST's built-in "Expand Selection" would still do something. But I'm not sure if this is really a realistic scenario. For servers without the capability it shouldn't make any difference, assuming the key binding was copied from the template including the "context" value. 

Alternatively the `fallback` values of "Goto Definition" and "Find References" could be changed to be enabled by default.