### PR TITLE
Add kind filter for Goto Symbol command

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -171,8 +171,7 @@
       },
       {
         "caption": "LSP: Goto Symbol…",
-        "command": "show_overlay",
-        "args": {"overlay": "command_palette", "command": "lsp_document_symbols"}
+        "command": "lsp_document_symbols"
       },
       {
         "caption": "LSP: Goto Symbol In Project…",

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -171,7 +171,8 @@
       },
       {
         "caption": "LSP: Goto Symbol…",
-        "command": "lsp_document_symbols"
+        "command": "show_overlay",
+        "args": {"overlay": "command_palette", "command": "lsp_document_symbols"}
       },
       {
         "caption": "LSP: Goto Symbol In Project…",

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -193,27 +193,6 @@ SUBLIME_KIND_SCOPES = {
     sublime.KIND_VARIABLE: "entity.name.constant | constant.other | support.constant | variable.other | variable.parameter | variable.other.member | variable.other.readwrite.member"  # noqa: E501
 }  # type: Dict[SublimeKind, str]
 
-# Recommended colors to use by themes for each symbol kind, based on the kind_container specialization class described
-# at https://www.sublimetext.com/docs/themes.html#quick-panel
-SUBLIME_KIND_ID_COLOR_SCOPES = {
-    sublime.KIND_ID_KEYWORD: "region.pinkish",
-    sublime.KIND_ID_TYPE: "region.purplish",
-    sublime.KIND_ID_FUNCTION: "region.redish",
-    sublime.KIND_ID_NAMESPACE: "region.bluish",
-    sublime.KIND_ID_NAVIGATION: "region.yellowish",
-    sublime.KIND_ID_MARKUP: "region.orangish",
-    sublime.KIND_ID_VARIABLE: "region.cyanish",
-    sublime.KIND_ID_SNIPPET: "region.greenish",
-    sublime.KIND_ID_COLOR_REDISH: "region.redish",
-    sublime.KIND_ID_COLOR_ORANGISH: "region.orangish",
-    sublime.KIND_ID_COLOR_YELLOWISH: "region.yellowish",
-    sublime.KIND_ID_COLOR_GREENISH: "region.greenish",
-    sublime.KIND_ID_COLOR_CYANISH: "region.cyanish",
-    sublime.KIND_ID_COLOR_BLUISH: "region.bluish",
-    sublime.KIND_ID_COLOR_PURPLISH: "region.purplish",
-    sublime.KIND_ID_COLOR_PINKISH: "region.pinkish"
-}  # type: Dict[int, str]
-
 DOCUMENT_HIGHLIGHT_KINDS = {
     DocumentHighlightKind.Text: "text",
     DocumentHighlightKind.Read: "read",

--- a/plugin/goto_diagnostic.py
+++ b/plugin/goto_diagnostic.py
@@ -184,7 +184,7 @@ class DiagnosticUriInputHandler(PreselectedListInputHandler):
         if diagnostic is None:
             self._preview = None
             return DiagnosticInputHandler(self.window, self.view, uri)
-        return sublime_plugin.BackInputHandler()  # type: ignore
+        return sublime_plugin.BackInputHandler()
 
     def confirm(self, value: Optional[DocumentUri]) -> None:
         self.uri = value

--- a/plugin/symbols.py
+++ b/plugin/symbols.py
@@ -9,7 +9,6 @@ from .core.registry import LspTextCommand
 from .core.sessions import print_to_status_bar
 from .core.typing import Any, List, Optional, Tuple, Dict, Union, cast
 from .core.views import range_to_region
-# from .core.views import SUBLIME_KIND_ID_COLOR_SCOPES
 from .core.views import SublimeKind
 from .core.views import SYMBOL_KINDS
 from .core.views import text_document_identifier
@@ -139,7 +138,6 @@ class LspSelectionSetCommand(sublime_plugin.TextCommand):
 class LspDocumentSymbolsCommand(LspTextCommand):
 
     capability = 'documentSymbolProvider'
-    # REGIONS_KEY = 'lsp_document_symbols'
 
     def __init__(self, view: sublime.View) -> None:
         super().__init__(view)

--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -1082,6 +1082,8 @@ class QuickPanelItem:
 
 
 class ListInputItem:
+    value = ...  # type: Any
+    kind = ...  # type: Tuple[int, str, str]
     def __init__(
         self,
         text: str,

--- a/stubs/sublime_plugin.pyi
+++ b/stubs/sublime_plugin.pyi
@@ -170,6 +170,10 @@ class CommandInputHandler:
     ...
 
 
+class BackInputHandler(CommandInputHandler):
+    ...
+
+
 class TextInputHandler(CommandInputHandler):
     ...
 


### PR DESCRIPTION
Closes #2055.

I removed the colored region box highlighting for now, because I don't really like it personally and ST's built-in Goto Symbol doesn't have something like that. But it could be added back easily.

The implementation is a bit hacky, and there is one significant drawback: a user key binding for this command would need to be adjusted in the following way:
```jsonc
[
    // Document Symbols (a replacement for ST's "Goto Symbol")
    {
        "keys": ["primary+r"],
        "command": "show_overlay",
        "args": {"overlay": "command_palette", "command": "lsp_document_symbols"},
        "context": [{"key": "lsp.session_with_capability", "operand": "documentSymbolProvider"}]
    },
]
```

Otherwise it won't work due to the input handlers in the command palette. I'm unsure if this breaking change would be acceptable. Maybe I can find a workaround to make it work with the former key binding too.

Other than that I think it's pretty cool and very practical to use.

Preview video:

[preview.webm](https://github.com/sublimelsp/LSP/assets/6579999/3bdfa528-f945-46ae-8f91-96b9b3d605c3)

"All Kinds" will be selected by default, so that the behavior if you just want to run the command and navigate the unfiltered results is the same as before. Oh and there seems to be still a bug with the sorting sometimes, I'll see if I can fix that.