### PR TITLE
fix "formatting on save" potentially running on outdated document state

### DIFF
--- a/plugin/save_command.py
+++ b/plugin/save_command.py
@@ -105,7 +105,9 @@ class LspSaveCommand(LspTextCommand):
     def _on_task_completed_async(self) -> None:
         self._pending_tasks.pop(0)
         if self._pending_tasks:
-            self._run_next_task_async()
+            # Even though we are on the async thread already, we want to give ST a chance to notify us about
+            # potential document changes.
+            sublime.set_timeout_async(self._run_next_task_async)
         else:
             self._trigger_native_save()
 


### PR DESCRIPTION
Issue reported on Discord where with both "code actions on save" and "formatting on save" enabled, the formatting would be done on an outdated document state if code actions have triggered an edit.

Reproducible with a go document like:

```go
package main

	func main() {
		fmt.Println("Hello1")
	}
```

and following project settings:

```js
	"settings": {
		"lsp_format_on_save": true,
		"lsp_code_actions_on_save": {
			"source.organizeImports": true,
		}
	}
```

The `FormattingTask` did trigger `_purge_changes_async()` on start but since the tasks ran in one continuous flow on the async thread, we didn't get to handle ST's `on_text_changed` notification in between tasks.

Fix by starting next task from `set_timeout_async` to allow pending events to trigger.