### PR TITLE
Sort and select closest result for Find References in quick panel

### DIFF
--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -1,5 +1,6 @@
 from .typing import Enum, IntEnum, IntFlag, StrEnum
 from .typing import Any, Dict, Generic, Iterable, List, Literal, Mapping, NotRequired, Optional, TypedDict, TypeVar, Union  # noqa: E501
+from functools import total_ordering
 import sublime
 
 INT_MAX = 2**31 - 1
@@ -6275,6 +6276,7 @@ class Notification:
         return payload
 
 
+@total_ordering
 class Point(object):
     def __init__(self, row: int, col: int) -> None:
         self.row = int(row)
@@ -6287,6 +6289,11 @@ class Point(object):
         if not isinstance(other, Point):
             return NotImplemented
         return self.row == other.row and self.col == other.col
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, Point):
+            return NotImplemented
+        return (self.row, self.col) < (other.row, other.col)
 
     @classmethod
     def from_lsp(cls, point: 'Position') -> 'Point':

--- a/plugin/locationpicker.py
+++ b/plugin/locationpicker.py
@@ -67,7 +67,8 @@ class LocationPicker:
         force_group: bool = True,
         group: int = -1,
         placeholder: str = "",
-        kind: SublimeKind = sublime.KIND_AMBIGUOUS
+        kind: SublimeKind = sublime.KIND_AMBIGUOUS,
+        selected_index: int = -1
     ) -> None:
         self._view = view
         self._view_states = ([r.to_tuple() for r in view.sel()], view.viewport_position())
@@ -92,8 +93,9 @@ class LocationPicker:
                 for location in locations
             ],
             on_select=self._select_entry,
-            on_highlight=self._highlight_entry,
             flags=sublime.KEEP_OPEN_ON_FOCUS_LOST,
+            selected_index=selected_index,
+            on_highlight=self._highlight_entry,
             placeholder=placeholder
         )
 

--- a/plugin/references.py
+++ b/plugin/references.py
@@ -155,7 +155,7 @@ class LspSymbolReferencesCommand(LspTextCommand):
             view_filename = self.view.file_name()
             for idx, location in enumerate(locations):
                 filename = session.config.map_server_uri_to_client_path(location['uri'])
-                if not filename == view_filename:
+                if filename != view_filename:
                     continue
                 if position_to_offset(location['range']['start'], self.view) <= pt:
                     index = idx

--- a/plugin/references.py
+++ b/plugin/references.py
@@ -154,12 +154,10 @@ class LspSymbolReferencesCommand(LspTextCommand):
             pt = selection[0].b
             view_filename = self.view.file_name()
             for idx, location in enumerate(locations):
-                filename = session.config.map_server_uri_to_client_path(location['uri'])
-                if filename != view_filename:
+                if view_filename != session.config.map_server_uri_to_client_path(location['uri']):
                     continue
-                if position_to_offset(location['range']['start'], self.view) <= pt:
-                    index = idx
-                else:
+                index = idx
+                if position_to_offset(location['range']['start'], self.view) > pt:
                     break
         LocationPicker(self.view, session, locations, side_by_side, force_group, group, placeholder, kind, index)
 


### PR DESCRIPTION
This is a part of the suggested enhancements from https://github.com/sublimelsp/LSP/issues/2084#issuecomment-1297691586.

With the setting `"show_references_in_quick_panel": true` enabled it will sort the results by URI and location and select the closest one if there is a result in the current file.

Note that the sort order can be OS dependent; for example Pyright uses `file:///C:/` format for Windows drive letters for files which are currently open, and `file:///c%3A/` format for unopened files. We could add another step to convert from URI to filename and sort those instead, but actually I found it quite useful that currently opened files are shown at the top of the list, when sorting by URI.