### PR TITLE
Remove ellipses in command palette labels

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -58,7 +58,7 @@
         "command": "lsp_format_document",
     },
     {
-        "caption": "LSP: Format File With…",
+        "caption": "LSP: Format File With",
         "command": "lsp_format_document",
         "args": {"select": true}
     },
@@ -75,38 +75,38 @@
         "command": "lsp_restart_server",
     },
     {
-        "caption": "LSP: Goto Symbol…",
+        "caption": "LSP: Goto Symbol",
         "command": "lsp_document_symbols",
     },
     {
-        "caption": "LSP: Goto Symbol In Project…",
+        "caption": "LSP: Goto Symbol in Project",
         "command": "lsp_workspace_symbols"
     },
     {
-        "caption": "LSP: Goto Definition…",
+        "caption": "LSP: Goto Definition",
         "command": "lsp_symbol_definition"
     },
     {
-        "caption": "LSP: Goto Type Definition…",
+        "caption": "LSP: Goto Type Definition",
         "command": "lsp_symbol_type_definition"
     },
     {
-        "caption": "LSP: Goto Declaration…",
+        "caption": "LSP: Goto Declaration",
         "command": "lsp_symbol_declaration",
     },
     {
-        "caption": "LSP: Goto Implementation…",
+        "caption": "LSP: Goto Implementation",
         "command": "lsp_symbol_implementation",
     },
     {
-        "caption": "LSP: Goto Diagnostic…",
+        "caption": "LSP: Goto Diagnostic",
         "command": "lsp_goto_diagnostic",
         "args": {
             "uri": "$view_uri"
         }
     },
     {
-        "caption": "LSP: Goto Diagnostic in Project…",
+        "caption": "LSP: Goto Diagnostic in Project",
         "command": "lsp_goto_diagnostic"
     },
     {
@@ -130,11 +130,11 @@
         "command": "lsp_symbol_rename"
     },
     {
-        "caption": "LSP: Code Action…",
+        "caption": "LSP: Code Action",
         "command": "lsp_code_actions"
     },
     {
-        "caption": "LSP: Refactor…",
+        "caption": "LSP: Refactor",
         "command": "lsp_code_actions",
         "args": {
             "only_kinds": [
@@ -143,7 +143,7 @@
         },
     },
     {
-        "caption": "LSP: Source Action…",
+        "caption": "LSP: Source Action",
         "command": "lsp_code_actions",
         "args": {
             "only_kinds": [


### PR DESCRIPTION
The shipped *Default/Default.sublime-commands* file per convention uses no ellipses (`...`) for the labels in the command palette. Ellipses seem to only be used for the menu items, for example compare `Preferences > Browse Packages...` from the main menu vs. `Preferences: Browse Packages` in the command palette. And you wouldn't filter for `...` in the command palette anyway.

Also lowercased `in`.