### PR TITLE
Handle custom URI schemes in hover text links

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1622,13 +1622,13 @@ class Session(TransportCallbacks):
         return self._maybe_resolve_code_action(code_action) \
             .then(lambda code_action: self._apply_code_action_async(code_action, view))
 
-    def open_uri_async(
+    def try_open_uri_async(
         self,
         uri: DocumentUri,
         r: Optional[Range] = None,
         flags: int = 0,
         group: int = -1
-    ) -> Promise[Optional[sublime.View]]:
+    ) -> Optional[Promise[Optional[sublime.View]]]:
         if uri.startswith("file:"):
             return self._open_file_uri_async(uri, r, flags, group)
         # Try to find a pre-existing session-buffer
@@ -1642,7 +1642,19 @@ class Session(TransportCallbacks):
         # There is no pre-existing session-buffer, so we have to go through AbstractPlugin.on_open_uri_async.
         if self._plugin:
             return self._open_uri_with_plugin_async(self._plugin, uri, r, flags, group)
-        return Promise.resolve(None)
+        return None
+
+    def open_uri_async(
+        self,
+        uri: DocumentUri,
+        r: Optional[Range] = None,
+        flags: int = 0,
+        group: int = -1
+    ) -> Promise[Optional[sublime.View]]:
+        promise = self.try_open_uri_async(uri, r, flags, group)
+        if promise is None:
+            raise RuntimeError("unexpected URI scheme")
+        return promise
 
     def _open_file_uri_async(
         self,
@@ -1668,7 +1680,7 @@ class Session(TransportCallbacks):
         r: Optional[Range],
         flags: int,
         group: int,
-    ) -> Promise[Optional[sublime.View]]:
+    ) -> Optional[Promise[Optional[sublime.View]]]:
         # I cannot type-hint an unpacked tuple
         pair = Promise.packaged_task()  # type: PackagedTask[Tuple[str, str, str]]
         # It'd be nice to have automatic tuple unpacking continuations
@@ -1693,7 +1705,7 @@ class Session(TransportCallbacks):
 
             pair[0].then(lambda tup: sublime.set_timeout(lambda: open_scratch_buffer(*tup)))
             return result[0]
-        return Promise.resolve(None)
+        return None
 
     def open_location_async(self, location: Union[Location, LocationLink], flags: int = 0,
                             group: int = -1) -> Promise[Optional[sublime.View]]:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1652,9 +1652,7 @@ class Session(TransportCallbacks):
         group: int = -1
     ) -> Promise[Optional[sublime.View]]:
         promise = self.try_open_uri_async(uri, r, flags, group)
-        if promise is None:
-            raise RuntimeError("unexpected URI scheme")
-        return promise
+        return Promise.resolve(None) if promise is None else promise
 
     def _open_file_uri_async(
         self,

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -1,4 +1,3 @@
-from urllib.parse import urlparse
 from .css import css as lsp_css
 from .protocol import CodeAction
 from .protocol import CodeActionKind
@@ -983,10 +982,6 @@ def is_location_href(href: str) -> bool:
     Check whether this href is an encoded location.
     """
     return href.startswith("location:")
-
-
-def starts_with_custom_uri_scheme(href: str) -> bool:
-    return urlparse(href).scheme.lower() not in ("", "http", "https")
 
 
 def _format_diagnostic_related_info(

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -1,3 +1,4 @@
+from urllib.parse import urlparse
 from .css import css as lsp_css
 from .protocol import CodeAction
 from .protocol import CodeActionKind
@@ -995,6 +996,34 @@ def is_location_href(href: str) -> bool:
     Check whether this href is an encoded location.
     """
     return href.startswith("location:")
+
+
+def starts_with_custom_uri_scheme(href: str) -> bool:
+    return urlparse(href).scheme.lower() not in ("", "http", "https")
+
+
+def row_col_from_uri_fragment(href: str) -> Tuple[Optional[int], Optional[int]]:
+    fragment = urlparse(href).fragment
+    if not fragment:
+        return (None, None)
+    rowcol = fragment.split(":")
+    row = None  # type: Optional[int]
+    col = None  # type: Optional[int]
+    if len(rowcol) >= 1:
+        try:
+            row = int(rowcol[0])
+            # rowcols in URI fragments are 1-based (dubious)
+            row -= 1
+        except Exception:
+            pass
+    if len(rowcol) >= 2:
+        try:
+            col = int(rowcol[1])
+            # rowcols in URI fragments are 1-based (dubious)
+            col -= 1
+        except Exception:
+            pass
+    return (row, col)
 
 
 def _format_diagnostic_related_info(

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -989,30 +989,6 @@ def starts_with_custom_uri_scheme(href: str) -> bool:
     return urlparse(href).scheme.lower() not in ("", "http", "https")
 
 
-def row_col_from_uri_fragment(href: str) -> Tuple[Optional[int], Optional[int]]:
-    fragment = urlparse(href).fragment
-    if not fragment:
-        return (None, None)
-    rowcol = fragment.split(":")
-    row = None  # type: Optional[int]
-    col = None  # type: Optional[int]
-    if len(rowcol) >= 1:
-        try:
-            row = int(rowcol[0])
-            # rowcols in URI fragments are 1-based (dubious)
-            row -= 1
-        except Exception:
-            pass
-    if len(rowcol) >= 2:
-        try:
-            col = int(rowcol[1])
-            # rowcols in URI fragments are 1-based (dubious)
-            col -= 1
-        except Exception:
-            pass
-    return (row, col)
-
-
 def _format_diagnostic_related_info(
     config: ClientConfig,
     info: DiagnosticRelatedInformation,

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -33,7 +33,6 @@ from .core.views import MarkdownLangMap
 from .core.views import minihtml
 from .core.views import range_to_region
 from .core.views import show_lsp_popup
-from .core.views import starts_with_custom_uri_scheme
 from .core.views import text_document_position_params
 from .core.views import unpack_href_location
 from .core.views import update_lsp_popup
@@ -365,7 +364,7 @@ class LspHoverCommand(LspTextCommand):
                 position = {"line": row, "character": col_utf16}  # type: Position
                 r = {"start": position, "end": position}  # type: Range
                 sublime.set_timeout_async(partial(session.open_uri_async, uri, r))
-        elif starts_with_custom_uri_scheme(href):
+        elif urlparse(href).scheme.lower() not in ("", "http", "https"):
             sublime.set_timeout_async(partial(self.try_open_custom_uri_async, href))
         else:
             open_in_browser(href)

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -1,4 +1,3 @@
-from urllib.parse import urlparse
 from .code_actions import actions_manager
 from .code_actions import CodeActionOrCommand
 from .code_actions import CodeActionsByConfigName
@@ -38,6 +37,7 @@ from .core.views import unpack_href_location
 from .core.views import update_lsp_popup
 from .session_view import HOVER_HIGHLIGHT_KEY
 from functools import partial
+from urllib.parse import urlparse
 import html
 import mdpopups
 import sublime


### PR DESCRIPTION
Before this change, custom URI schemes would be delegated to the browser.

With this change, an attempt is made to look for a session that can handle the URI.

Moreover, if there is a fragment present in the URI, then it's assumed that that fragment encodes the (row, col) to jump to. This logic is somewhat dubious, but it's the only reasonable way (as far as I can see) to handle this.

Anoher approach could be to introduce a new on_open_uri2_async callback for plugins where they can also provide a (row, col) to jump to. But, then we would also require an opt-in switch for plugins where they would advertise that they can handle the "version 2" of on_open_uri.

(I've attached a GIF of goto-definition now working even for hover text links with Java, but I don't think the mouse cursor is visible)

![jdtls-goto-def](https://github.com/sublimelsp/LSP/assets/2431823/83f29d24-de52-40d9-8ecb-631f98292e9d)
