### PR TITLE
minor visual tweaks to ShowMessageRequest popup

### DIFF
--- a/notification.css
+++ b/notification.css
@@ -2,14 +2,15 @@
     margin: 0.5rem;
     padding: 1rem;
 }
-.notification .message {
-    margin-top: 1rem;
-    margin-bottom: 3rem;
+
+.notification h2 {
+    margin-bottom: 1rem;
 }
 
 .notification .actions a {
-    text-decoration: none;
-    padding: 0.5rem;
     border: 2px solid color(var(--foreground) alpha(0.25));
     color: var(--foreground);
+    margin-top: 3rem;
+    padding: 0.5rem;
+    text-decoration: none;
 }

--- a/plugin/core/message_request_handler.py
+++ b/plugin/core/message_request_handler.py
@@ -1,19 +1,23 @@
 from .protocol import Response
+from .protocol import ShowMessageRequestParams
 from .sessions import Session
 from .typing import Any, List, Callable
 from .views import show_lsp_popup
+from .views import text2html
 import sublime
 
 
 class MessageRequestHandler():
-    def __init__(self, view: sublime.View, session: Session, request_id: Any, params: dict, source: str) -> None:
+    def __init__(
+        self, view: sublime.View, session: Session, request_id: Any, params: ShowMessageRequestParams, source: str
+    ) -> None:
         self.session = session
         self.request_id = request_id
         self.request_sent = False
         self.view = view
         self.actions = params.get("actions", [])
         self.titles = list(action.get("title") for action in self.actions)
-        self.message = params.get('message', '')
+        self.message = text2html(params['message'])
         self.message_type = params.get('type', 4)
         self.source = source
 
@@ -21,11 +25,8 @@ class MessageRequestHandler():
         if not self.request_sent:
             self.request_sent = True
             self.view.hide_popup()
-            # when noop; nothing was selected e.g. the user pressed escape
-            param = None
             index = int(href)
-            if index != -1:
-                param = self.actions[index]
+            param = self.actions[index] if index != -1 else None
             response = Response(self.request_id, param)
             self.session.send_response(response)
 
@@ -41,29 +42,15 @@ class MessageRequestHandler():
         )
 
 
-def message_content(source: str, message_type: int, message: str, titles: List[str]) -> str:
-    formatted = []
-    icons = {
-        1: '❗',
-        2: '⚠️',
-        3: 'ℹ️',
-        4: '📝'
-    }
-    icon = icons.get(message_type, '')
-    formatted.append("<h2>{}</h2>".format(source))
-    formatted.append("<p class='message'>{} {}</p>".format(icon, message))
-
-    buttons = []
-    for idx, title in enumerate(titles):
-        buttons.append("<a href='{}'>{}</a>".format(idx, title))
-
-    formatted.append("<p class='actions'>" + " ".join(buttons) + "</p>")
-
-    return "".join(formatted)
-
-
-def show_notification(view: sublime.View, source: str, message_type: int, message: str, titles: List[str],
-                      on_navigate: Callable, on_hide: Callable) -> None:
+def show_notification(
+    view: sublime.View,
+    source: str,
+    message_type: int,
+    message: str,
+    titles: List[str],
+    on_navigate: Callable[[int], None],
+    on_hide: Callable[[int], None]
+) -> None:
     stylesheet = sublime.load_resource("Packages/LSP/notification.css")
     contents = message_content(source, message_type, message, titles)
     show_lsp_popup(
@@ -73,3 +60,22 @@ def show_notification(view: sublime.View, source: str, message_type: int, messag
         wrapper_class='notification',
         on_navigate=on_navigate,
         on_hide=on_hide)
+
+
+def message_content(source: str, message_type: int, message: str, titles: List[str]) -> str:
+    formatted = []  # type: List[str]
+    icons = {
+        1: '❗',
+        2: '⚠️',
+        3: 'ℹ️',
+        4: '📝'
+    }
+    icon = icons.get(message_type, '')
+    formatted.append("<h2>{}</h2>".format(source))
+    formatted.append("<div class='message'>{} {}</div>".format(icon, message))
+    if titles:
+        buttons = []  # type: List[str]
+        for idx, title in enumerate(titles):
+            buttons.append("<a href='{}'>{}</a>".format(idx, title))
+        formatted.append("<div class='actions'>" + " ".join(buttons) + "</div>")
+    return "".join(formatted)

--- a/plugin/core/message_request_handler.py
+++ b/plugin/core/message_request_handler.py
@@ -26,7 +26,7 @@ class MessageRequestHandler():
         self.view = view
         self.actions = params.get("actions", [])
         self.action_titles = list(action.get("title") for action in self.actions)
-        self.message = text2html(params['message'])
+        self.message = params['message']
         self.message_type = params.get('type', 4)
         self.source = source
 
@@ -34,11 +34,11 @@ class MessageRequestHandler():
         formatted = []  # type: List[str]
         formatted.append("<h2>{}</h2>".format(self.source))
         icon = ICONS.get(self.message_type, '')
-        formatted.append("<div class='message'>{} {}</div>".format(icon, self.message))
+        formatted.append("<div class='message'>{} {}</div>".format(icon, text2html(self.message)))
         if self.action_titles:
             buttons = []  # type: List[str]
             for idx, title in enumerate(self.action_titles):
-                buttons.append("<a href='{}'>{}</a>".format(idx, title))
+                buttons.append("<a href='{}'>{}</a>".format(idx, text2html(title)))
             formatted.append("<div class='actions'>" + " ".join(buttons) + "</div>")
         show_lsp_popup(
             self.view,

--- a/plugin/core/message_request_handler.py
+++ b/plugin/core/message_request_handler.py
@@ -1,10 +1,19 @@
+from .protocol import MessageType
 from .protocol import Response
 from .protocol import ShowMessageRequestParams
 from .sessions import Session
-from .typing import Any, List, Callable
+from .typing import Any, Dict, List
 from .views import show_lsp_popup
 from .views import text2html
 import sublime
+
+
+ICONS = {
+    MessageType.Error: '❗',
+    MessageType.Warning: '⚠️',
+    MessageType.Info: 'ℹ️',
+    MessageType.Log: '📝'
+}  # type: Dict[MessageType, str]
 
 
 class MessageRequestHandler():
@@ -16,66 +25,35 @@ class MessageRequestHandler():
         self.request_sent = False
         self.view = view
         self.actions = params.get("actions", [])
-        self.titles = list(action.get("title") for action in self.actions)
+        self.action_titles = list(action.get("title") for action in self.actions)
         self.message = text2html(params['message'])
         self.message_type = params.get('type', 4)
         self.source = source
 
-    def _send_user_choice(self, href: int = -1) -> None:
-        if not self.request_sent:
-            self.request_sent = True
-            self.view.hide_popup()
-            index = int(href)
-            param = self.actions[index] if index != -1 else None
-            response = Response(self.request_id, param)
-            self.session.send_response(response)
-
     def show(self) -> None:
-        show_notification(
+        formatted = []  # type: List[str]
+        formatted.append("<h2>{}</h2>".format(self.source))
+        icon = ICONS.get(self.message_type, '')
+        formatted.append("<div class='message'>{} {}</div>".format(icon, self.message))
+        if self.action_titles:
+            buttons = []  # type: List[str]
+            for idx, title in enumerate(self.action_titles):
+                buttons.append("<a href='{}'>{}</a>".format(idx, title))
+            formatted.append("<div class='actions'>" + " ".join(buttons) + "</div>")
+        show_lsp_popup(
             self.view,
-            self.source,
-            self.message_type,
-            self.message,
-            self.titles,
-            self._send_user_choice,
-            self._send_user_choice
-        )
+            "".join(formatted),
+            css=sublime.load_resource("Packages/LSP/notification.css"),
+            wrapper_class='notification',
+            on_navigate=self._send_user_choice,
+            on_hide=self._send_user_choice)
 
-
-def show_notification(
-    view: sublime.View,
-    source: str,
-    message_type: int,
-    message: str,
-    titles: List[str],
-    on_navigate: Callable[[int], None],
-    on_hide: Callable[[int], None]
-) -> None:
-    stylesheet = sublime.load_resource("Packages/LSP/notification.css")
-    contents = message_content(source, message_type, message, titles)
-    show_lsp_popup(
-        view,
-        contents,
-        css=stylesheet,
-        wrapper_class='notification',
-        on_navigate=on_navigate,
-        on_hide=on_hide)
-
-
-def message_content(source: str, message_type: int, message: str, titles: List[str]) -> str:
-    formatted = []  # type: List[str]
-    icons = {
-        1: '❗',
-        2: '⚠️',
-        3: 'ℹ️',
-        4: '📝'
-    }
-    icon = icons.get(message_type, '')
-    formatted.append("<h2>{}</h2>".format(source))
-    formatted.append("<div class='message'>{} {}</div>".format(icon, message))
-    if titles:
-        buttons = []  # type: List[str]
-        for idx, title in enumerate(titles):
-            buttons.append("<a href='{}'>{}</a>".format(idx, title))
-        formatted.append("<div class='actions'>" + " ".join(buttons) + "</div>")
-    return "".join(formatted)
+    def _send_user_choice(self, href: int = -1) -> None:
+        if self.request_sent:
+            return
+        self.request_sent = True
+        self.view.hide_popup()
+        index = int(href)
+        param = self.actions[index] if index != -1 else None
+        response = Response(self.request_id, param)
+        self.session.send_response(response)

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -618,8 +618,8 @@ def show_lsp_popup(
     flags: int = 0,
     css: Optional[str] = None,
     wrapper_class: Optional[str] = None,
-    on_navigate: Optional[Callable[[int], None]] = None,
-    on_hide: Optional[Callable[[int], None]] = None
+    on_navigate: Optional[Callable[..., None]] = None,
+    on_hide: Optional[Callable[..., None]] = None
 ) -> None:
     css = css if css is not None else lsp_css().popups
     wrapper_class = wrapper_class if wrapper_class is not None else lsp_css().popups_classname

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -610,9 +610,17 @@ def text_document_code_action_params(
 LSP_POPUP_SPACER_HTML = '<div class="lsp_popup--spacer"></div>'
 
 
-def show_lsp_popup(view: sublime.View, contents: str, location: int = -1, md: bool = False, flags: int = 0,
-                   css: Optional[str] = None, wrapper_class: Optional[str] = None,
-                   on_navigate: Optional[Callable] = None, on_hide: Optional[Callable] = None) -> None:
+def show_lsp_popup(
+    view: sublime.View,
+    contents: str,
+    location: int = -1,
+    md: bool = False,
+    flags: int = 0,
+    css: Optional[str] = None,
+    wrapper_class: Optional[str] = None,
+    on_navigate: Optional[Callable[[int], None]] = None,
+    on_hide: Optional[Callable[[int], None]] = None
+) -> None:
     css = css if css is not None else lsp_css().popups
     wrapper_class = wrapper_class if wrapper_class is not None else lsp_css().popups_classname
     contents += LSP_POPUP_SPACER_HTML


### PR DESCRIPTION
The popup shown on server triggering `window/showMessageRequest` was a bit out of date.

- Run the message through `text2html` so that newlines are respected.
- Tweak margins so that there is no big gap at the bottom of the content when actions are not specified.

Would be good to test this with some other servers to ensure that preserving newlines actually doesn't make it worse. I remember eslint used it but not sure what else.

## Before

![Screenshot 2023-10-16 at 22 31 42](https://github.com/sublimelsp/LSP/assets/153197/f42a4544-ead5-46c8-a7f2-f4327af43cc7)

## After

![Screenshot 2023-10-16 at 22 30 45](https://github.com/sublimelsp/LSP/assets/153197/3740124d-1039-4ef0-8f01-8a6891ab8388)
