### PR TITLE
Add support for remote images in hover popups

### DIFF
--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -37,6 +37,7 @@ from .core.views import update_lsp_popup
 from .session_view import HOVER_HIGHLIGHT_KEY
 from functools import partial
 import html
+import mdpopups
 import sublime
 
 
@@ -99,6 +100,7 @@ class LspHoverCommand(LspTextCommand):
     def __init__(self, view: sublime.View) -> None:
         super().__init__(view)
         self._base_dir = None   # type: Optional[str]
+        self._image_resolver = None
 
     def run(
         self,
@@ -311,6 +313,14 @@ class LspHoverCommand(LspTextCommand):
                     location=point,
                     on_navigate=lambda href: self._on_navigate(href, point),
                     on_hide=lambda: self.view.erase_regions(HOVER_HIGHLIGHT_KEY))
+
+        self._image_resolver = mdpopups.resolve_images(
+            contents, mdpopups.worker_thread_resolver, partial(self._on_images_resolved, contents))
+
+    def _on_images_resolved(self, original_contents: str, contents: str) -> None:
+        self._image_resolver = None
+        if contents != original_contents and self.view.is_popup_visible():
+            update_lsp_popup(self.view, contents)
 
     def _on_navigate(self, href: str, point: int) -> None:
         if href.startswith("subl:"):

--- a/stubs/mdpopups.pyi
+++ b/stubs/mdpopups.pyi
@@ -85,3 +85,16 @@ def scope2style(
     selected: bool = False,
     explicit_background: bool = False
 ) -> str: ...
+
+
+def worker_thread_resolver(
+    url: str,
+    done: Callable[[bytes], None]
+) -> None: ...
+
+
+def resolve_images(
+    minihtml: str,
+    resolver: Callable[[str, Callable[[bytes], None]], None],
+    on_done: Callable[[str], None]
+) -> Optional[object]: ...


### PR DESCRIPTION
Fixes #1363.

I have tested it with a small modification to LSP-pyright:
```diff
--- Installed Packages/LSP-pyright/plugin.py
+++ Packages/LSP-pyright/plugin.py
@@ -94,6 +94,7 @@
             contents = hover.get("contents")
             if isinstance(contents, dict) and contents.get("kind") == "markdown":
                 contents["value"] = self.patch_markdown_content(contents["value"])
+                contents["value"] += "\n\n![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pinkAccent.png)"
             return
         if method == "completionItem/resolve" and isinstance(response.result, dict):
             completion = cast(CompletionItem, response.result)
```