### PR TITLE
Fix performance regression in Goto Symbol overlay

### DIFF
--- a/plugin/symbols.py
+++ b/plugin/symbols.py
@@ -79,7 +79,7 @@ def symbol_information_to_quick_panel_item(
 
 
 def symbol_to_list_input_item(
-    view: sublime.View, item: Union[DocumentSymbol, SymbolInformation], hierarchy: str = ''
+    item: Union[DocumentSymbol, SymbolInformation], hierarchy: str = ''
 ) -> sublime.ListInputItem:
     name = item['name']
     kind = item['kind']
@@ -199,7 +199,7 @@ class LspDocumentSymbolsCommand(LspTextCommand):
             else:
                 items = cast(List[SymbolInformation], response)
                 for item in items:
-                    self.items.append(symbol_to_list_input_item(self.view, item))
+                    self.items.append(symbol_to_list_input_item(item))
             self.items.sort(key=lambda item: Point.from_lsp(item.value['range']['start']))
             window = self.view.window()
             if window:
@@ -218,7 +218,7 @@ class LspDocumentSymbolsCommand(LspTextCommand):
     ) -> List[sublime.ListInputItem]:
         name = item['name']
         name_hierarchy = hierarchy + " > " + name if hierarchy else name
-        items = [symbol_to_list_input_item(self.view, item, hierarchy)]
+        items = [symbol_to_list_input_item(item, hierarchy)]
         for child in item.get('children') or []:
             items.extend(self.process_document_symbol_recursive(child, name_hierarchy))
         return items


### PR DESCRIPTION
... which was described in #2346.

This should make the LSP Goto Symbol overlay appear (almost) immediately again, even for very large files, by lazily calculating the character offsets from LSP row/col position (for highlighting and scrolling).

I tested with a file with 5000 symbols in it, where this saves 10k API calls.

---

By the way, it doesn't really make any sense that this could have been a cause for worse performance, because before the commit https://github.com/sublimelsp/LSP/commit/2e06833ca86cb88b4ae3acf663541551de675458 the same amount of API calls (for `SymbolInformation[]` response) were done as well (`range_to_region` function), or even twice the amount (for `DocumentSymbol[]` response). Perhaps the ListInputHandler is just slower than `window.show_quick_panel`, in combination with many recent API calls. Anyway, this seems to work and it looks like a useful improvement to me.