### PR TITLE
Show diagnostics popup when hovering over gutter icons

### DIFF
--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -4,6 +4,7 @@ from .code_actions import CodeActionsByConfigName
 from .completion import QueryCompletionsTask
 from .core.constants import HOVER_ENABLED_KEY
 from .core.logging import debug
+from .core.open import open_in_browser
 from .core.panels import PanelName
 from .core.protocol import Diagnostic
 from .core.protocol import DiagnosticSeverity
@@ -27,6 +28,7 @@ from .core.sessions import SessionBufferProtocol
 from .core.settings import userprefs
 from .core.signature_help import SigHelp
 from .core.types import basescope2languageid
+from .core.types import ClientConfig
 from .core.types import debounced
 from .core.types import DebouncerNonThreadSafe
 from .core.types import FEATURES_TIMEOUT
@@ -40,6 +42,7 @@ from .core.views import DOCUMENT_HIGHLIGHT_KIND_SCOPES
 from .core.views import DOCUMENT_HIGHLIGHT_KINDS
 from .core.views import first_selection_region
 from .core.views import format_code_actions_for_quick_panel
+from .core.views import format_diagnostic_for_html
 from .core.views import make_link
 from .core.views import MarkdownLangMap
 from .core.views import range_to_region
@@ -471,17 +474,31 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         if hover_zone == sublime.HOVER_TEXT and window and window.settings().get(HOVER_ENABLED_KEY, True):
             self.view.run_command("lsp_hover", {"point": point})
         elif hover_zone == sublime.HOVER_GUTTER:
-            # Lightbulb must be visible and at the same line
-            if self._lightbulb_line != self.view.rowcol(point)[0]:
-                return
-            content = code_actions_content(self._actions_by_config)
-            if content:
-                show_lsp_popup(
-                    self.view,
-                    content,
-                    flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY,
-                    location=point,
-                    on_navigate=lambda href: self._on_navigate(href, point))
+            sublime.set_timeout_async(partial(self._on_hover_gutter_async, point))
+
+    def _on_hover_gutter_async(self, point: int) -> None:
+        content = ''
+        if self._lightbulb_line == self.view.rowcol(point)[0]:
+            content += code_actions_content(self._actions_by_config)
+        if userprefs().diagnostics_gutter_marker and userprefs().show_diagnostics_severity_level:
+            diagnostics_with_config = []  # type: List[Tuple[ClientConfig, Diagnostic]]
+            max_severity_level = min(userprefs().show_diagnostics_severity_level, DiagnosticSeverity.Information)
+            for sb, diagnostics in self.diagnostics_intersecting_async(self.view.line(point))[0]:
+                diagnostics_with_config.extend((sb.session.config, diagnostic) for diagnostic in diagnostics
+                    if diagnostic_severity(diagnostic) <= max_severity_level)
+            if diagnostics_with_config:
+                diagnostics_with_config.sort(key=lambda d: diagnostic_severity(d[1]))
+                content += '<div class="diagnostics">'
+                for config, diagnostic in diagnostics_with_config:
+                    content += format_diagnostic_for_html(config, diagnostic)
+                content += '</div>'
+        if content:
+            show_lsp_popup(
+                self.view,
+                content,
+                flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY,
+                location=point,
+                on_navigate=lambda href: self._on_navigate(href, point))
 
     def on_text_command(self, command_name: str, args: Optional[dict]) -> Optional[Tuple[str, dict]]:
         if command_name == "auto_complete":
@@ -700,6 +717,8 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
                         placeholder="Code actions")
             else:
                 self.handle_code_action_select(config_name, actions, 0)
+        else:
+            open_in_browser(href)
 
     def handle_code_action_select(self, config_name: str, actions: List[CodeActionOrCommand], index: int) -> None:
         if index == -1:

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -484,8 +484,10 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             diagnostics_with_config = []  # type: List[Tuple[ClientConfig, Diagnostic]]
             max_severity_level = min(userprefs().show_diagnostics_severity_level, DiagnosticSeverity.Information)
             for sb, diagnostics in self.diagnostics_intersecting_async(self.view.line(point))[0]:
-                diagnostics_with_config.extend((sb.session.config, diagnostic) for diagnostic in diagnostics
-                    if diagnostic_severity(diagnostic) <= max_severity_level)
+                diagnostics_with_config.extend(
+                    (sb.session.config, diagnostic) for diagnostic in diagnostics
+                    if diagnostic_severity(diagnostic) <= max_severity_level
+                )
             if diagnostics_with_config:
                 diagnostics_with_config.sort(key=lambda d: diagnostic_severity(d[1]))
                 content += '<div class="diagnostics">'


### PR DESCRIPTION
This will show a popup with all diagnostics from the line (except hint severity), sorted by severity, when you hover over a gutter icon. It is compatible with the code actions popup if applicable for the current caret position and using the "bulb" setting.