### PR TITLE
change default value of show_references_in_quick_panel to true

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -160,7 +160,7 @@
   // --- Other --------------------------------------------------------------------------
 
   // Show symbol references in Sublime's quick panel instead of the bottom panel.
-  "show_references_in_quick_panel": false,
+  "show_references_in_quick_panel": true,
 
   // Show code lens:
   // "annotation" - show an annotation on the right when code actions are available

--- a/messages/1.27.0.txt
+++ b/messages/1.27.0.txt
@@ -1,4 +1,4 @@
-=> 1.30.0
+=> 1.27.0
 
 ⚠️⚠️⚠️
 To ensure that everything works properly after LSP package is updated, it's strongly recommended

--- a/messages/1.30.0.txt
+++ b/messages/1.30.0.txt
@@ -1,0 +1,14 @@
+=> 1.30.0
+
+⚠️⚠️⚠️
+To ensure that everything works properly after LSP package is updated, it's strongly recommended
+to restart Sublime Text once it finishes updating all packages.
+⚠️⚠️⚠️
+
+# Breaking changes
+
+- The default value of `show_references_in_quick_panel` has changed from `false` to `true`.
+
+# Improvements
+
+# Fixes

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -264,7 +264,7 @@ class Settings:
         r("show_multiline_document_highlights", True)
         r("show_diagnostics_panel_on_save", 0)
         r("show_diagnostics_severity_level", 2)
-        r("show_references_in_quick_panel", False)
+        r("show_references_in_quick_panel", True)
         r("show_symbol_action_links", False)
         r("show_view_status", True)
 

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -655,7 +655,7 @@
             },
             "show_references_in_quick_panel": {
               "type": "boolean",
-              "default": false,
+              "default": true,
               "markdownDescription": "Show symbol references in Sublime's quick panel instead of the bottom panel."
             },
             "popup_max_characters_width": {


### PR DESCRIPTION
The panel feels archaic and less user-friendly due to issue with navigating results.
The default should IMO be as close to what ST offers as possible.