### PR TITLE
Add menu item to toggle code lenses

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -164,6 +164,10 @@
         "command": "lsp_type_hierarchy"
     },
     {
+        "caption": "LSP: Toggle Code Lenses",
+        "command": "lsp_toggle_code_lenses",
+    },
+    {
         "caption": "LSP: Toggle Inlay Hints",
         "command": "lsp_toggle_inlay_hints",
     },

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -157,6 +157,11 @@
         "caption": "-"
       },
       {
+        "caption": "LSP: Show Code Lens",
+        "command": "lsp_toggle_code_lens",
+        "checkbox": true
+      },
+      {
         "caption": "LSP: Show Inlay Hints",
         "command": "lsp_toggle_inlay_hints"
       },

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -157,13 +157,14 @@
         "caption": "-"
       },
       {
-        "caption": "LSP: Show Code Lens",
-        "command": "lsp_toggle_code_lens",
+        "caption": "LSP: Show Code Lenses",
+        "command": "lsp_toggle_code_lenses",
         "checkbox": true
       },
       {
         "caption": "LSP: Show Inlay Hints",
-        "command": "lsp_toggle_inlay_hints"
+        "command": "lsp_toggle_inlay_hints",
+        "checkbox": true
       },
       {
         "caption": "LSP: Show Hover Popups",

--- a/boot.py
+++ b/boot.py
@@ -7,6 +7,7 @@ from .plugin.code_actions import LspCodeActionsCommand
 from .plugin.code_actions import LspRefactorCommand
 from .plugin.code_actions import LspSourceActionCommand
 from .plugin.code_lens import LspCodeLensCommand
+from .plugin.code_lens import LspToggleCodeLensCommand
 from .plugin.color import LspColorPresentationCommand
 from .plugin.completion import LspCommitCompletionWithOppositeInsertMode
 from .plugin.completion import LspResolveDocsCommand

--- a/boot.py
+++ b/boot.py
@@ -7,7 +7,7 @@ from .plugin.code_actions import LspCodeActionsCommand
 from .plugin.code_actions import LspRefactorCommand
 from .plugin.code_actions import LspSourceActionCommand
 from .plugin.code_lens import LspCodeLensCommand
-from .plugin.code_lens import LspToggleCodeLensCommand
+from .plugin.code_lens import LspToggleCodeLensesCommand
 from .plugin.color import LspColorPresentationCommand
 from .plugin.completion import LspCommitCompletionWithOppositeInsertMode
 from .plugin.completion import LspResolveDocsCommand

--- a/plugin/code_lens.py
+++ b/plugin/code_lens.py
@@ -1,14 +1,46 @@
+from .core.constants import CODE_LENS_ENABLED_KEY
 from .core.protocol import CodeLens
 from .core.protocol import CodeLensExtended
 from .core.protocol import Error
-from .core.typing import List, Tuple, Dict, Iterable, Generator, Union, cast
+from .core.typing import List, Tuple, Dict, Iterable, Optional, Generator, Union, cast
 from .core.registry import LspTextCommand
+from .core.registry import LspWindowCommand
 from .core.registry import windows
 from .core.views import make_command_link
 from .core.views import range_to_region
 from html import escape as html_escape
+from functools import partial
 import itertools
 import sublime
+
+
+class LspToggleCodeLensCommand(LspWindowCommand):
+    capability = 'inlayHintProvider'
+
+    @classmethod
+    def are_enabled(cls, window: Optional[sublime.Window]) -> bool:
+        if not window:
+            return False
+        return bool(window.settings().get(CODE_LENS_ENABLED_KEY, True))
+
+    def is_checked(self) -> bool:
+        return bool(self.window.settings().get(CODE_LENS_ENABLED_KEY, True))
+
+    def run(self) -> None:
+        enable = not self.is_checked()
+        self.window.settings().set(CODE_LENS_ENABLED_KEY, enable)
+        sublime.set_timeout_async(partial(self._update_views_async, enable))
+
+    def _update_views_async(self, enable: bool) -> None:
+        window_manager = windows.lookup(self.window)
+        if not window_manager:
+            return
+        for session in window_manager.get_sessions():
+            for session_view in session.session_views_async():
+                if enable:
+                    session_view.start_code_lenses_async()
+                else:
+                    session_view.clear_code_lenses_async()
 
 
 class CodeLensData:

--- a/plugin/code_lens.py
+++ b/plugin/code_lens.py
@@ -14,8 +14,8 @@ import itertools
 import sublime
 
 
-class LspToggleCodeLensCommand(LspWindowCommand):
-    capability = 'inlayHintProvider'
+class LspToggleCodeLensesCommand(LspWindowCommand):
+    capability = 'codeLensProvider'
 
     @classmethod
     def are_enabled(cls, window: Optional[sublime.Window]) -> bool:
@@ -24,7 +24,7 @@ class LspToggleCodeLensCommand(LspWindowCommand):
         return bool(window.settings().get(CODE_LENS_ENABLED_KEY, True))
 
     def is_checked(self) -> bool:
-        return bool(self.window.settings().get(CODE_LENS_ENABLED_KEY, True))
+        return self.are_enabled(self.window)
 
     def run(self) -> None:
         enable = not self.is_checked()

--- a/plugin/core/constants.py
+++ b/plugin/core/constants.py
@@ -5,6 +5,7 @@
 HOVER_HIGHLIGHT_KEY = 'lsp_hover_highlight'
 
 # Setting keys
+CODE_LENS_ENABLED_KEY = 'lsp_show_code_lens'
 HOVER_ENABLED_KEY = 'lsp_show_hover_popups'
 HOVER_PROVIDER_COUNT_KEY = 'lsp_hover_provider_count'
 SHOW_DEFINITIONS_KEY = 'show_definitions'

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -578,6 +578,9 @@ class SessionViewProtocol(Protocol):
     def start_code_lenses_async(self) -> None:
         ...
 
+    def clear_code_lenses_async(self) -> None:
+        ...
+
     def set_code_lenses_pending_refresh(self, needs_refresh: bool = True) -> None:
         ...
 

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -1,5 +1,5 @@
 from .code_lens import CodeLensView
-from .code_lens import LspToggleCodeLensCommand
+from .code_lens import LspToggleCodeLensesCommand
 from .core.active_request import ActiveRequest
 from .core.constants import HOVER_ENABLED_KEY
 from .core.constants import HOVER_HIGHLIGHT_KEY
@@ -376,7 +376,7 @@ class SessionView:
     # --- textDocument/codeLens ----------------------------------------------------------------------------------------
 
     def start_code_lenses_async(self) -> None:
-        if not LspToggleCodeLensCommand.are_enabled(self.view.window()):
+        if not LspToggleCodeLensesCommand.are_enabled(self.view.window()):
             return
         params = {'textDocument': text_document_identifier(self.view)}
         for request_id, data in self._active_requests.items():
@@ -394,7 +394,7 @@ class SessionView:
         self.resolve_visible_code_lenses_async()
 
     def resolve_visible_code_lenses_async(self) -> None:
-        if not LspToggleCodeLensCommand.are_enabled(self.view.window()):
+        if not LspToggleCodeLensesCommand.are_enabled(self.view.window()):
             return
         if not self._code_lenses.is_initialized():
             self.start_code_lenses_async()


### PR DESCRIPTION
Code Lens is one of those features that is IMO too annoying to have always enabled but can be useful to use once in a while to catch un-referenced symbols and such so I think it deserves its own toggle like that.

Threw it in very quickly based on Inlay Hints and Hover Popups toggles. Might have missed something.