### PR TITLE
Add "ruby-lsp" section to documentation

### DIFF
--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -489,7 +489,7 @@ There are multiple options:
 
 ### Sorbet
 
-1. Install the sorbet and sorbet-runtime gem (see [github:sorbet/sorbet](https://github.com/sorbet/sorbet)):
+1. Install the `sorbet` and `sorbet-runtime` gem (see [github:sorbet/sorbet](https://github.com/sorbet/sorbet)):
 
     ```sh
     gem install sorbet
@@ -518,7 +518,7 @@ There are multiple options:
 
 ### Ruby LSP
 
-1. Install the Ruby LSP gem (see [github:Shopify/ruby-lsp](https://github.com/Shopify/ruby-lsp)):
+1. Install the `ruby-lsp` gem (see [github:Shopify/ruby-lsp](https://github.com/Shopify/ruby-lsp)):
 
     ```sh
     gem install ruby-lsp

--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -535,7 +535,7 @@ There are multiple options:
                 "selector": "source.ruby | text.html.ruby",
                 "initializationOptions": {
                     "enabledFeatures": {
-                        "diagnostics": false
+                        "diagnostics": true
                     },
                     "experimentalFeaturesEnabled": true
                 }

--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -512,6 +512,32 @@ There are multiple options:
     }
     ```
 
+### ruby-lsp
+
+1. Install the ruby-lsp gem (see [github:Shopify/ruby-lsp](https://github.com/Shopify/ruby-lsp)):
+
+        gem install ruby-lsp
+
+2. Open `Preferences > Package Settings > LSP > Settings` and add the `"ruby-lsp"` client configuration to the `"clients"`:
+
+    ```jsonc
+    {
+        "clients": {
+            "ruby-lsp": {
+                "enabled": true,
+                "command": ["ruby-lsp"],
+                "selector": "source.ruby | text.html.ruby",
+                "initializationOptions": {
+                    "enabledFeatures": {
+                        "diagnostics": false
+                    },
+                    "experimentalFeaturesEnabled": true
+                }
+            }
+        }
+    }
+    ```
+
 ## Rust
 
 Follow installation instructions on [LSP-rust-analyzer](https://github.com/sublimelsp/LSP-rust-analyzer).

--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -491,12 +491,16 @@ There are multiple options:
 
 1. Install the sorbet and sorbet-runtime gem (see [github:sorbet/sorbet](https://github.com/sorbet/sorbet)):
 
-        gem install sorbet
-        gem install sorbet-runtime
+    ```sh
+    gem install sorbet
+    gem install sorbet-runtime
+    ```
 
     If you have a Gemfile, using bundler, add sorbet and sorbet-runtime to your Gemfile and run:
 
-        bundle install
+    ```sh
+    bundle install
+    ```
 
 2. Open `Preferences > Package Settings > LSP > Settings` and add the `"sorbet"` client configuration to the `"clients"`:
 
@@ -512,11 +516,13 @@ There are multiple options:
     }
     ```
 
-### ruby-lsp
+### Ruby LSP
 
-1. Install the ruby-lsp gem (see [github:Shopify/ruby-lsp](https://github.com/Shopify/ruby-lsp)):
+1. Install the Ruby LSP gem (see [github:Shopify/ruby-lsp](https://github.com/Shopify/ruby-lsp)):
 
-        gem install ruby-lsp
+    ```sh
+    gem install ruby-lsp
+    ```
 
 2. Open `Preferences > Package Settings > LSP > Settings` and add the `"ruby-lsp"` client configuration to the `"clients"`:
 


### PR DESCRIPTION
Hi there,

there is another notable LSP implementation for Ruby, called `ruby-lsp`. I added it to the docs.
Config inspired by their docs: https://github.com/Shopify/ruby-lsp/blob/main/EDITORS.md#sublime-text-lsp
Please feel free to request changes or do them on your own if I missed something. Thanks!

Cheers!