### PR TITLE
Small fix to guard against None

### DIFF
--- a/plugin/core/open.py
+++ b/plugin/core/open.py
@@ -77,7 +77,7 @@ def _find_open_file(window: sublime.Window, fname: str, group: int = -1) -> Opti
     """A replacement for Window.find_open_file that prefers the active view instead of the leftmost one."""
     _group = window.active_group() if group == -1 else group
     view = window.active_view_in_group(_group)
-    if fname == view.file_name():
+    if view and fname == view.file_name():
         return view
     return window.find_open_file(fname, group)
 

--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -429,7 +429,7 @@ class Window:
     def active_sheet_in_group(self, group: int) -> 'Sheet':
         ...
 
-    def active_view_in_group(self, group: int) -> 'View':
+    def active_view_in_group(self, group: int) -> 'Optional[View]':
         ...
 
     def sheets_in_group(self, group: int) -> 'List[Sheet]':


### PR DESCRIPTION
A small fix for the last PR, which was merged hastily :-)

`Window.active_view_in_group` could return `None` if a nonexistent group is passed. This shouldn't happen and could be considered the user's fault, but better safe than sorry.