### PR TITLE
Small visual tweak for signature help popup

### DIFF
--- a/plugin/core/signature_help.py
+++ b/plugin/core/signature_help.py
@@ -85,7 +85,7 @@ class SigHelp:
             self._active_parameter_underline = active_parameter_style.get('underline', False)
         formatted.extend(self._render_label(signature))
         formatted.extend(self._render_docs(view, signature))
-        return '<body id="lsp-signature-help">{}</body>'.format(''.join(formatted))
+        return "".join(formatted)
 
     def active_signature_help(self) -> SignatureHelp:
         """

--- a/plugin/core/signature_help.py
+++ b/plugin/core/signature_help.py
@@ -85,7 +85,7 @@ class SigHelp:
             self._active_parameter_underline = active_parameter_style.get('underline', False)
         formatted.extend(self._render_label(signature))
         formatted.extend(self._render_docs(view, signature))
-        return "".join(formatted)
+        return '<body id="lsp-signature-help">{}</body>'.format(''.join(formatted))
 
     def active_signature_help(self) -> SignatureHelp:
         """
@@ -105,7 +105,7 @@ class SigHelp:
 
     def _render_intro(self) -> str:
         fmt = '<p><div style="font-size: 0.9rem"><b>{}</b> of <b>{}</b> overloads ' + \
-              "(use ↑ ↓ to navigate, press Esc to hide):</div></p>"
+              '(use <kbd>↑</kbd> <kbd>↓</kbd> to navigate, press <kbd>Esc</kbd> to hide):</div></p>'
         return fmt.format(
             self._active_signature_index + 1,
             len(self._signatures),

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -613,6 +613,7 @@ LSP_POPUP_SPACER_HTML = '<div class="lsp_popup--spacer"></div>'
 def show_lsp_popup(
     view: sublime.View,
     contents: str,
+    *,
     location: int = -1,
     md: bool = False,
     flags: int = 0,
@@ -640,8 +641,15 @@ def show_lsp_popup(
         on_hide=on_hide)
 
 
-def update_lsp_popup(view: sublime.View, contents: str, md: bool = False, css: Optional[str] = None,
-                     wrapper_class: Optional[str] = None, body_id: Optional[str] = None) -> None:
+def update_lsp_popup(
+    view: sublime.View,
+    contents: str,
+    *,
+    md: bool = False,
+    css: Optional[str] = None,
+    wrapper_class: Optional[str] = None,
+    body_id: Optional[str] = None
+) -> None:
     css = css if css is not None else lsp_css().popups
     wrapper_class = wrapper_class if wrapper_class is not None else lsp_css().popups_classname
     contents += LSP_POPUP_SPACER_HTML

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -606,7 +606,7 @@ def text_document_code_action_params(
     }
 
 
-# Workaround for a limited margin-collapsing capabilities of the minihtml.
+# Workaround for limited margin-collapsing capabilities of the minihtml.
 LSP_POPUP_SPACER_HTML = '<div class="lsp_popup--spacer"></div>'
 
 
@@ -623,7 +623,7 @@ def show_lsp_popup(
 ) -> None:
     css = css if css is not None else lsp_css().popups
     wrapper_class = wrapper_class if wrapper_class is not None else lsp_css().popups_classname
-    contents += LSP_POPUP_SPACER_HTML
+    contents += LSP_POPUP_SPACER_HTML  # TODO fix this tag being appended outside of the <body> block
     mdpopups.show_popup(
         view,
         contents,

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -618,15 +618,17 @@ def show_lsp_popup(
     flags: int = 0,
     css: Optional[str] = None,
     wrapper_class: Optional[str] = None,
+    body_id: Optional[str] = None,
     on_navigate: Optional[Callable[..., None]] = None,
     on_hide: Optional[Callable[..., None]] = None
 ) -> None:
     css = css if css is not None else lsp_css().popups
     wrapper_class = wrapper_class if wrapper_class is not None else lsp_css().popups_classname
-    contents += LSP_POPUP_SPACER_HTML  # TODO fix this tag being appended outside of the <body> block
+    contents += LSP_POPUP_SPACER_HTML
+    body_wrapper = '<body id="{}">{{}}</body>'.format(body_id) if body_id else '<body>{}</body>'
     mdpopups.show_popup(
         view,
-        contents,
+        body_wrapper.format(contents),
         css=css,
         md=md,
         flags=flags,
@@ -639,11 +641,12 @@ def show_lsp_popup(
 
 
 def update_lsp_popup(view: sublime.View, contents: str, md: bool = False, css: Optional[str] = None,
-                     wrapper_class: Optional[str] = None) -> None:
+                     wrapper_class: Optional[str] = None, body_id: Optional[str] = None) -> None:
     css = css if css is not None else lsp_css().popups
     wrapper_class = wrapper_class if wrapper_class is not None else lsp_css().popups_classname
     contents += LSP_POPUP_SPACER_HTML
-    mdpopups.update_popup(view, contents, css=css, md=md, wrapper_class=wrapper_class)
+    body_wrapper = '<body id="{}">{{}}</body>'.format(body_id) if body_id else '<body>{}</body>'
+    mdpopups.update_popup(view, body_wrapper.format(contents), css=css, md=md, wrapper_class=wrapper_class)
 
 
 FORMAT_STRING = 0x1

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -615,6 +615,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             content,
             flags=sublime.COOPERATE_WITH_AUTO_COMPLETE,
             location=point,
+            body_id='lsp-signature-help',
             on_hide=self._on_sighelp_hide,
             on_navigate=self._on_sighelp_navigate)
 

--- a/popups.css
+++ b/popups.css
@@ -18,6 +18,13 @@
 .lsp_popup h6 {
     font-size: 1rem;
 }
+.lsp_popup kbd {
+    font-size: 0.8rem;
+    line-height: 0.8rem;
+    color: var(--mdpopups-fg);
+    background-color: color(var(--mdpopups-bg) lightness(+ 5%));
+    border-color: color(var(--mdpopups-fg) alpha(0.25));
+}
 .highlight {
     border-width: 0;
     border-radius: 0;

--- a/tests/test_signature_help.py
+++ b/tests/test_signature_help.py
@@ -202,7 +202,7 @@ class SignatureHelpTest(unittest.TestCase):
             r'''
             <p>
             <div style="font-size: 0\.9rem">
-            <b>2</b> of <b>2</b> overloads \(use ↑ ↓ to navigate, press Esc to hide\):
+            <b>2</b> of <b>2</b> overloads \(use <kbd>↑</kbd> <kbd>↓</kbd> to navigate, press <kbd>Esc</kbd> to hide\):
             </div>
             </p>
             <div class="highlight"><pre><span style="color: #\w{6}">f\(</span>


### PR DESCRIPTION
A little tweak which adds a `<kbd>` tag for the keyboard keys and also a `<body>` tag[^1] with [unique id](https://www.sublimetext.com/docs/minihtml.html#best-practices) for the signature help popup.

[^1]: The `<body>` tag will not be the outermost tag in the minihtml, because mdpopups still adds its own `<div>` wrapper tag around it, but there is nothing we can do about that and it won't affect the functionality.

I have adjusted the CSS style for the `<kbd>` tag a bit, beacause the default style from mdpopups uses a too high contrast against the background color in my opinion. The style will also apply to regular hover popups if they contain literal `<kbd>` HTML tags.

|     | Mariana | Breakers |
| --- | ------- | -------- |
| Before | ![before1](https://github.com/sublimelsp/LSP/assets/6579999/a05404f7-d03a-4de6-91af-bf2fe3dd262d) | ![before2](https://github.com/sublimelsp/LSP/assets/6579999/1318c435-7f0a-4c5b-bf73-bfa2a36eabb4) |
| After  | ![after1](https://github.com/sublimelsp/LSP/assets/6579999/9382431f-9eeb-4704-bec0-5c59fa13fffa) | ![after2](https://github.com/sublimelsp/LSP/assets/6579999/58e4333c-8790-4c5f-a882-251f5cd9d7a9) |
| mdpopups default style for `<kbd>` | ![default1](https://github.com/sublimelsp/LSP/assets/6579999/f8ccb1b3-12d9-4ded-8aa9-325729f7429f) | ![default2](https://github.com/sublimelsp/LSP/assets/6579999/2eb577e8-9183-4149-ac33-6b16edde63ed) |