### PR TITLE
fix unsaved buffers pyright incompatibility

### DIFF
--- a/plugin/core/url.py
+++ b/plugin/core/url.py
@@ -26,7 +26,7 @@ def filename_to_uri(file_name: str) -> str:
 def view_to_uri(view: sublime.View) -> str:
     file_name = view.file_name()
     if not file_name:
-        return "buffer://sublime/{}".format(view.buffer_id())
+        return "buffer://{}".format(view.buffer_id())
     return filename_to_uri(file_name)
 
 

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -70,4 +70,4 @@ class MultiplatformTests(unittest.TestCase):
         view.file_name = unittest.mock.MagicMock(return_value=None)
         view.buffer_id = unittest.mock.MagicMock(return_value=42)
         uri = view_to_uri(view)
-        self.assertEqual(uri, "buffer://sublime/42")
+        self.assertEqual(uri, "buffer://42")


### PR DESCRIPTION
The `sublime` part in `buffer://sublime/[view_id]` URIs that we were using for unsaved buffers triggered an infinite loop in pyrights file traversing code. While I don't pretend to understand its code fully, the `sublime` in our made-up URIs is not really necessary or makes a lot of sense even.

Fixes https://github.com/sublimelsp/LSP-pyright/issues/281