### PR TITLE
improve buffer URI format

### DIFF
--- a/plugin/core/url.py
+++ b/plugin/core/url.py
@@ -26,7 +26,7 @@ def filename_to_uri(file_name: str) -> str:
 def view_to_uri(view: sublime.View) -> str:
     file_name = view.file_name()
     if not file_name:
-        return "buffer://{}".format(view.buffer_id())
+        return "buffer:View-{}".format(view.buffer_id())
     return filename_to_uri(file_name)
 
 

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -70,4 +70,4 @@ class MultiplatformTests(unittest.TestCase):
         view.file_name = unittest.mock.MagicMock(return_value=None)
         view.buffer_id = unittest.mock.MagicMock(return_value=42)
         uri = view_to_uri(view)
-        self.assertEqual(uri, "buffer://42")
+        self.assertEqual(uri, "buffer:View-42")


### PR DESCRIPTION
Per discussion in https://github.com/sublimelsp/LSP/pull/2360, change the URI format for unsaved files so that the part after the `scheme` is parsed as a path and not as an `authority` (`netloc` in python).

Shouldn't really affect anything (neither fix the Pyright issue) but seems like a more correct thing to do.

(Also workarounds the issue with `urlparse` failing to parse the URI correctly when path starts with numbers - add `View-` prefix).