### PR TITLE
docs: Enable "diagnostics" in solargraph example

### DIFF
--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -480,7 +480,7 @@ There are multiple options:
                 "command": ["solargraph", "stdio"],
                 "selector": "source.ruby | text.html.ruby",
                 "initializationOptions": {
-                    "diagnostics": false
+                    "diagnostics": true
                 }
             }
         }


### PR DESCRIPTION
Hi there,

as a follow up to https://github.com/sublimelsp/LSP/pull/2352 I tested enabled diagnostics for the solargraph server. It works fine so far so I do not see any reason not to "enable" it per default in the docs.

As always, please feel free to request changes or do them on your own if I missed something. Thanks!

Cheers!