### PR TITLE
use simple error for code lenses that failed resolve

### DIFF
--- a/plugin/code_lens.py
+++ b/plugin/code_lens.py
@@ -94,7 +94,7 @@ class CodeLensData:
     def resolve(self, view: sublime.View, code_lens_or_error: Union[CodeLens, Error]) -> None:
         if isinstance(code_lens_or_error, Error):
             self.is_resolve_error = True
-            self.annotation = html_escape(str(code_lens_or_error))
+            self.annotation = '<span style="color: color(var(--redish)">error</span>'
             return
         self.data = code_lens_or_error
         self.region = range_to_region(code_lens_or_error['range'], view)


### PR DESCRIPTION
Don't use the response error as the text for the code lens that failed resolving. That can resolve in stuff like this:

![Screenshot 2023-11-15 at 00 06 06](https://github.com/sublimelsp/LSP/assets/153197/289544c0-d747-4e20-91a9-fa4aaee6cbdb)

The protocol errors are not really meant to be surfaced in an UI like that.

This is how it looks after:

![Screenshot 2023-11-15 at 00 10 16](https://github.com/sublimelsp/LSP/assets/153197/45669ec2-cb84-4984-bb10-48e8858aba1a)

Not married to the styling or the text itself...