### PR TITLE
Small tweaks for Readme page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,12 @@
-:information_source: You are reading the README of the `main` branch. This branch targets ST4. If you are looking for the ST3 version, switch to the [st3 branch](https://github.com/sublimelsp/LSP/tree/st3).
-
 <p>
   <h1 align="center">LSP</h1>
 </p>
 
 <p align="center">
-  <a href="https://github.com/sublimelsp/LSP/blob/main/LICENSE">
-    <img src="https://img.shields.io/github/license/sublimelsp/LSP">
-  </a>
-  <a href="https://github.com/sublimelsp/LSP/releases">
-    <img src="https://img.shields.io/github/release/sublimelsp/LSP.svg">
-  </a>
-  <a href="https://lsp.sublimetext.io">
-    <img src="https://img.shields.io/badge/docs-ST4-blue">
-  </a>
-  <a href="#chat">
-    <img src="https://img.shields.io/discord/280102180189634562?label=SublimeHQ%20Discord&logo=discord">
-  </a>
-  <br>
+  <a href="https://github.com/sublimelsp/LSP/blob/main/LICENSE"><img src="https://img.shields.io/github/license/sublimelsp/LSP"></a>
+  <a href="https://github.com/sublimelsp/LSP/releases"><img src="https://img.shields.io/github/release/sublimelsp/LSP.svg"></a>
+  <a href="https://lsp.sublimetext.io"><img src="https://img.shields.io/badge/docs-lsp.sublimetext.io-blue"></a>
+  <a href="https://discord.gg/TZ5WN8t"><img src="https://img.shields.io/discord/280102180189634562?label=SublimeHQ%20Discord&logo=discord"></a>
 </p>
 
 <p align="center">Like an IDE, except it's the good parts. <a href="https://lsp.sublimetext.io">Learn more</a>.</p>
@@ -45,7 +34,6 @@ See more information in the [documentation](https://lsp.sublimetext.io) :open_bo
 ## Getting help
 
 If you have any problems, see the [troubleshooting](https://sublimelsp.github.io/LSP/troubleshooting/) guide for tips and known limitations. If the documentation cannot solve your problem, you can look for help in:
-<a name="chat"></a>
 
 * The [#lsp](https://discordapp.com/channels/280102180189634562/645268178397560865) channel (join the [SublimeHQ Discord](https://discord.gg/TZ5WN8t) first!)
 * By [searching or creating a new issue](https://github.com/sublimelsp/LSP/issues)


### PR DESCRIPTION
1. When you hover over the badges in the current Readme, the spaces between the buttons are underlined, which looks weird. The cause seems to be that the closing `</a>` tag is on a new line with indentation, and this indentation will become part of the link.

[readme.webm](https://github.com/sublimelsp/LSP/assets/6579999/0214efa3-6375-4801-b0fd-5cac964f13ef)

2. Updated the label of the "docs" badge with the link target location.

3. I would expect that when I click on the Discord badge, that it will redirect me to the discord page, and not just scroll the page down a little bit (where it is even unclear where the link points to, because corresponding Discord link is at the bottom of the Readme page, so the anchor will not end up at the top of the browser's viewport). Especially because the label of the badge is "SublimeHQ Discord".

4. The `<br>` tag after the badges within the paragraph seems to be useless?

5. Can we remove the ST3 note at the top of the page? LSP for ST3 is not maintained anymore for a long time already, and ST4 is available for a few years now. Also there is nothing really interesting why you would change to the st3 branch - as a ST3 user you are not able to install the ST4 version from Package Control anyway.

---

I noticed that there are still some duplicated links (to the docs website), which perhaps are not all necessary. But I didn't change that. Also the Gif could maybe use an update one day.