### PR TITLE
Fix some mypy type issues in stubs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,8 +40,8 @@ jobs:
           python-version: '3.8'
       - run: sudo apt update
       - run: sudo apt install --no-install-recommends -y x11-xserver-utils
-      - run: pip3 install mypy==0.971 flake8==5.0.4 pyright==1.1.335 yapf==0.31.0 --user
+      - run: pip3 install mypy==1.7.1 flake8==5.0.4 pyright==1.1.339 --user
       - run: echo "$HOME/.local/bin" >> $GITHUB_PATH
-      # - run: mypy -p plugin
+      - run: mypy stubs
       - run: flake8 plugin tests
       - run: pyright plugin

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,5 +1,6 @@
 {
     "pythonVersion": "3.11",
     "reportMissingModuleSource": "none",
+    "reportIncompatibleMethodOverride": "none",
     "stubPath": "./stubs",
 }

--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -704,7 +704,7 @@ class Window:
         """
         ...
 
-    def hwnd(self):
+    def hwnd(self) -> int:
         """
         A platform specific window handle. Windows only.
         """
@@ -944,14 +944,14 @@ class Window:
         """
         ...
 
-    def layout(self):
+    def layout(self) -> Dict[str, Any]:
         """
         Get the group layout of the window.
         """
         ...
 
     @deprecated("Use layout() instead")
-    def get_layout(self):
+    def get_layout(self) -> Dict[str, Any]:
         ...
 
     def set_layout(self, layout: Dict[str, Any]) -> None:
@@ -1145,7 +1145,7 @@ class Window:
         """
         ...
 
-    def template_settings(self):
+    def template_settings(self) -> Settings:
         """
         Per-window settings that are persisted in the session, and duplicated into new windows.
         """
@@ -1349,7 +1349,7 @@ class TextChange:
     str: str
     """A string of the new contents of the region specified by `a` and `b`."""
 
-    def __init__(self, pa: HistoricPosition, pb: HistoricPosition, len_utf16: int, len_utf8: int, s: str) -> None:
+    def __init__(self, pa: HistoricPosition, pb: HistoricPosition, len_utf16: int, len_utf8: int, s: str) -> None:  # type: ignore[valid-type] # noqa
         ...
 
 
@@ -1388,7 +1388,7 @@ class Selection(Reversible):
         """
         ...
 
-    def __eq__(self, rhs: Selection | None) -> bool:
+    def __eq__(self, rhs: object) -> bool:
         """
         Whether the selections are identical.
         """
@@ -1929,7 +1929,7 @@ class View:
         """
         ...
 
-    def style(self):
+    def style(self) -> Dict[str, str]:
         """
         The global style settings for the view. All colors are normalized to the six character hex form with a leading
         hash, e.g. `#ff0000`.
@@ -2462,7 +2462,7 @@ class View:
         """
         ...
 
-    def preserve_auto_complete_on_focus_lost(self):
+    def preserve_auto_complete_on_focus_lost(self) -> None:
         """
         Sets the auto complete popup state to be preserved the next time the `View` loses focus. When the `View` regains
         focus, the auto complete window will be re-shown, with the previously selected entry pre-selected.
@@ -2471,7 +2471,7 @@ class View:
 
     def export_to_html(
         self,
-        regions=None,
+        regions: Optional[Region | List[Region]] = None,
         minihtml: bool = ...,
         enclosing_tags: bool = ...,
         font_size: bool = ...,
@@ -2614,7 +2614,7 @@ class Phantom:
     ) -> None:
         ...
 
-    def __eq__(self, rhs: 'Phantom') -> bool:
+    def __eq__(self, rhs: object) -> bool:
         ...
 
     def to_tuple(self) -> Tuple[Tuple[int, int], str, int, Optional[Callable[[str], None]]]:
@@ -2726,7 +2726,7 @@ class CompletionItem:
         ) -> None:
         ...
 
-    def __eq__(self, rhs: 'CompletionItem') -> bool:
+    def __eq__(self, rhs: object) -> bool:
         ...
 
     @classmethod

--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -1388,7 +1388,7 @@ class Selection(Reversible):
         """
         ...
 
-    def __eq__(self, rhs: object) -> bool:
+    def __eq__(self, rhs: Selection | None) -> bool:  # type: ignore[override]
         """
         Whether the selections are identical.
         """
@@ -2614,7 +2614,7 @@ class Phantom:
     ) -> None:
         ...
 
-    def __eq__(self, rhs: object) -> bool:
+    def __eq__(self, rhs: 'Phantom') -> bool:  # type: ignore[override]
         ...
 
     def to_tuple(self) -> Tuple[Tuple[int, int], str, int, Optional[Callable[[str], None]]]:
@@ -2726,7 +2726,7 @@ class CompletionItem:
         ) -> None:
         ...
 
-    def __eq__(self, rhs: object) -> bool:
+    def __eq__(self, rhs: 'CompletionItem') -> bool:  # type: ignore[override]
         ...
 
     @classmethod

--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -2614,7 +2614,7 @@ class Phantom:
     ) -> None:
         ...
 
-    def __eq__(self, rhs: 'Phantom') -> bool:  # type: ignore[override]
+    def __eq__(self, rhs: Phantom) -> bool:  # type: ignore[override]
         ...
 
     def to_tuple(self) -> Tuple[Tuple[int, int], str, int, Optional[Callable[[str], None]]]:

--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -2471,7 +2471,7 @@ class View:
 
     def export_to_html(
         self,
-        regions: Optional[Region | List[Region]] = None,
+        regions: Region | List[Region] | None = ...,
         minihtml: bool = ...,
         enclosing_tags: bool = ...,
         font_size: bool = ...,

--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -2726,7 +2726,7 @@ class CompletionItem:
         ) -> None:
         ...
 
-    def __eq__(self, rhs: 'CompletionItem') -> bool:  # type: ignore[override]
+    def __eq__(self, rhs: CompletionItem) -> bool:  # type: ignore[override]
         ...
 
     @classmethod

--- a/stubs/sublime_plugin.pyi
+++ b/stubs/sublime_plugin.pyi
@@ -58,7 +58,7 @@ class CommandInputHandler:
         """
         ...
 
-    def next_input(self, args) -> CommandInputHandler | None:
+    def next_input(self, args: Any) -> CommandInputHandler | None:
         """
         Return the next input after the user has completed this one. May return
         :py:`None` to indicate no more input is required, or
@@ -119,7 +119,7 @@ class ListInputHandler(CommandInputHandler):
         """
         ...
 
-    def description(self, value, text: str) -> str:
+    def description(self, value: Any, text: str) -> str:
         """
         The text to show in the Command Palette when this input handler is not at the top of the input handler stack.
         Defaults to the text of the list item the user selected.
@@ -221,7 +221,7 @@ class TextCommand(Command):
     def __init__(self, view: View) -> None:
         ...
 
-    def run(self, edit: Edit, **kwargs: Dict[str, Any]) -> None:
+    def run(self, edit: Edit, **kwargs: Dict[str, Any]) -> None:  # type: ignore[override]
         """
         Called when the command is run. Command arguments are passed as keyword arguments.
         """

--- a/tox.ini
+++ b/tox.ini
@@ -20,11 +20,11 @@ per-file-ignores =
 
 [testenv]
 deps =
-    ; mypy==0.971
+    mypy==1.7.1
     flake8==5.0.4
-    pyright==1.1.335
+    pyright==1.1.339
 commands =
-    # mypy disabled as it doesn't currently support cyclic definitions - https://github.com/python/mypy/issues/731
-    ; mypy plugin
+    # mypy disabled for main code as it doesn't currently support cyclic definitions - https://github.com/python/mypy/issues/731
+    mypy stubs
     flake8 plugin tests
-    pyright plugin
+    pyright plugin stubs


### PR DESCRIPTION
- Check stubs using mypy. Noticed some type issues when checking `lsp_utils`.
- Ignore `reportIncompatibleMethodOverride` pyright warning which is reported in the new pyright version because it has introduced a new, stricter `typeCheckingMode` "standard" that is enabled by default.