### PR TITLE
fix document state getting out of sync in rare cases

### DIFF
--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -119,6 +119,7 @@ class SessionBuffer:
         self._diagnostics_are_visible = False
         self.document_diagnostic_needs_refresh = False
         self._document_diagnostic_pending_response = None  # type: Optional[int]
+        self._last_synced_version = 0
         self._last_text_change_time = 0.0
         self._diagnostics_debouncer_async = DebouncerNonThreadSafe(async_thread=True)
         self._workspace_diagnostics_debouncer_async = DebouncerNonThreadSafe(async_thread=True)
@@ -155,6 +156,7 @@ class SessionBuffer:
             self.session.send_notification(did_open(view, language_id))
             self.opened = True
             version = view.change_count()
+            self._last_synced_version = version
             self._do_color_boxes_async(view, version)
             self.do_document_diagnostic_async(view, version)
             self.do_semantic_tokens_async(view, view.size() > HUGE_FILE_SIZE)
@@ -276,6 +278,8 @@ class SessionBuffer:
 
     def on_text_changed_async(self, view: sublime.View, change_count: int,
                               changes: Iterable[sublime.TextChange]) -> None:
+        if self._last_synced_version >= change_count:
+            return
         self._last_text_change_time = time.time()
         last_change = list(changes)[-1]
         if last_change.a.pt == 0 and last_change.b.pt == 0 and last_change.str == '' and view.size() != 0:
@@ -318,6 +322,7 @@ class SessionBuffer:
         try:
             notification = did_change(view, version, changes)
             self.session.send_notification(notification)
+            self._last_synced_version = version
         except MissingUriError:
             return  # we're closing
         finally:

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -278,7 +278,7 @@ class SessionBuffer:
 
     def on_text_changed_async(self, view: sublime.View, change_count: int,
                               changes: Iterable[sublime.TextChange]) -> None:
-        if self._last_synced_version >= change_count:
+        if change_count <= self._last_synced_version:
             return
         self._last_text_change_time = time.time()
         last_change = list(changes)[-1]


### PR DESCRIPTION
I've reproduced a case where document state gets desynchronized on the LSP side. The issue seems to be only reproducible when there are at least two servers starting on a file (or maybe it just makes it more likely to happen). The easiest way to reproduce is to start ST, (re)open a file on which at least two servers will get started and start typing immediately. After undoing the changes LSP will show some stale errors.

https://github.com/sublimelsp/LSP/assets/153197/8af0eba7-9626-4496-9cb4-31f6971b3070

This happened on opening the file. We have applied all latest changes through `didOpen` when the change count was, let's say, 1, but there was also already pending text change notification with a change count of 1 which we have applied again a little later.

To fix, ignore text change notification that refer to current or old versions of the view since those are already applied/synced.

I was trying to think whether there is some deeper issue in the code that should be fixed instead but given how async tasks are scheduled, I don't think there is and it's just an expected case that we need to handle.