### PR TITLE
Add only_files argument for lsp_save_all command

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -17,10 +17,11 @@
             {"key": "auto_complete_visible"}
         ]
     },
-    // Save all open files with lsp_save
+    // Save all open files that have a language server attached with lsp_save
     // {
     //     "keys": ["UNBOUND"],
-    //     "command": "lsp_save_all"
+    //     "command": "lsp_save_all",
+    //     "args": {"only_files": false}
     // },
     // Run Code Action
     // {

--- a/docs/src/keyboard_shortcuts.md
+++ b/docs/src/keyboard_shortcuts.md
@@ -33,6 +33,7 @@ Refer to the [Customization section](customization.md#keyboard-shortcuts-key-bin
 | Run Code Lens | unbound | `lsp_code_lens`
 | Run Refactor Action | unbound | `lsp_code_actions` (with args: `{"only_kinds": ["refactor"]}`)
 | Run Source Action | unbound | `lsp_code_actions` (with args: `{"only_kinds": ["source"]}`)
+| Save All | unbound | `lsp_save_all` (supports optional args `{"only_files": true}` - to ignore buffers which have no associated file on disk)
 | Show Call Hierarchy | unbound | `lsp_call_hierarchy`
 | Show Type Hierarchy | unbound | `lsp_type_hierarchy`
 | Signature Help | <kbd>ctrl</kbd> <kbd>alt</kbd> <kbd>space</kbd> | `lsp_signature_help_show`

--- a/plugin/save_command.py
+++ b/plugin/save_command.py
@@ -117,13 +117,15 @@ class LspSaveCommand(LspTextCommand):
 
 
 class LspSaveAllCommand(sublime_plugin.WindowCommand):
-    def run(self) -> None:
+    def run(self, only_files: bool = False) -> None:
         done = set()
         for view in self.window.views():
             buffer_id = view.buffer_id()
             if buffer_id in done:
                 continue
             if not view.is_dirty():
+                continue
+            if only_files and view.file_name() is None:
                 continue
             done.add(buffer_id)
             view.run_command("lsp_save", None)


### PR DESCRIPTION
Closes #2371 (?)

Using this argument, you can add a key binding (or menu entry or command palette entry) to save all files, without being bothered by save dialogs for new buffers.

Also did a small adjustment to the caption of the example key binding, to make it clear that `lsp_save_all` only saves views for which a language server is running.