### PR TITLE
Support all arguments of native save in lsp_save command

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -247,6 +247,7 @@
     {
         "keys": ["primary+s"],
         "command": "lsp_save",
+        "args": {"async": true},
         "context": [{"key": "lsp.session_with_capability", "operand": "textDocumentSync.willSave | textDocumentSync.willSaveWaitUntil | codeActionProvider.codeActionKinds | documentFormattingProvider | documentRangeFormattingProvider"}]
     },
 ]

--- a/tests/test_code_actions.py
+++ b/tests/test_code_actions.py
@@ -118,7 +118,7 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
             code_action_kind
         )
         self.set_response('textDocument/codeAction', [code_action])
-        self.view.run_command('lsp_save')
+        self.view.run_command('lsp_save', {'async': True})
         yield from self.await_message('textDocument/codeAction')
         yield from self.await_message('textDocument/didSave')
         self.assertEquals(entire_content(self.view), 'const x = 1;')
@@ -134,7 +134,7 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
             code_action_kind
         )
         self.set_response('textDocument/codeAction', [code_action])
-        self.view.run_command('lsp_save')
+        self.view.run_command('lsp_save', {'async': True})
         code_action_request = yield from self.await_message('textDocument/codeAction')
         self.assertEquals(len(code_action_request['context']['diagnostics']), 1)
         self.assertEquals(code_action_request['context']['diagnostics'][0]['message'], 'Missing semicolon')
@@ -176,7 +176,7 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
                 ]
             ),
         ])
-        self.view.run_command('lsp_save')
+        self.view.run_command('lsp_save', {'async': True})
         # Wait for the view to be saved
         yield lambda: not self.view.is_dirty()
         self.assertEquals(entire_content(self.view), 'const x = 1;')
@@ -191,7 +191,7 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
             code_action_kind
         )
         self.set_response('textDocument/codeAction', [code_action])
-        self.view.run_command('lsp_save')
+        self.view.run_command('lsp_save', {'async': True})
         yield from self.await_message('textDocument/codeAction')
         yield from self.await_message('textDocument/didSave')
         self.assertEquals(entire_content(self.view), 'const x = 1;')
@@ -200,7 +200,7 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
     def test_no_fix_on_non_matching_kind(self) -> Generator:
         yield from self._setup_document_with_missing_semicolon()
         initial_content = 'const x = 1'
-        self.view.run_command('lsp_save')
+        self.view.run_command('lsp_save', {'async': True})
         yield from self.await_message('textDocument/didSave')
         self.assertEquals(entire_content(self.view), initial_content)
         self.assertEquals(self.view.is_dirty(), False)
@@ -215,7 +215,7 @@ class CodeActionsOnSaveTestCase(TextDocumentTestCase):
             code_action_kind
         )
         self.set_response('textDocument/codeAction', [code_action])
-        self.view.run_command('lsp_save')
+        self.view.run_command('lsp_save', {'async': True})
         yield from self.await_message('textDocument/didSave')
         self.assertEquals(entire_content(self.view), 'const x = 1')
 

--- a/tests/test_single_document.py
+++ b/tests/test_single_document.py
@@ -106,7 +106,7 @@ class SingleDocumentTestCase(TextDocumentTestCase):
         assert self.view
         self.view.settings().set("lsp_format_on_save", False)
         self.insert_characters("A")
-        self.view.run_command("lsp_save")
+        self.view.run_command("lsp_save", {'async': True})
         yield from self.await_message("textDocument/didChange")
         yield from self.await_message("textDocument/didSave")
         yield from self.await_clear_view_and_save()
@@ -123,7 +123,7 @@ class SingleDocumentTestCase(TextDocumentTestCase):
                 'end': {'line': 0, 'character': 1}
             }
         }])
-        self.view.run_command("lsp_save")
+        self.view.run_command("lsp_save", {'async': True})
         yield from self.await_message("textDocument/formatting")
         yield from self.await_message("textDocument/didChange")
         yield from self.await_message("textDocument/didSave")
@@ -384,7 +384,7 @@ class WillSaveWaitUntilTestCase(TextDocumentTestCase):
             }
         }])
         self.view.settings().set("lsp_format_on_save", False)
-        self.view.run_command("lsp_save")
+        self.view.run_command("lsp_save", {'async': True})
         yield from self.await_message("textDocument/willSaveWaitUntil")
         yield from self.await_message("textDocument/didChange")
         yield from self.await_message("textDocument/didSave")


### PR DESCRIPTION
This might be not very relevant in practice, because `lsp_save` is just an internal command.
But I think this implementation to just pass through the arguments is cleaner and more flexible than hardcoding a single argument, especially since `lsp_save` is meant to be a replacement for `save`.