### PR TITLE
Added solidity language server setup guide

### DIFF
--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -629,14 +629,15 @@ Follow installation instructions on [LSP-metals](https://github.com/scalameta/me
 
 ## Solidity
 
-1. Install [github:NomicFoundation/hardhat-vscode](https://github.com/NomicFoundation/hardhat-vscode/tree/development/server) (follow instructions in the repo):
-
-2. Open `Preferences > Package Settings > LSP > Settings` and add the `"solidity"` client configuration to the `"clients"`:
+1. Install the [Ethereum](https://packagecontrol.io/packages/Ethereum) package from Package Control for syntax highlighting.
+2. Install [github:NomicFoundation/hardhat-vscode](https://github.com/NomicFoundation/hardhat-vscode/tree/development/server).
+3. Open `Preferences > Package Settings > LSP > Settings` and add the `"solidity"` client configuration to the `"clients"`:
 
     ```jsonc
     {
         "clients": {
             "solidity": {
+                "enabled": true,
                 "command": ["nomicfoundation-solidity-language-server", "--stdio"],
                 "selector": "source.solidity"
             }

--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -627,7 +627,7 @@ Follow installation instructions on [LSP-metals](https://github.com/scalameta/me
     }
     ```
 
-### Solidity
+## Solidity
 
 1. Install [github:NomicFoundation/hardhat-vscode](https://github.com/NomicFoundation/hardhat-vscode/tree/development/server) (follow instructions in the repo):
 

--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -630,7 +630,7 @@ Follow installation instructions on [LSP-metals](https://github.com/scalameta/me
 ## Solidity
 
 1. Install the [Ethereum](https://packagecontrol.io/packages/Ethereum) package from Package Control for syntax highlighting.
-2. Install [github:NomicFoundation/hardhat-vscode](https://github.com/NomicFoundation/hardhat-vscode/tree/development/server).
+2. Install the [github:NomicFoundation/hardhat-vscode](https://github.com/NomicFoundation/hardhat-vscode/tree/development/server) language server.
 3. Open `Preferences > Package Settings > LSP > Settings` and add the `"solidity"` client configuration to the `"clients"`:
 
     ```jsonc

--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -637,7 +637,7 @@ Follow installation instructions on [LSP-metals](https://github.com/scalameta/me
     {
         "clients": {
             "solidity": {
-                "command": ["/PATH/TO/node", "PATH/TO/nomicfoundation-solidity-language-server", "--stdio"],
+                "command": ["nomicfoundation-solidity-language-server", "--stdio"],
                 "selector": "source.solidity"
             }
         }

--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -627,6 +627,23 @@ Follow installation instructions on [LSP-metals](https://github.com/scalameta/me
     }
     ```
 
+### Solidity
+
+1. Install [github:NomicFoundation/hardhat-vscode](https://github.com/NomicFoundation/hardhat-vscode/tree/development/server) (follow instructions in the repo):
+
+2. Open `Preferences > Package Settings > LSP > Settings` and add the `"solidity"` client configuration to the `"clients"`:
+
+    ```jsonc
+    {
+        "clients": {
+            "solidity": {
+                "command": ["/PATH/TO/node", "PATH/TO/nomicfoundation-solidity-language-server", "--stdio"],
+                "selector": "source.solidity"
+            }
+        }
+    }
+    ```
+
 ## Stylelint
 
 Follow installation instructions on [LSP-stylelint](https://github.com/sublimelsp/LSP-stylelint).


### PR DESCRIPTION
### Description

Just added a quick guide how to make LSP package to work with solidity, I've also tried to make [solc](https://docs.soliditylang.org/en/v0.8.23/installing-solidity.html#macos-packages) lsp to work, but [hardhat-vscode](https://github.com/NomicFoundation/hardhat-vscode/tree/development/server) feels much more suitable and easier to set up.

### Demo

<img width="1512" alt="image" src="https://github.com/sublimelsp/LSP/assets/6112517/a75ec431-beca-4a2b-a9a4-c4fb0309f7cd">

<img width="1512" alt="image" src="https://github.com/sublimelsp/LSP/assets/6112517/de1cfa60-b5a7-4772-bfe6-53b435e70054">
