### PR TITLE
Update instructions for OCaml and ReasonML

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -344,10 +344,9 @@
     },
     "ocaml": {
       "command": [
-        "ocaml-language-server",
-        "--stdio"
+        "ocamllsp"
       ],
-      "selector": "source.reason | source.ocaml",
+      "selector": "source.ocaml | source.reason",
     },
     "polymer-ide": {
       "command": [

--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -380,22 +380,7 @@ Spell check can be provided by [LSP-ltex-ls](https://github.com/LDAP/LSP-ltex-ls
 
 ## OCaml/Reason
 
-1. Install the [Reason](https://packagecontrol.io/packages/Reason) package from Package Control for syntax highlighting.
-2. Install the [Reason Language Server](https://github.com/jaredly/reason-language-server#sublime-text).
-3. Open `Preferences > Package Settings > LSP > Settings` and add the `"reason"` client configuration to the `"clients"`:
-
-
-    ```jsonc
-    {
-        "clients": {
-            "reason": {
-                "enabled": true,
-                "command": ["PATH/TO/reason-language-server.exe"], // Update the PATH
-                "selector": "source.ocaml | source.reason"
-            }
-        }
-    }
-    ```
+Follow installation instructions on [OCaml-LSP](https://github.com/ocaml/ocaml-lsp).
 
 ## Odin
 


### PR DESCRIPTION
I plan to document instructions for Sublime on the OCaml-LSP side, but this change basically allows us to use OCaml-LSP as is.