### PR TITLE
feat: support setting cursor position in text edits

### DIFF
--- a/plugin/edit.py
+++ b/plugin/edit.py
@@ -1,8 +1,9 @@
 from .core.edit import TextEditTuple
 from .core.logging import debug
-from .core.typing import List, Optional, Any, Generator, Iterable
+from .core.typing import List, Optional, Any, Generator, Iterable, Tuple
 from contextlib import contextmanager
 import operator
+import re
 import sublime
 import sublime_plugin
 
@@ -21,8 +22,11 @@ def temporary_setting(settings: sublime.Settings, key: str, val: Any) -> Generat
 
 
 class LspApplyDocumentEditCommand(sublime_plugin.TextCommand):
+    re_snippet = re.compile(r'\$(0|\{0:([^}]*)\})')
 
-    def run(self, edit: sublime.Edit, changes: Optional[List[TextEditTuple]] = None) -> None:
+    def run(
+        self, edit: sublime.Edit, changes: Optional[List[TextEditTuple]] = None, process_snippets: bool = False
+    ) -> None:
         # Apply the changes in reverse, so that we don't invalidate the range
         # of any change that we haven't applied yet.
         if not changes:
@@ -30,10 +34,27 @@ class LspApplyDocumentEditCommand(sublime_plugin.TextCommand):
         with temporary_setting(self.view.settings(), "translate_tabs_to_spaces", False):
             view_version = self.view.change_count()
             last_row, _ = self.view.rowcol_utf16(self.view.size())
+            snippet_region_count = 0
             for start, end, replacement, version in reversed(_sort_by_application_order(changes)):
                 if version is not None and version != view_version:
                     debug('ignoring edit due to non-matching document version')
                     continue
+                snippet_region = None  # type: Optional[Tuple[Tuple[int, int], Tuple[int, int]]]
+                if process_snippets and replacement:
+                    parsed = self.parse_snippet(replacement)
+                    if parsed:
+                        replacement, (placeholder_start, placeholder_length) = parsed
+                        # There might be newlines before the placeholder. Find the actual line and character offset
+                        # of the placeholder.
+                        prefix = replacement[0:placeholder_start]
+                        last_newline_start = prefix.rfind('\n')
+                        start_line = start[0] + prefix.count('\n')
+                        if last_newline_start == -1:
+                            start_column = start[1] + placeholder_start
+                        else:
+                            start_column = len(prefix) - last_newline_start - 1
+                        end_column = start_column + placeholder_length
+                        snippet_region = ((start_line, start_column), (start_line, end_column))
                 region = sublime.Region(
                     self.view.text_point_utf16(*start, clamp_column=True),
                     self.view.text_point_utf16(*end, clamp_column=True)
@@ -45,6 +66,16 @@ class LspApplyDocumentEditCommand(sublime_plugin.TextCommand):
                     last_row, _ = self.view.rowcol(self.view.size())
                 else:
                     self.apply_change(region, replacement, edit)
+                if snippet_region is not None:
+                    if snippet_region_count == 0:
+                        self.view.sel().clear()
+                    snippet_region_count += 1
+                    self.view.sel().add(sublime.Region(
+                        self.view.text_point_utf16(*snippet_region[0], clamp_column=True),
+                        self.view.text_point_utf16(*snippet_region[1], clamp_column=True)
+                    ))
+            if snippet_region_count == 1:
+                self.view.show(self.view.sel())
 
     def apply_change(self, region: sublime.Region, replacement: str, edit: sublime.Edit) -> None:
         if region.empty():
@@ -54,6 +85,15 @@ class LspApplyDocumentEditCommand(sublime_plugin.TextCommand):
                 self.view.replace(edit, region, replacement)
             else:
                 self.view.erase(edit, region)
+
+    def parse_snippet(self, replacement: str) -> Optional[Tuple[str, Tuple[int, int]]]:
+        match = re.search(self.re_snippet, replacement)
+        if not match:
+            return
+        placeholder = match.group(2) or ''
+        new_replacement = replacement.replace(match.group(0), placeholder)
+        placeholder_start_and_length = (match.start(0), len(placeholder))
+        return (new_replacement, placeholder_start_and_length)
 
 
 def _sort_by_application_order(changes: Iterable[TextEditTuple]) -> List[TextEditTuple]:

--- a/plugin/formatting.py
+++ b/plugin/formatting.py
@@ -50,9 +50,11 @@ def format_document(text_command: LspTextCommand, formatter: Optional[str] = Non
     return Promise.resolve(None)
 
 
-def apply_text_edits_to_view(response: Optional[List[TextEdit]], view: sublime.View) -> None:
+def apply_text_edits_to_view(
+    response: Optional[List[TextEdit]], view: sublime.View, *, process_snippets: bool = False
+) -> None:
     edits = list(parse_text_edit(change) for change in response) if response else []
-    view.run_command('lsp_apply_document_edit', {'changes': edits})
+    view.run_command('lsp_apply_document_edit', {'changes': edits, 'process_snippets': process_snippets})
 
 
 class WillSaveWaitTask(SaveTask):

--- a/plugin/formatting.py
+++ b/plugin/formatting.py
@@ -51,10 +51,10 @@ def format_document(text_command: LspTextCommand, formatter: Optional[str] = Non
 
 
 def apply_text_edits_to_view(
-    response: Optional[List[TextEdit]], view: sublime.View, *, process_snippets: bool = False
+    response: Optional[List[TextEdit]], view: sublime.View, *, process_placeholders: bool = False
 ) -> None:
     edits = list(parse_text_edit(change) for change in response) if response else []
-    view.run_command('lsp_apply_document_edit', {'changes': edits, 'process_snippets': process_snippets})
+    view.run_command('lsp_apply_document_edit', {'changes': edits, 'process_placeholders': process_placeholders})
 
 
 class WillSaveWaitTask(SaveTask):

--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -1758,7 +1758,7 @@ class View:
     # def is_in_edit(self) -> bool:  # undocumented
     #     ...
 
-    def insert(self, edit: Edit, pt: int, text: str) -> None:
+    def insert(self, edit: Edit, pt: int, text: str) -> int:
         """
         Insert the given string into the buffer.
 


### PR DESCRIPTION
Add opt-in handling for placeholders in text edits which define the position of the cursor after text edits are applied. This is required (well, not required but it improves experience) for custom rust-analyzer `moveItem` command that I'm adding support for in https://github.com/sublimelsp/LSP-rust-analyzer/pull/111#pullrequestreview-1805125212

Based on rust-analyzer extension code: https://github.com/rust-lang/rust-analyzer/blob/f7823f31069c6ec5be24d0497847bf1bb8a4c683/editors/code/src/snippets.ts#L41-L87

Also check rust-analyzer description of their custom snippet text edit: https://github.com/rust-lang/rust-analyzer/blob/master/docs/dev/lsp-extensions.md#snippet-textedit