### PR TITLE
docs: Add `stimulus-lsp` to language_servers.md

### DIFF
--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -514,6 +514,28 @@ There are multiple options:
     }
     ```
 
+### Stimulus LSP
+
+1. Install the `stimulus-language-server` package (see [github:marcoroth/stimulus-lsp](https://github.com/marcoroth/stimulus-lsp)):
+
+    ```sh
+    npm install -g stimulus-language-server
+    ```
+
+2. Open `Preferences > Package Settings > LSP > Settings` and add the `"stimulus"` client configuration to the `"clients"`:
+
+    ```jsonc
+    {
+        "clients": {
+            "stimulus": {
+                "enabled": true,
+                "command": ["stimulus-language-server", "--stdio"],
+                "selector": "text.html.rails"
+            }
+        }
+    }
+    ```
+
 ### Ruby LSP
 
 1. Install the `ruby-lsp` gem (see [github:Shopify/ruby-lsp](https://github.com/Shopify/ruby-lsp)):


### PR DESCRIPTION
Add [Stimulus LSP](https://github.com/marcoroth/stimulus-lsp) to Language Servers docs section.

Config inspired by the [Neovim install instructions](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#stimulus_ls).