### PR TITLE
include lsp_utils settings in LSP

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -26,6 +26,14 @@
         }
     },
     {
+        "caption": "Preferences: LSP Utils Settings",
+        "command": "edit_settings",
+        "args": {
+            "base_file": "${packages}/LSP/lsp_utils.sublime-settings",
+            "default": "// Settings in here override those in \"LSP/lsp_utils.sublime-settings\"\n{\n\t$0\n}\n"
+        }
+    },
+    {
         "caption": "LSP Development: Parse VSCode Package JSON From Clipboard",
         "command": "lsp_parse_vscode_package_json"
     },

--- a/lsp_utils.sublime-settings
+++ b/lsp_utils.sublime-settings
@@ -1,0 +1,14 @@
+{
+    // Specifies the type and priority of the Node.js installation that should be used for Node.js-based servers.
+    // The allowed values are:
+    //  - 'system' - a Node.js runtime found on the PATH
+    //  - 'local' - a Node.js runtime managed by LSP that doesn't affect the system
+    // The order in which the values are specified determines which one is tried first,
+    // with the later one being used as a fallback.
+    // You can also specify just a single value to disable the fallback.
+    "nodejs_runtime": ["system", "local"],
+    // Uses Node.js runtime from the Electron package rather than the official distribution. This has the benefit of
+    // lower memory usage due to it having the pointer compression (https://v8.dev/blog/pointer-compression) enabled.
+    // Only relevant when using `local` variant of `nodejs_runtime`.
+    "local_use_electron": false,
+}

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -756,6 +756,42 @@
       },
       {
         "file_patterns": [
+          "/lsp_utils.sublime-settings"
+        ],
+        "schema": {
+          "type": "object",
+          "properties": {
+            "nodejs_runtime": {
+              "type": "array",
+              "markdownDescription": "Specifies the type and priority of the Node.js installation that should be used for Node.js-based servers.\n\nThe allowed values are:\n\n- `system` - a Node.js runtime found on the PATH\n- `local` - a Node.js runtime managed by LSP that doesn't affect the system\n\nThe order in which the values are specified determines which one is tried first,\nwith the later one being used as a fallback.\nYou can also specify just a single value to disable the fallback.",
+              "default": [
+                "system",
+                "local",
+              ],
+              "items": {
+                "type": "string",
+                "enum": [
+                  "system",
+                  "local"
+                ],
+                "markdownEnumDescriptions": [
+                  "Node.js runtime found on the PATH",
+                  "Node.js runtime managed by LSP"
+                ]
+              },
+              "uniqueItems": true,
+            },
+            "local_use_electron": {
+              "type": "boolean",
+              "default": false,
+              "markdownDescription": "Uses Node.js runtime from the Electron package rather than the official distribution. This has the benefit of lower memory usage due to it having the [pointer compression](https://v8.dev/blog/pointer-compression) enabled.\n\nOnly relevant when using `local` variant of `nodejs_runtime`."
+            }
+          },
+          "additionalProperties": false,
+        }
+      },
+      {
+        "file_patterns": [
           "/Preferences.sublime-settings"
         ],
         "schema": {


### PR DESCRIPTION
Doing as suggested in https://github.com/sublimelsp/LSP/pull/2388 and moving `lsp_utils` settings into `LSP`. A temporary step until we migrate to a new plugin API that I've started looking into.