### PR TITLE
docs: add asm-lsp

### DIFF
--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -16,7 +16,7 @@ If there are no setup steps for a language server on this page, but a [language 
 
 Follow installation instructions on [LSP-angular](https://github.com/sublimelsp/LSP-angular).
 
-## ASM LSP
+## Assembly
 
 1. Install `asm-lsp` via Cargo (see [github:bergercookie/asm-lsp](https://github.com/bergercookie/asm-lsp)):
 
@@ -32,7 +32,7 @@ Follow installation instructions on [LSP-angular](https://github.com/sublimelsp/
             "asm-lsp": {
                 "enabled": true,
                 "command": ["asm-lsp"],
-                "selector": "text.plain | source.disasm"
+                "selector": "source.asm | source.assembly"
             }
         }
     }

--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -24,7 +24,9 @@ Follow installation instructions on [LSP-angular](https://github.com/sublimelsp/
     cargo install asm-lsp
     ```
 
-2. Open `Preferences > Package Settings > LSP > Settings` and add the `"asm-lsp"` client configuration to the `"clients"`:
+2. Install the [x86 and x86_64 Assembly](https://packagecontrol.io/packages/x86%20and%20x86_64%20Assembly) package from Package Control.
+
+3. Open `Preferences > Package Settings > LSP > Settings` and add the `"asm-lsp"` client configuration to the `"clients"`:
 
     ```jsonc
     {

--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -16,6 +16,28 @@ If there are no setup steps for a language server on this page, but a [language 
 
 Follow installation instructions on [LSP-angular](https://github.com/sublimelsp/LSP-angular).
 
+## ASM LSP
+
+1. Install `asm-lsp` via Cargo (see [github:bergercookie/asm-lsp](https://github.com/bergercookie/asm-lsp)):
+
+    ```sh
+    cargo install asm-lsp
+    ```
+
+2. Open `Preferences > Package Settings > LSP > Settings` and add the `"asm-lsp"` client configuration to the `"clients"`:
+
+    ```jsonc
+    {
+        "clients": {
+            "asm-lsp": {
+                "enabled": true,
+                "command": ["asm-lsp"],
+                "selector": "text.plain | source.disasm"
+            }
+        }
+    }
+    ```
+
 ## Bash
 
 Follow installation instructions on [LSP-bash](https://github.com/sublimelsp/LSP-bash).


### PR DESCRIPTION
Hi! Would it be possible to add [asm-lsp](https://github.com/bergercookie/asm-lsp) to the docs?

I wasn't super sure what to list for the selectors in the configuration. Checking the selector on my test files (see `samples/` in the project's repo) yielded `text.plain`. I tried finding a more comprehensive lists of scopes to use a more assembly-specific scope, but the best I could find was [this](https://stackoverflow.com/questions/30153110/get-all-scope-names-on-sublime-text-3) stack overflow post. The post listed `source.disasm`, but I struggled to find a file that used that. I tested the configuration as-is and it works, but I'm happy to change anything if I've made a mistake :)