### PR TITLE
fix KeyError exception triggered on closing a window

### DIFF
--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -545,7 +545,7 @@ class WindowRegistry:
     def discard(self, window: sublime.Window) -> None:
         wm = self._windows.pop(window.id(), None)
         if wm:
-            wm.destroy()
+            sublime.set_timeout_async(wm.destroy)
 
 
 class RequestTimeTracker:


### PR DESCRIPTION
`wm.destroy` is called in two cases:
- from `EventListener.on_pre_close_window`, before the window is closed
- from `plugin_unloaded` hook when LSP package is unloaded

The changed line is triggered in the former case.

As the [comment in `WindowManager.destroy()` says](https://github.com/sublimelsp/LSP/blob/f10f45e4323fbe39e2f138dd9f7ce47544c110d6/plugin/core/windows.py#L402-L406), we should (have to!) call it from the main thread when the plugin is unloaded. But afaics, we don't need to call it from the main thread when closing a window so change the code to not do that.

Calling it from the main thread on window closing triggers a `KeyError` exception due to `DocumentListener.on_close` being triggered first and `DocumentListener.on_session_shutdown_async` later. The latter removes session view from the main thread first and the former tries to remove it again from scheduled execution on the async thread.

Fixes #2399