### PR TITLE
docs: rewrite self-help instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,13 +4,14 @@ about: Create a report to help us improve
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 **Describe the bug**
+
 A clear and concise description of what the bug is.
 
 **To Reproduce**
+
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
@@ -18,18 +19,26 @@ Steps to reproduce the behavior:
 4. See error
 
 **Expected behavior**
+
 A clear and concise description of what you expected to happen.
 
 **Screenshots**
+
 If applicable, add screenshots to help explain your problem.
 
+**Logs**
+
+Check https://lsp.sublimetext.io/troubleshooting/#self-help-instructions on how to provide additional logs.
+
 **Environment (please complete the following information):**
+
 - OS: [e.g. Ubuntu 20.04 or macOS 10.15]
 - Sublime Text version: [e.g. 4085]
 - LSP version: [e.g. 1.0.12, run `Package Control: List Packages` to find the version]
 - Language servers used: [e.g. clangd, gopls, dart, Vetur, intelephense, HIE]
 
 **Additional context**
+
 Add any other context about the problem here. For example, whether you're using a helper
 package or your manual server configuration in LSP.sublime-settings. When using
 a manual server configuration please include it here if you believe it's applicable.

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -1,13 +1,13 @@
 ## Self-help instructions
 
-To see the LSP server and client communication, run `LSP: Toggle Log Panel` from the Command Palette. Logs are useful to diagnose problems.
+Following are the primary places to look at when diagnosing issues:
+
+1. Run `LSP: Toggle Log Panel` from the *Command Palette* to see communication logs between the server and the client. It allows to see what the server is doing exactly.
+2. Open the *Sublime Text* console by going to `View` -> `Show Console` from the main menu. It provides information about installed packages, potential LSP crashes and additional LSP debugging logs when `log_debug` is enabled in `Preferences: LSP Settings`.
+3. Focus the relevant file, then run `LSP: Troubleshoot server` from the *Command Palette* and select a server to see troubleshooting information. It can be a very efficient way to diagnose problems quickly when shared.
 
 !!! note
-    It might be a good idea to restart Sublime Text and reproduce the issue again so that the logs are clean.
-
-If you believe the issue is with this package, please include the output from the Sublime console in your issue report!
-
-If the server is crashing on startup, try running `LSP: Troubleshoot server` from the Command Palette and check the "Server output" for potential errors. Consider sharing the output of this command in the report.
+    In case of reporting an issue, consider providing all before-mentioned logs. If you can reproduce the issue, then restarting Sublime Text before capturing the logs can help improve clarity of the logs.
 
 ## Updating the PATH used by LSP servers
 


### PR DESCRIPTION
Rewritten self-help instructions.

I wanted it to be something that we can link people to when asking for additional information without having to repeat ourselves all the time. The old text was a bit all over the place. Now it's hopefully more precise and concise and will get us the stuff we need.

Feel free to suggest improvements as english is not my forte and I'm not particularly good at writing docs. :)

(we can potentially even link to it in an issue template)