### PR TITLE
Remove hover provider count view setting

### DIFF
--- a/plugin/core/constants.py
+++ b/plugin/core/constants.py
@@ -18,7 +18,6 @@ HOVER_HIGHLIGHT_KEY = 'lsp_hover_highlight'
 # Setting keys
 CODE_LENS_ENABLED_KEY = 'lsp_show_code_lens'
 HOVER_ENABLED_KEY = 'lsp_show_hover_popups'
-HOVER_PROVIDER_COUNT_KEY = 'lsp_hover_provider_count'
 SHOW_DEFINITIONS_KEY = 'show_definitions'
 
 # Region flags

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -679,6 +679,7 @@ class AbstractViewListener(metaclass=ABCMeta):
     TOTAL_ERRORS_AND_WARNINGS_STATUS_KEY = "lsp_total_errors_and_warnings"
 
     view = cast(sublime.View, None)
+    hover_provider_count = 0
 
     @abstractmethod
     def session_async(self, capability: str, point: Optional[int] = None) -> Optional['Session']:

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -171,6 +171,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         self._completions_task = None  # type: Optional[QueryCompletionsTask]
         self._stored_selection = []  # type: List[sublime.Region]
         self._should_format_on_paste = False
+        self.hover_provider_count = 0
         self._setup()
 
     def __del__(self) -> None:

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -3,7 +3,6 @@ from .code_actions import CodeActionOrCommand
 from .code_actions import CodeActionsByConfigName
 from .core.constants import HOVER_ENABLED_KEY
 from .core.constants import HOVER_HIGHLIGHT_KEY
-from .core.constants import HOVER_PROVIDER_COUNT_KEY
 from .core.constants import SHOW_DEFINITIONS_KEY
 from .core.open import lsp_range_from_uri_fragment
 from .core.open import open_file_uri
@@ -22,7 +21,6 @@ from .core.sessions import AbstractViewListener
 from .core.sessions import SessionBufferProtocol
 from .core.settings import userprefs
 from .core.typing import List, Optional, Dict, Tuple, Sequence, Union
-from .core.typing import cast
 from .core.url import parse_uri
 from .core.views import diagnostic_severity
 from .core.views import first_selection_region
@@ -409,7 +407,8 @@ class LspToggleHoverPopupsCommand(sublime_plugin.WindowCommand):
         sublime.set_timeout_async(partial(self._update_views_async, enable))
 
     def _has_hover_provider(self, view: sublime.View) -> bool:
-        return cast(int, view.settings().get(HOVER_PROVIDER_COUNT_KEY, 0)) > 0
+        listener = windows.listener_for_view(view)
+        return listener.hover_provider_count > 0 if listener else False
 
     def _update_views_async(self, enable: bool) -> None:
         window_manager = windows.lookup(self.window)


### PR DESCRIPTION
Instead it can be stored on the DocumentSyncListener instance, which is created once per view (by ST).

I think view settings should only be used to create context keys (`setting.lsp_active`) or to potentially interact with other packages (`lsp_uri` - not sure if that was the intention, but I think this setting is okay). The hover provider count is only an internal variable of the LSP package, so it doesn't really belong into the settings.