### PR TITLE
Add SystemVerilog language server setup guide

### DIFF
--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -685,6 +685,26 @@ Follow installation instructions on [LSP-svelte](https://github.com/sublimelsp/L
 
 Follow installation instructions on [LSP-SourceKit](https://github.com/sublimelsp/LSP-SourceKit).
 
+## SystemVerilog
+
+1. Install the [SystemVerilog](https://packagecontrol.io/packages/SystemVerilog) package from Package Control for syntax highlighting.
+2. Make sure you install the latest version of [Verible](https://github.com/chipsalliance/verible).
+3. Open `Preferences > Package Settings > LSP > Settings` and add the `"verible"` client configuration to the `"clients"`:
+
+    ```jsonc
+    {
+        "clients": {
+            "verible": {
+                "enabled": true,
+                "command": [
+                    "/PATH/TO/verible-verilog-ls"
+                ],
+                "selector": "source.systemverilog"
+            }
+        }
+    }
+    ```
+
 ## TAGML
 
 Follow installation instructions on [LSP-tagml](https://github.com/HuygensING/LSP-tagml).


### PR DESCRIPTION
# Description
I added instructions to the `language_servers.md` file on how to configure the Verible LS (probably the most mature, open source LS for SystemVerilog) in conjunction with the Sublime SystemVerilog syntax package.

# Demo
<img width="1920" alt="server-loaded" src="https://github.com/sublimelsp/LSP/assets/11639590/eb10c941-26cb-495c-ad1a-9a6214ea7bbb">
<img width="1920" alt="syntax-checking" src="https://github.com/sublimelsp/LSP/assets/11639590/12391807-dd24-4928-83ee-1b513972a691">
<img width="1920" alt="menu" src="https://github.com/sublimelsp/LSP/assets/11639590/b272c8fd-2434-4dd4-a165-069fd3b38b94">

I can also confirm formatting with `LSP: Format File` is working as expected.

Thanks for your feedback.