### PR TITLE
Add support for SnippetTextEdits

### DIFF
--- a/plugin/core/edit.py
+++ b/plugin/core/edit.py
@@ -1,13 +1,18 @@
 from .logging import debug
 from .protocol import Position
+from .protocol import SnippetTextEdit
 from .protocol import TextEdit
 from .protocol import UINT_MAX
 from .protocol import WorkspaceEdit
-from .typing import List, Dict, Optional, Tuple
+from .typing import List, Dict, Optional, Tuple, TypeGuard, Union
 import sublime
 
 
-WorkspaceChanges = Dict[str, Tuple[List[TextEdit], Optional[int]]]
+WorkspaceChanges = Dict[str, Tuple[List[Union[TextEdit, SnippetTextEdit]], Optional[int]]]
+
+
+def is_snippet_text_edit(edit: Union[TextEdit, SnippetTextEdit]) -> TypeGuard[SnippetTextEdit]:
+    return 'snippet' in edit and 'newText' not in edit
 
 
 def parse_workspace_edit(workspace_edit: WorkspaceEdit) -> WorkspaceChanges:
@@ -28,7 +33,7 @@ def parse_workspace_edit(workspace_edit: WorkspaceEdit) -> WorkspaceChanges:
         raw_changes = workspace_edit.get('changes')
         if isinstance(raw_changes, dict):
             for uri, edits in raw_changes.items():
-                changes[uri] = (edits, None)
+                changes[uri] = (edits, None)  # type: ignore
     return changes
 
 

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -6335,3 +6335,10 @@ CompletionEditRange = __CompletionList_itemDefaults_editRange_Type_1
 
 # Temporary for backward compatibility with LSP packages.
 RangeLsp = Range
+
+# Temporary for this PR as long as protocol types are not yet updated
+SnippetTextEdit = TypedDict('SnippetTextEdit', {
+    'range': Range,
+    'snippet': Dict[str, str],
+    'annotationId': NotRequired[ChangeAnnotationIdentifier]
+})

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -158,12 +158,13 @@ LSP_EDIT_DOCUMENT_CHANGES_3 = {
 class TextEditTests(unittest.TestCase):
 
     def test_parse_from_lsp(self):
-        (start, end, newText) = parse_text_edit(LSP_TEXT_EDIT)
+        (start, end, newText, is_snippet) = parse_text_edit(LSP_TEXT_EDIT)
         self.assertEqual(newText, 'newText\n')  # Without the \r
         self.assertEqual(start[0], 10)
         self.assertEqual(start[1], 4)
         self.assertEqual(end[0], 11)
         self.assertEqual(end[1], 3)
+        self.assertEqual(is_snippet, False)
 
 
 class WorkspaceEditTests(unittest.TestCase):


### PR DESCRIPTION
*Untested, but I think something like this could work*

CI will obviously fail until the protocol types are updated to the latest spec version.

This would probably make https://github.com/sublimelsp/LSP/commit/29100425f8c2635d7b33524519c4bf2bbd6ee86f obsolete at some point in the future, assuming that rust-analyzer switches from its custom SnippetTextEdit to the one from the LSP 3.18 specs.