### PR TITLE
Fix usage of sublime.score_selector

### DIFF
--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -840,11 +840,10 @@ class ClientConfig:
         syntax = view.syntax()
         if not syntax:
             return False
-        # Every part of a x.y.z scope seems to contribute 8.
-        # An empty selector result in a score of 1.
-        # A non-matching non-empty selector results in a score of 0.
-        # We want to match at least one part of an x.y.z, and we don't want to match on empty selectors.
-        return scheme in self.schemes and sublime.score_selector(syntax.scope, self.selector) >= 8
+        # We don't want to match on empty selectors.
+        if len(self.selector.strip()) == 0:
+            return False
+        return scheme in self.schemes and sublime.score_selector(syntax.scope, self.selector)
 
     def map_client_path_to_server_uri(self, path: str) -> str:
         if self.path_maps:

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -840,10 +840,10 @@ class ClientConfig:
         syntax = view.syntax()
         if not syntax:
             return False
-        # We don't want to match on empty selectors.
-        if len(self.selector.strip()) == 0:
+        selector = self.selector.strip()
+        if not selector:
             return False
-        return scheme in self.schemes and sublime.score_selector(syntax.scope, self.selector)
+        return scheme in self.schemes and sublime.score_selector(syntax.scope, selector) > 0
 
     def map_client_path_to_server_uri(self, path: str) -> str:
         if self.path_maps:


### PR DESCRIPTION
ST 4173 tweaks how selector scoring works resulting in LSP no longer functioning.

As per the comment there seems to be a misunderstanding of how `sublime.score_selector` works. The entire selector must always match for a non-zero score, so if the goal is to check if it's not empty and matches then checking for `>= 8` is simply wrong.