### PR TITLE
Enhancements for the rename panel

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -42,6 +42,7 @@ from .plugin.document_link import LspOpenLinkCommand
 from .plugin.documents import DocumentSyncListener
 from .plugin.documents import TextChangeListener
 from .plugin.edit import LspApplyDocumentEditCommand
+from .plugin.edit import LspApplyWorkspaceChangesCommand
 from .plugin.execute_command import LspExecuteCommand
 from .plugin.folding_range import LspFoldAllCommand
 from .plugin.folding_range import LspFoldCommand

--- a/boot.py
+++ b/boot.py
@@ -69,6 +69,7 @@ from .plugin.panels import LspToggleServerPanelCommand
 from .plugin.panels import LspUpdateLogPanelCommand
 from .plugin.panels import LspUpdatePanelCommand
 from .plugin.references import LspSymbolReferencesCommand
+from .plugin.rename import LspHideRenameButtonsCommand
 from .plugin.rename import LspSymbolRenameCommand
 from .plugin.save_command import LspSaveAllCommand
 from .plugin.save_command import LspSaveCommand

--- a/boot.py
+++ b/boot.py
@@ -42,7 +42,7 @@ from .plugin.document_link import LspOpenLinkCommand
 from .plugin.documents import DocumentSyncListener
 from .plugin.documents import TextChangeListener
 from .plugin.edit import LspApplyDocumentEditCommand
-from .plugin.edit import LspApplyWorkspaceChangesCommand
+from .plugin.edit import LspApplyWorkspaceEditCommand
 from .plugin.execute_command import LspExecuteCommand
 from .plugin.folding_range import LspFoldAllCommand
 from .plugin.folding_range import LspFoldCommand

--- a/plugin/core/panels.py
+++ b/plugin/core/panels.py
@@ -38,6 +38,7 @@ class PanelName:
 class PanelManager:
     def __init__(self, window: sublime.Window) -> None:
         self._window = window
+        self.rename_panel_buttons = None  # type: Optional[sublime.PhantomSet]
 
     def destroy_output_panels(self) -> None:
         for field in filter(lambda a: not a.startswith('__'), PanelName.__dict__.keys()):
@@ -91,6 +92,8 @@ class PanelManager:
         panel = self.create_output_panel(name)
         if not panel:
             return None
+        if name == PanelName.Rename:
+            self.rename_panel_buttons = sublime.PhantomSet(panel, "lsp_rename_buttons")
         settings = panel.settings()
         if result_file_regex:
             settings.set("result_file_regex", result_file_regex)

--- a/plugin/core/panels.py
+++ b/plugin/core/panels.py
@@ -1,6 +1,6 @@
 from .types import PANEL_FILE_REGEX
 from .types import PANEL_LINE_REGEX
-from .typing import Optional
+from .typing import Iterable, Optional
 import sublime
 
 
@@ -38,7 +38,7 @@ class PanelName:
 class PanelManager:
     def __init__(self, window: sublime.Window) -> None:
         self._window = window
-        self.rename_panel_buttons = None  # type: Optional[sublime.PhantomSet]
+        self._rename_panel_buttons = None  # type: Optional[sublime.PhantomSet]
 
     def destroy_output_panels(self) -> None:
         for field in filter(lambda a: not a.startswith('__'), PanelName.__dict__.keys()):
@@ -47,6 +47,7 @@ class PanelManager:
             if panel and panel.is_valid():
                 panel.settings().set("syntax", "Packages/Text/Plain text.tmLanguage")
                 self._window.destroy_output_panel(panel_name)
+        self._rename_panel_buttons = None
 
     def toggle_output_panel(self, panel_type: str) -> None:
         panel_name = "output.{}".format(panel_type)
@@ -93,7 +94,7 @@ class PanelManager:
         if not panel:
             return None
         if name == PanelName.Rename:
-            self.rename_panel_buttons = sublime.PhantomSet(panel, "lsp_rename_buttons")
+            self._rename_panel_buttons = sublime.PhantomSet(panel, "lsp_rename_buttons")
         settings = panel.settings()
         if result_file_regex:
             settings.set("result_file_regex", result_file_regex)
@@ -124,3 +125,7 @@ class PanelManager:
     def hide_diagnostics_panel_async(self) -> None:
         if self.is_panel_open(PanelName.Diagnostics):
             self.toggle_output_panel(PanelName.Diagnostics)
+
+    def update_rename_panel_buttons(self, phantoms: Iterable[sublime.Phantom]) -> None:
+        if self._rename_panel_buttons:
+            self._rename_panel_buttons.update(phantoms)

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -102,6 +102,18 @@ def get_line(window: sublime.Window, file_name: str, row: int) -> str:
         return linecache.getline(file_name, row + 1).strip()
 
 
+def get_line2(window: sublime.Window, file_name: str, row: int) -> str:
+    '''
+    Same as get_line, but don't strip away leading and trailing whitespace.
+    '''
+    view = window.find_open_file(file_name)
+    if view:
+        point = view.text_point(row, 0)
+        return view.substr(view.line(point))
+    else:
+        return linecache.getline(file_name, row + 1)
+
+
 def get_storage_path() -> str:
     """
     The "Package Storage" is a way to store server data without influencing the behavior of Sublime Text's "catalog".

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -86,7 +86,7 @@ class InvalidUriSchemeException(Exception):
         return "invalid URI scheme: {}".format(self.uri)
 
 
-def get_line(window: sublime.Window, file_name: str, row: int) -> str:
+def get_line(window: sublime.Window, file_name: str, row: int, strip: bool = True) -> str:
     '''
     Get the line from the buffer if the view is open, else get line from linecache.
     row - is 0 based. If you want to get the first line, you should pass 0.
@@ -95,23 +95,12 @@ def get_line(window: sublime.Window, file_name: str, row: int) -> str:
     if view:
         # get from buffer
         point = view.text_point(row, 0)
-        return view.substr(view.line(point)).strip()
+        line = view.substr(view.line(point))
     else:
         # get from linecache
         # linecache row is not 0 based, so we increment it by 1 to get the correct line.
-        return linecache.getline(file_name, row + 1).strip()
-
-
-def get_line2(window: sublime.Window, file_name: str, row: int) -> str:
-    '''
-    Same as get_line, but don't strip away leading and trailing whitespace.
-    '''
-    view = window.find_open_file(file_name)
-    if view:
-        point = view.text_point(row, 0)
-        return view.substr(view.line(point))
-    else:
-        return linecache.getline(file_name, row + 1)
+        line = linecache.getline(file_name, row + 1)
+    return line.strip() if strip else line
 
 
 def get_storage_path() -> str:

--- a/plugin/edit.py
+++ b/plugin/edit.py
@@ -1,5 +1,4 @@
 from .core.edit import parse_range
-from .core.edit import parse_workspace_edit
 from .core.logging import debug
 from .core.protocol import TextEdit
 from .core.protocol import WorkspaceEdit
@@ -35,7 +34,7 @@ class LspApplyWorkspaceEditCommand(LspWindowCommand):
         if not session:
             debug('Could not find session', session_name, 'required to apply WorkspaceEdit')
             return
-        session.apply_parsed_workspace_edits(parse_workspace_edit(edit))
+        sublime.set_timeout_async(lambda: session.apply_workspace_edit_async(edit))
 
 
 class LspApplyDocumentEditCommand(sublime_plugin.TextCommand):

--- a/plugin/edit.py
+++ b/plugin/edit.py
@@ -1,7 +1,8 @@
 from .core.edit import parse_range
-from .core.edit import WorkspaceChanges
+from .core.edit import parse_workspace_edit
 from .core.logging import debug
 from .core.protocol import TextEdit
+from .core.protocol import WorkspaceEdit
 from .core.registry import LspWindowCommand
 from .core.typing import List, Optional, Any, Generator, Iterable, Tuple
 from contextlib import contextmanager
@@ -27,14 +28,14 @@ def temporary_setting(settings: sublime.Settings, key: str, val: Any) -> Generat
         settings.set(key, prev_val)
 
 
-class LspApplyWorkspaceChangesCommand(LspWindowCommand):
+class LspApplyWorkspaceEditCommand(LspWindowCommand):
 
-    def run(self, session_name: str, workspace_changes: WorkspaceChanges) -> None:
+    def run(self, session_name: str, edit: WorkspaceEdit) -> None:
         session = self.session_by_name(session_name)
         if not session:
-            debug('Could not find session', session_name)
+            debug('Could not find session', session_name, 'required to apply WorkspaceEdit')
             return
-        session.apply_parsed_workspace_edits(workspace_changes)
+        session.apply_parsed_workspace_edits(parse_workspace_edit(edit))
 
 
 class LspApplyDocumentEditCommand(sublime_plugin.TextCommand):

--- a/plugin/edit.py
+++ b/plugin/edit.py
@@ -1,5 +1,8 @@
 from .core.edit import parse_range
+from .core.edit import WorkspaceChanges
+from .core.logging import debug
 from .core.protocol import TextEdit
+from .core.registry import LspWindowCommand
 from .core.typing import List, Optional, Any, Generator, Iterable, Tuple
 from contextlib import contextmanager
 import operator
@@ -22,6 +25,16 @@ def temporary_setting(settings: sublime.Settings, key: str, val: Any) -> Generat
     settings.erase(key)
     if has_prev_val and settings.get(key) != prev_val:
         settings.set(key, prev_val)
+
+
+class LspApplyWorkspaceChangesCommand(LspWindowCommand):
+
+    def run(self, session_name: str, workspace_changes: WorkspaceChanges) -> None:
+        session = self.session_by_name(session_name)
+        if not session:
+            debug('Could not find session', session_name)
+            return
+        session.apply_parsed_workspace_edits(workspace_changes)
 
 
 class LspApplyDocumentEditCommand(sublime_plugin.TextCommand):

--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -204,7 +204,7 @@ class LspSymbolRenameCommand(LspTextCommand):
         if choice == sublime.DIALOG_YES:
             session.apply_parsed_workspace_edits(changes)
         elif choice == sublime.DIALOG_NO:
-            self._render_rename_panel(changes, total_changes, file_count, session.config.name)
+            self._render_rename_panel(response, changes, total_changes, file_count, session.config.name)
 
     def _on_prepare_result(self, pos: int, response: Optional[PrepareRenameResult]) -> None:
         if response is None:
@@ -234,6 +234,7 @@ class LspSymbolRenameCommand(LspTextCommand):
 
     def _render_rename_panel(
         self,
+        workspace_edit: WorkspaceEdit,
         changes_per_uri: WorkspaceChanges,
         total_changes: int,
         file_count: int,
@@ -302,8 +303,8 @@ class LspSymbolRenameCommand(LspTextCommand):
             apply=sublime.command_url('chain', {
                 'commands': [
                     [
-                        'lsp_apply_workspace_changes',
-                        {'session_name': session_name, 'workspace_changes': changes_per_uri}
+                        'lsp_apply_workspace_edit',
+                        {'session_name': session_name, 'edit': workspace_edit}
                     ],
                     [
                         'hide_panel',

--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -28,11 +28,10 @@ BUTTONS_TEMPLATE = """
 <style>
     html {{
         background-color: transparent;
-        height: 2rem;
-        padding-top: 0.3rem;
+        margin-top: 0.5rem;
+        margin-bottom: 0.5rem;
     }}
     a {{
-        display: inline;
         line-height: 1.6rem;
         padding-left: 0.6rem;
         padding-right: 0.6rem;
@@ -57,7 +56,7 @@ BUTTONS_TEMPLATE = """
     }}
 </style>
 <body id='lsp-buttons'>
-    <a href='{apply}' class='primary'>Apply</a>
+    <a href='{apply}' class='primary'>Apply</a>&nbsp;
     <a href='{discard}'>Discard</a>
 </body>"""
 

--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -74,7 +74,7 @@ def is_range_response(result: PrepareRenameResult) -> TypeGuard[Range]:
 
 
 def utf16_to_code_points(s: str, col: int) -> int:
-    """ Converts from UTF-16 code units to Unicode code points, usable for string slicing. """
+    """Convert a position from UTF-16 code units to Unicode code points, usable for string slicing."""
     utf16_len = 0
     idx = 0
     for idx, c in enumerate(s):

--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -28,7 +28,7 @@ BUTTONS_TEMPLATE = """
 <style>
     html {{
         background-color: transparent;
-        margin-top: 0.5rem;
+        margin-top: 1.5rem;
         margin-bottom: 0.5rem;
     }}
     a {{
@@ -48,10 +48,7 @@ BUTTONS_TEMPLATE = """
         color: white;
         background-color: #636363;
     }}
-    a.primary {{
-        background-color: color(var(--accent) min-contrast(white 6.0));
-    }}
-    html.light a.primary {{
+    a.primary, html.light a.primary {{
         background-color: color(var(--accent) min-contrast(white 6.0));
     }}
 </style>
@@ -250,7 +247,7 @@ class LspSymbolRenameCommand(LspTextCommand):
             return
         to_render = []  # type: List[str]
         reference_document = []  # type: List[str]
-        header_lines = "{} changes across {} files.\n\n".format(total_changes, file_count)
+        header_lines = "{} changes across {} files.\n".format(total_changes, file_count)
         to_render.append(header_lines)
         reference_document.append(header_lines)
         ROWCOL_PREFIX = " {:>4}:{:<4} {}"
@@ -345,6 +342,5 @@ class LspHideRenameButtonsCommand(sublime_plugin.WindowCommand):
         wm = windows.lookup(self.window)
         if not wm:
             return
-        pm = wm.panel_manager
-        if pm:
-            pm.update_rename_panel_buttons([])
+        if wm.panel_manager:
+            wm.panel_manager.update_rename_panel_buttons([])

--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -294,10 +294,6 @@ class LspSymbolRenameCommand(LspTextCommand):
         selection.add(sublime.Region(0, panel.size()))
         panel.run_command('toggle_inline_diff')
         selection.clear()
-        buttons = pm.rename_panel_buttons
-        if not buttons:
-            return
-        buttons_position = sublime.Region(len(to_render[0]) - 1)
         BUTTONS_HTML = BUTTONS_TEMPLATE.format(
             apply=sublime.command_url('chain', {
                 'commands': [
@@ -317,8 +313,8 @@ class LspSymbolRenameCommand(LspTextCommand):
             }),
             discard=DISCARD_COMMAND_URL
         )
-        buttons.update([
-            sublime.Phantom(buttons_position, BUTTONS_HTML, sublime.LAYOUT_BLOCK)
+        pm.update_rename_panel_buttons([
+            sublime.Phantom(sublime.Region(len(to_render[0]) - 1), BUTTONS_HTML, sublime.LAYOUT_BLOCK)
         ])
 
 
@@ -350,8 +346,5 @@ class LspHideRenameButtonsCommand(sublime_plugin.WindowCommand):
         if not wm:
             return
         pm = wm.panel_manager
-        if not pm:
-            return
-        buttons = pm.rename_panel_buttons
-        if buttons:
-            buttons.update([])
+        if pm:
+            pm.update_rename_panel_buttons([])

--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -272,7 +272,7 @@ class LspSymbolRenameCommand(LspTextCommand):
                     if start_row == end_row and len(new_text_rows) == 1 and end_col < len(line_content):
                         new_line_content += line_content[end_col:]
                     to_render.append(
-                        ROWCOL_PREFIX.format(start_row + 1, start_col_utf16 + 1, new_line_content.strip() + "\n"))
+                        ROWCOL_PREFIX.format(start_row + 1, start_col + 1, new_line_content.strip() + "\n"))
                 else:
                     to_render.append(original_line)
         characters = "\n".join(to_render)

--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -266,11 +266,12 @@ class LspSymbolRenameCommand(LspTextCommand):
                 if scheme == "file" and line_content:
                     end_row, end_col_utf16 = parse_range(edit['range']['end'])
                     new_text_rows = edit['newText'].split('\n')
-                    end_col = start_col if end_col_utf16 <= start_col_utf16 else \
-                        utf16_to_code_points(line_content, end_col_utf16)
                     new_line_content = line_content[:start_col] + new_text_rows[0]
-                    if start_row == end_row and len(new_text_rows) == 1 and end_col < len(line_content):
-                        new_line_content += line_content[end_col:]
+                    if start_row == end_row and len(new_text_rows) == 1:
+                        end_col = start_col if end_col_utf16 <= start_col_utf16 else \
+                            utf16_to_code_points(line_content, end_col_utf16)
+                        if end_col < len(line_content):
+                            new_line_content += line_content[end_col:]
                     to_render.append(
                         ROWCOL_PREFIX.format(start_row + 1, start_col + 1, new_line_content.strip() + "\n"))
                 else:

--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -15,7 +15,7 @@ from .core.typing import Any, Optional, List, TypeGuard
 from .core.typing import cast
 from .core.url import parse_uri
 from .core.views import first_selection_region
-from .core.views import get_line
+from .core.views import get_line2
 from .core.views import range_to_region
 from .core.views import text_document_position_params
 from functools import partial
@@ -243,8 +243,8 @@ class LspSymbolRenameCommand(LspTextCommand):
             reference_document.append(filename_line)
             for edit in changes:
                 start_row, start_col_utf16 = parse_range(edit['range']['start'])
-                line_content = get_line(wm.window, file, start_row) if scheme == 'file' else '<no preview available>'
-                original_line = ROWCOL_PREFIX.format(start_row + 1, start_col_utf16 + 1, line_content + "\n")
+                line_content = get_line2(wm.window, file, start_row) if scheme == 'file' else '<no preview available>'
+                original_line = ROWCOL_PREFIX.format(start_row + 1, start_col_utf16 + 1, line_content.strip() + "\n")
                 reference_document.append(original_line)
                 if scheme == "file" and line_content:
                     end_row, end_col_utf16 = parse_range(edit['range']['end'])
@@ -253,7 +253,8 @@ class LspSymbolRenameCommand(LspTextCommand):
                     new_line_content = line_content[:start_col_utf16] + new_text_rows[0]
                     if start_row == end_row and len(new_text_rows) == 1 and end_col_utf16 < len(line_content):
                         new_line_content += line_content[end_col_utf16:]
-                    to_render.append(ROWCOL_PREFIX.format(start_row + 1, start_col_utf16 + 1, new_line_content + "\n"))
+                    to_render.append(
+                        ROWCOL_PREFIX.format(start_row + 1, start_col_utf16 + 1, new_line_content.strip() + "\n"))
                 else:
                     to_render.append(original_line)
         characters = "\n".join(to_render)

--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -15,7 +15,7 @@ from .core.typing import Any, Optional, List, TypeGuard
 from .core.typing import cast
 from .core.url import parse_uri
 from .core.views import first_selection_region
-from .core.views import get_line2
+from .core.views import get_line
 from .core.views import range_to_region
 from .core.views import text_document_position_params
 from functools import partial
@@ -243,7 +243,8 @@ class LspSymbolRenameCommand(LspTextCommand):
             reference_document.append(filename_line)
             for edit in changes:
                 start_row, start_col_utf16 = parse_range(edit['range']['start'])
-                line_content = get_line2(wm.window, file, start_row) if scheme == 'file' else '<no preview available>'
+                line_content = get_line(wm.window, file, start_row, strip=False) if scheme == 'file' else \
+                    '<no preview available>'
                 original_line = ROWCOL_PREFIX.format(start_row + 1, start_col_utf16 + 1, line_content.strip() + "\n")
                 reference_document.append(original_line)
                 if scheme == "file" and line_content:

--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -61,7 +61,7 @@ BUTTONS_TEMPLATE = """
     <a href='{discard}'>Discard</a>
 </body>"""
 
-DISCARD_COMMAND = sublime.command_url('chain', {
+DISCARD_COMMAND_URL = sublime.command_url('chain', {
     'commands': [
         ['hide_panel', {}],
         ['lsp_hide_rename_buttons', {}]
@@ -316,7 +316,7 @@ class LspSymbolRenameCommand(LspTextCommand):
                     ]
                 ]
             }),
-            discard=DISCARD_COMMAND
+            discard=DISCARD_COMMAND_URL
         )
         buttons.update([
             sublime.Phantom(buttons_position, BUTTONS_HTML, sublime.LAYOUT_BLOCK)

--- a/tests/test_rename_panel.py
+++ b/tests/test_rename_panel.py
@@ -1,0 +1,50 @@
+from LSP.plugin.rename import utf16_to_code_points
+import unittest
+
+
+class LspRenamePanelTests(unittest.TestCase):
+
+    def test_utf16_ascii(self):
+        s = 'abc'
+        self.assertEqual(utf16_to_code_points(s, 0), 0)
+        self.assertEqual(utf16_to_code_points(s, 1), 1)
+        self.assertEqual(utf16_to_code_points(s, 2), 2)
+        self.assertEqual(utf16_to_code_points(s, 3), 3)  # EOL after last character should count as its own code point
+        self.assertEqual(utf16_to_code_points(s, 1337), 3)  # clamp to EOL
+
+    def test_utf16_deseret_letter(self):
+        # https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocuments
+        s = 'a𐐀b'
+        self.assertEqual(len(s), 3)
+        self.assertEqual(utf16_to_code_points(s, 0), 0)
+        self.assertEqual(utf16_to_code_points(s, 1), 1)
+        self.assertEqual(utf16_to_code_points(s, 2), 1)  # 𐐀 needs 2 UTF-16 code units, so this is still at code point 1
+        self.assertEqual(utf16_to_code_points(s, 3), 2)
+        self.assertEqual(utf16_to_code_points(s, 4), 3)
+        self.assertEqual(utf16_to_code_points(s, 1337), 3)
+
+    def test_utf16_emoji(self):
+        s = 'a😀x'
+        self.assertEqual(len(s), 3)
+        self.assertEqual(utf16_to_code_points(s, 0), 0)
+        self.assertEqual(utf16_to_code_points(s, 1), 1)
+        self.assertEqual(utf16_to_code_points(s, 2), 1)
+        self.assertEqual(utf16_to_code_points(s, 3), 2)
+        self.assertEqual(utf16_to_code_points(s, 4), 3)
+        self.assertEqual(utf16_to_code_points(s, 1337), 3)
+
+    def test_utf16_emoji_zwj_sequence(self):
+        # https://unicode.org/emoji/charts/emoji-zwj-sequences.html
+        s = 'a😵‍💫x'
+        self.assertEqual(len(s), 5)
+        self.assertEqual(s, 'a\U0001f635\u200d\U0001f4abx')
+        # 😵‍💫 consists of 5 UTF-16 code units and Python treats it as 3 characters
+        self.assertEqual(utf16_to_code_points(s, 0), 0)  # a
+        self.assertEqual(utf16_to_code_points(s, 1), 1)  # \U0001f635
+        self.assertEqual(utf16_to_code_points(s, 2), 1)  # \U0001f635
+        self.assertEqual(utf16_to_code_points(s, 3), 2)  # \u200d (zero width joiner)
+        self.assertEqual(utf16_to_code_points(s, 4), 3)  # \U0001f4ab
+        self.assertEqual(utf16_to_code_points(s, 5), 3)  # \U0001f4ab
+        self.assertEqual(utf16_to_code_points(s, 6), 4)  # x
+        self.assertEqual(utf16_to_code_points(s, 7), 5)  # after x
+        self.assertEqual(utf16_to_code_points(s, 1337), 5)


### PR DESCRIPTION
1. Currently the "Dry Run" functionality for a multi-file rename operation is a bit awkward to use, because after you have looked at the rename locations which are shown in the panel, you need to run the rename command again, including typing of the new name, to actually do the rename. This PR adds "Apply" and "Discard" buttons into the panel to save a bit of time. In theory there could be wrong changes applied if you edit the view(s) first, before clicking the "Apply" button (because the document version is not mandatory in the LSP edits), but in that case I'd consider it to be the user's fault (or does anyone have an idea how to prevent it?). The buttons will automatically hide after they are clicked.

2. Changes are now displayed in the panel using Sublime's inline diff feature. Perhaps it could be reused later to add a preview for other "refactor" code actions.

    Small drawback: the diff rendering requires more vertical space (an empty line after each line is needed because otherwise ST diff rendering would combine the lines into a single block). But is it really a drawback? I think it's okay and the diff rendering is useful because it shows what will change on the line (admittedly the changes are obvious for a simple rename, but still...)

3. I've also adjusted the dialog labels:

    Before:

    ![before](https://github.com/sublimelsp/LSP/assets/6579999/a2b4c15d-a2f1-4a08-b7cb-0fe150babc05)

    After:

    ![after](https://github.com/sublimelsp/LSP/assets/6579999/25c217aa-c7c4-400f-9ceb-039075fd756f)

    Could someone on Mac/Linux confirm that passing the `title` parameter doesn't throw an error - I assume that it is simply ignored on Mac/Linux (?)
    > Title for the dialog. Windows only.