### PR TITLE
feat: toggle show diagnostics without server restart

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -250,4 +250,10 @@
         "args": {"async": true},
         "context": [{"key": "lsp.session_with_capability", "operand": "textDocumentSync.willSave | textDocumentSync.willSaveWaitUntil | codeActionProvider.codeActionKinds | documentFormattingProvider | documentRangeFormattingProvider"}]
     },
+    // Toggle showing diagnostics
+    {
+        "keys": ["alt+shift+l"],
+        "command": "lsp_toggle_show_diagnostics",
+        "args": {"toggle": null}
+    }
 ]

--- a/boot.py
+++ b/boot.py
@@ -73,6 +73,7 @@ from .plugin.save_command import LspSaveAllCommand
 from .plugin.save_command import LspSaveCommand
 from .plugin.selection_range import LspExpandSelectionCommand
 from .plugin.semantic_highlighting import LspShowScopeNameCommand
+from .plugin.session_view import LspToggleShowDiagnosticsCommand
 from .plugin.symbols import LspDocumentSymbolsCommand
 from .plugin.symbols import LspSelectionAddCommand
 from .plugin.symbols import LspSelectionClearCommand

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -354,7 +354,6 @@ class SessionView:
                 self.view.erase_regions(data.key)
 
     def _hide_diagnostics(self):
-        print('_hide_diagnostics')
         for severity in reversed(range(1, len(DIAGNOSTIC_SEVERITY) + 1)):
             for multiline in (True, False):
                 key = self.diagnostics_key(severity, multiline)
@@ -365,7 +364,6 @@ class SessionView:
                     self.view.erase_regions(data.key)
 
     def _show_diagnostics(self):
-        print('_show_diagnostics')
         self.present_diagnostics_async(is_view_visible=True, data_per_severity=self._data_per_severity)
 
     def on_request_started_async(self, request_id: int, request: Request) -> None:


### PR DESCRIPTION
referencing https://github.com/sublimelsp/LSP/issues/2161#issuecomment-1935350667

Introduce the ability to toggle the display of diagnostics without restarting the server

LSP-pyright's output can be quite distracting when trying to read the code to understand it before making changes.

Current method to hide the output, setting `show_diagnostics_severity_level` to `0`, causes the server to restart which can take quite a while with lsp-pyright. Which can be very frustrating and slows down development.

Even worse is that there is no indication that the server is still starting up, so i have to wait longer to make sure there are no errors as opposed to the server still starting up


How it works is by caching the latest diagnostic information. When toggled off, it removes the regions, and when toggled on again, it re-adds the regions by mimicking that new diagnostic information was received


This PR is more a low-quality proof of concept as I don't know the LSP code-base enough nor whats required to contribute correctly

