### PR TITLE
Keep tab selection and focus when applying WorkspaceEdit

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1779,8 +1779,8 @@ class Session(TransportCallbacks):
                 self.open_uri_async(uri).then(functools.partial(self._apply_text_edits, edits, view_version, uri))
             )
         return Promise.all(promises).then(
-            lambda _: self._check_select_sheets(selected_sheets)).then(
-            lambda _: self._check_focus_sheet(active_sheet))
+            lambda _: self._set_selected_sheets(selected_sheets)).then(
+            lambda _: self._set_focused_sheet(active_sheet))
 
     def _apply_text_edits(
         self, edits: List[TextEdit], view_version: Optional[int], uri: str, view: Optional[sublime.View]
@@ -1790,11 +1790,11 @@ class Session(TransportCallbacks):
             return
         apply_text_edits(view, edits, required_view_version=view_version)
 
-    def _check_select_sheets(self, sheets: List[sublime.Sheet]) -> None:
+    def _set_selected_sheets(self, sheets: List[sublime.Sheet]) -> None:
         if len(sheets) > 1 and len(self.window.selected_sheets()) != len(sheets):
             self.window.select_sheets(sheets)
 
-    def _check_focus_sheet(self, sheet: Optional[sublime.Sheet]) -> None:
+    def _set_focused_sheet(self, sheet: Optional[sublime.Sheet]) -> None:
         if sheet and sheet != self.window.active_sheet():
             self.window.focus_sheet(sheet)
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1771,12 +1771,13 @@ class Session(TransportCallbacks):
         return self.apply_parsed_workspace_edits(parse_workspace_edit(edit))
 
     def apply_parsed_workspace_edits(self, changes: WorkspaceChanges) -> Promise[None]:
+        sheet = self.window.active_sheet()
         promises = []  # type: List[Promise[None]]
         for uri, (edits, view_version) in changes.items():
             promises.append(
                 self.open_uri_async(uri).then(functools.partial(self._apply_text_edits, edits, view_version, uri))
             )
-        return Promise.all(promises).then(lambda _: None)
+        return Promise.all(promises).then(lambda _: self._check_focus_sheet(sheet))
 
     def _apply_text_edits(
         self, edits: List[TextEdit], view_version: Optional[int], uri: str, view: Optional[sublime.View]
@@ -1785,6 +1786,10 @@ class Session(TransportCallbacks):
             print('LSP: ignoring edits due to no view for uri: {}'.format(uri))
             return
         apply_text_edits(view, edits, required_view_version=view_version)
+
+    def _check_focus_sheet(self, sheet: Optional[sublime.Sheet]) -> None:
+        if sheet and sheet != self.window.active_sheet():
+            self.window.focus_sheet(sheet)
 
     def decode_semantic_token(
             self, token_type_encoded: int, token_modifiers_encoded: int) -> Tuple[str, List[str], Optional[str]]:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1759,8 +1759,7 @@ class Session(TransportCallbacks):
             arguments = command.get("arguments")
             if arguments is not None:
                 execute_command['arguments'] = arguments
-            return promise.then(
-                lambda _: self.execute_command(execute_command, progress=False, view=view))
+            return promise.then(lambda _: self.execute_command(execute_command, progress=False, view=view))
         return promise
 
     def apply_workspace_edit_async(self, edit: WorkspaceEdit) -> Promise[None]:
@@ -1778,9 +1777,9 @@ class Session(TransportCallbacks):
             promises.append(
                 self.open_uri_async(uri).then(functools.partial(self._apply_text_edits, edits, view_version, uri))
             )
-        return Promise.all(promises).then(
-            lambda _: self._set_selected_sheets(selected_sheets)).then(
-            lambda _: self._set_focused_sheet(active_sheet))
+        return Promise.all(promises) \
+            .then(lambda _: self._set_selected_sheets(selected_sheets)) \
+            .then(lambda _: self._set_focused_sheet(active_sheet))
 
     def _apply_text_edits(
         self, edits: List[TextEdit], view_version: Optional[int], uri: str, view: Optional[sublime.View]
@@ -1926,8 +1925,8 @@ class Session(TransportCallbacks):
 
     def m_workspace_applyEdit(self, params: Any, request_id: Any) -> None:
         """handles the workspace/applyEdit request"""
-        self.apply_workspace_edit_async(params.get('edit', {})).then(
-            lambda _: self.send_response(Response(request_id, {"applied": True})))
+        self.apply_workspace_edit_async(params.get('edit', {})) \
+            .then(lambda _: self.send_response(Response(request_id, {"applied": True})))
 
     def m_workspace_codeLens_refresh(self, _: Any, request_id: Any) -> None:
         """handles the workspace/codeLens/refresh request"""

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1791,7 +1791,7 @@ class Session(TransportCallbacks):
         apply_text_edits(view, edits, required_view_version=view_version)
 
     def _check_select_sheets(self, sheets: List[sublime.Sheet]) -> None:
-        if len(sheets) > 1 == len(self.window.selected_sheets()):
+        if len(sheets) > 1 and len(self.window.selected_sheets()) != len(sheets):
             self.window.select_sheets(sheets)
 
     def _check_focus_sheet(self, sheet: Optional[sublime.Sheet]) -> None:

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -195,8 +195,10 @@ class LspHoverCommand(LspTextCommand):
             if target:
                 link_promises.append(Promise.resolve(link))
             elif sv.has_capability_async("documentLinkProvider.resolveProvider"):
-                link_promises.append(sv.session.send_request_task(Request.resolveDocumentLink(link, sv.view)).then(
-                    lambda link: self._on_resolved_link(sv.session_buffer, link)))
+                link_promises.append(
+                    sv.session.send_request_task(Request.resolveDocumentLink(link, sv.view))
+                    .then(lambda link: self._on_resolved_link(sv.session_buffer, link))
+                )
         if link_promises:
             Promise.all(link_promises).then(partial(self._on_all_document_links_resolved, listener, point))
 

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -210,8 +210,8 @@ class TextDocumentTestCase(DeferrableTestCase):
     def await_run_code_action(self, code_action: Dict[str, Any]) -> Generator:
         promise = YieldPromise()
         sublime.set_timeout_async(
-            lambda: self.session.run_code_action_async(code_action, progress=False, view=self.view).then(
-                promise.fulfill))
+            lambda: self.session.run_code_action_async(code_action, progress=False, view=self.view)
+            .then(promise.fulfill))
         yield from self.await_promise(promise)
 
     def set_response(self, method: str, response: Any) -> None:


### PR DESCRIPTION
Prevent that the tab selection changes if a WorkspaceEdit affects files that are not currently open in the window (because `window.open_file()` focuses the new tab).

