### PR TITLE
Fix URI format for res scheme

### DIFF
--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -855,7 +855,7 @@ class ClientConfig:
 
     def map_server_uri_to_client_path(self, uri: str) -> str:
         scheme, path = parse_uri(uri)
-        if scheme != "file":
+        if scheme not in ("file", "res"):
             raise ValueError("{}: {} URI scheme is unsupported".format(uri, scheme))
         if self.path_maps:
             for path_map in self.path_maps:

--- a/plugin/core/url.py
+++ b/plugin/core/url.py
@@ -80,7 +80,7 @@ def _to_resource_uri(path: str, prefix: str) -> str:
 
     See: https://github.com/sublimehq/sublime_text/issues/3742
     """
-    return "res://Packages{}".format(pathname2url(path[len(prefix):]))
+    return "res:/Packages{}".format(pathname2url(path[len(prefix):]))
 
 
 def _uppercase_driveletter(match: Any) -> str:

--- a/plugin/locationpicker.py
+++ b/plugin/locationpicker.py
@@ -47,7 +47,7 @@ def open_basic_file(
     if uri.startswith("file:"):
         filename = session.config.map_server_uri_to_client_path(uri)
     else:
-        prefix = 'res://Packages'  # Note: keep in sync with core/url.py#_to_resource_uri
+        prefix = 'res:/Packages'  # Note: keep in sync with core/url.py#_to_resource_uri
         assert uri.startswith(prefix)
         filename = sublime.packages_path() + url2pathname(uri[len(prefix):])
         # Window.open_file can only focus and scroll to a location in a resource file if it is already opened

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -62,7 +62,7 @@ class MultiplatformTests(unittest.TestCase):
 
     def test_resource_path(self):
         uri = filename_to_uri(os.path.join(sublime.installed_packages_path(), "Package Control", "dir", "file.py"))
-        self.assertEqual(uri, "res://Packages/Package%20Control/dir/file.py")
+        self.assertEqual(uri, "res:/Packages/Package%20Control/dir/file.py")
 
     def test_buffer_uri(self):
         view = sublime.active_window().active_view()


### PR DESCRIPTION
With a recent Pyright version, some features don't work (i.e. error in console or error dialog) for package ressource files (View Package File from the command palette).

This is because we use `Packages` as the authority name in `res:` URIs, and the authority is converted to lowercase by vscode-uri library in the server responses. Instead, we should move `Packages` to be part of the `path` component of the URI and leave `authority` empty.

See: https://github.com/microsoft/pyright/issues/7495

---

The only case where I can find `res://` being used in the Sublime Text API is in minihtml for the `<img>` element, see https://www.sublimetext.com/docs/minihtml.html#tags:

> `<img>` — supports PNG, JPG and GIF images from `file://`, `res://` and `data:` URLs.

For example with Terminus installed (as `.sublime-package` from Package Control), try in the console:
- works:
    ```python
    view.show_popup('<img src="res://Packages/Terminus/images/link.png"/>')
    ```
- doesn't work:
    ```python
    view.show_popup('<img src="res:/Packages/Terminus/images/link.png"/>')
    ```

But I consider this a bug or bad design in ST, they also should better support/use a single slash in `res` URIs.

*Edit*: The builtin `run_macro_file` command also supports `res://` URIs for its command argument.