### PR TITLE
Fix failing python 3.8 unittests on MacOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,8 +24,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - if: ${{ matrix.os == 'macOS-latest' }}
-        run: brew unlink openssl
       - uses: SublimeText/UnitTesting/actions/setup@v1
       - uses: SublimeText/UnitTesting/actions/run-tests@v1
         with:

--- a/tests/test_configurations.py
+++ b/tests/test_configurations.py
@@ -1,12 +1,15 @@
+import sublime
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+from unittesting import ViewTestCase
+
 from LSP.plugin.core.configurations import WindowConfigManager
 from test_mocks import DISABLED_CONFIG
 from test_mocks import TEST_CONFIG
-from unittest.mock import MagicMock
-import sublime
-import unittest
 
 
-class GlobalConfigManagerTests(unittest.TestCase):
+class GlobalConfigManagerTests(TestCase):
 
     def test_empty_configs(self):
         window_mgr = WindowConfigManager(sublime.active_window(), {})
@@ -24,35 +27,29 @@ class GlobalConfigManagerTests(unittest.TestCase):
         self.assertFalse(list(window_mgr.all.values())[0].enabled)
 
 
-class WindowConfigManagerTests(unittest.TestCase):
+class WindowConfigManagerTests(ViewTestCase):
 
     def test_no_configs(self):
-        view = sublime.active_window().active_view()
-        self.assertIsNotNone(view)
-        assert view
-        manager = WindowConfigManager(sublime.active_window(), {})
-        self.assertEqual(list(manager.match_view(view)), [])
+        self.assertIsNotNone(self.view)
+        self.assertIsNotNone(self.window)
+        manager = WindowConfigManager(self.window, {})
+        self.assertEqual(list(manager.match_view(self.view)), [])
 
     def test_with_single_config(self):
-        window = sublime.active_window()
-        view = window.active_view()
-        self.assertIsNotNone(view)
-        assert view
-        manager = WindowConfigManager(window, {TEST_CONFIG.name: TEST_CONFIG})
-        view.syntax = MagicMock(return_value=sublime.Syntax(
+        self.assertIsNotNone(self.view)
+        self.assertIsNotNone(self.window)
+        self.view.settings().set("lsp_uri", "file:///foo/bar.txt")
+        self.view.syntax = MagicMock(return_value=sublime.Syntax(
             path="Packages/Text/Plain text.tmLanguage",
             name="Plain Text",
             scope="text.plain",
             hidden=False
         ))
-        view.settings().set("lsp_uri", "file:///foo/bar.txt")
-        self.assertEqual(list(manager.match_view(view)), [TEST_CONFIG])
+        manager = WindowConfigManager(self.window, {TEST_CONFIG.name: TEST_CONFIG})
+        self.assertEqual(list(manager.match_view(self.view)), [TEST_CONFIG])
 
     def test_applies_project_settings(self):
-        window = sublime.active_window()
-        view = window.active_view()
-        assert view
-        window.project_data = MagicMock(return_value={
+        self.window.project_data = MagicMock(return_value={
             "settings": {
                 "LSP": {
                     "test": {
@@ -61,24 +58,22 @@ class WindowConfigManagerTests(unittest.TestCase):
                 }
             }
         })
-        manager = WindowConfigManager(window, {DISABLED_CONFIG.name: DISABLED_CONFIG})
-        view.syntax = MagicMock(return_value=sublime.Syntax(
+        self.view.settings().set("lsp_uri", "file:///foo/bar.txt")
+        self.view.syntax = MagicMock(return_value=sublime.Syntax(
             path="Packages/Text/Plain text.tmLanguage",
             name="Plain Text",
             scope="text.plain",
             hidden=False
         ))
-        view.settings().set("lsp_uri", "file:///foo/bar.txt")
-        configs = list(manager.match_view(view))
+        manager = WindowConfigManager(self.window, {DISABLED_CONFIG.name: DISABLED_CONFIG})
+        configs = list(manager.match_view(self.view))
         self.assertEqual(len(configs), 1)
         config = configs[0]
         self.assertEqual(DISABLED_CONFIG.name, config.name)
         self.assertTrue(config.enabled)
 
     def test_disables_temporarily(self):
-        window = sublime.active_window()
-        view = window.active_view()
-        window.project_data = MagicMock(return_value={
+        self.window.project_data = MagicMock(return_value={
             "settings": {
                 "LSP": {
                     "test": {
@@ -88,7 +83,7 @@ class WindowConfigManagerTests(unittest.TestCase):
             }
         })
 
-        manager = WindowConfigManager(window, {DISABLED_CONFIG.name: DISABLED_CONFIG})
+        manager = WindowConfigManager(self.window, {DISABLED_CONFIG.name: DISABLED_CONFIG})
         # disables config in-memory
         manager.disable_config(DISABLED_CONFIG.name, only_for_session=True)
-        self.assertFalse(any(manager.match_view(view)))
+        self.assertFalse(any(manager.match_view(self.view)))


### PR DESCRIPTION
This commit adopts `unittesting.ViewTestCase` to run view related test cases.

ViewTestCase ...

1. provides `view` and `window` members pointing to a dedicated view, being created for testing.
2. ensures not to close empty windows, which was probably the most likely reason for unittests failing before on MacOS.