### PR TITLE
Print messages from window/logMessage into console instead of LSP log panel

### DIFF
--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -216,6 +216,8 @@ class MessageType(IntEnum):
     """ An information message. """
     Log = 4
     """ A log message. """
+    Debug = 5
+    """ A debug message. """
 
 
 class TextDocumentSyncKind(IntEnum):

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -46,6 +46,7 @@ from .protocol import InitializeResult
 from .protocol import InsertTextMode
 from .protocol import Location
 from .protocol import LocationLink
+from .protocol import LogMessageParams
 from .protocol import LSPAny
 from .protocol import LSPErrorCodes
 from .protocol import LSPObject
@@ -1918,7 +1919,7 @@ class Session(TransportCallbacks):
         """handles the window/showMessage notification"""
         self.call_manager('handle_show_message', self, params)
 
-    def m_window_logMessage(self, params: Any) -> None:
+    def m_window_logMessage(self, params: LogMessageParams) -> None:
         """handles the window/logMessage notification"""
         self.call_manager('handle_log_message', self, params)
 

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -14,6 +14,7 @@ from .panels import PanelManager
 from .panels import PanelName
 from .protocol import DocumentUri
 from .protocol import Error
+from .protocol import LogMessageParams
 from .protocol import MessageType
 from .sessions import AbstractViewListener
 from .sessions import get_plugin
@@ -414,7 +415,7 @@ class WindowManager(Manager, WindowConfigChangeListener):
             self.panel_manager.destroy_output_panels()
             self.panel_manager = None
 
-    def handle_log_message(self, session: Session, params: Any) -> None:
+    def handle_log_message(self, session: Session, params: LogMessageParams) -> None:
         if not userprefs().log_debug:
             return
         message_type = params['type']

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -14,6 +14,7 @@ from .panels import PanelManager
 from .panels import PanelName
 from .protocol import DocumentUri
 from .protocol import Error
+from .protocol import MessageType
 from .sessions import AbstractViewListener
 from .sessions import get_plugin
 from .sessions import Logger
@@ -414,7 +415,20 @@ class WindowManager(Manager, WindowConfigChangeListener):
             self.panel_manager = None
 
     def handle_log_message(self, session: Session, params: Any) -> None:
-        self.handle_server_message_async(session.config.name, extract_message(params))
+        if not userprefs().log_debug:
+            return
+        message_type = params['type']
+        level = {
+            MessageType.Error: "ERROR",
+            MessageType.Warning: "WARNING",
+            MessageType.Info: "INFO",
+            MessageType.Log: "LOG",
+            MessageType.Debug: "DEBUG"
+        }.get(message_type, "?")
+        message = params['message']
+        print("{}: {}: {}".format(session.config.name, level, message))
+        if message_type == MessageType.Error:
+            self.window.status_message("{}: {}".format(session.config.name, message))
 
     def handle_stderr_log(self, session: Session, message: str) -> None:
         self.handle_server_message_async(session.config.name, message)


### PR DESCRIPTION
I think it's not very useful to print those messages into the LSP log panel, in addition to the payload log. Those lines are just redundant there, for example
```
LSP-pyright: Received change text document command for closed file file:///d%3A/code/Python/LspTest/main.py
:: [22:05:28.199] <-  LSP-pyright window/logMessage: {'message': 'Received change text document command for closed file file:///d%3A/code/Python/LspTest/main.py', 'type': 1}
```

Instead, if `"log_debug"` is enabled, I suggest to log them into the console, similar to the other log/debug messages like
```
LSP: enabled configs: [...]
LSP: starting [...]
LSP: LSP-pyright: supported code action kinds: [...]
```
Error messages are additionally printed to the status bar (only if `"log_debug"` setting is enabled).