### PR TITLE
[Docs] Change default godot-editor port 

### DIFF
--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -205,7 +205,7 @@ Follow installation instructions on [LSP-gopls](https://github.com/sublimelsp/LS
             "godot-lsp": {
                 "enabled": true,
                 "command": ["/PATH/TO/godot-editor.exe"], // Update the PATH
-                "tcp_port": 6008,
+                "tcp_port": 6005,
                 "selector": "source.gdscript",
             }
         }

--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -205,7 +205,7 @@ Follow installation instructions on [LSP-gopls](https://github.com/sublimelsp/LS
             "godot-lsp": {
                 "enabled": true,
                 "command": ["/PATH/TO/godot-editor.exe"], // Update the PATH
-                "tcp_port": 6005,
+                "tcp_port": 6005, // Older versions of Godot(3.x) use port 6008
                 "selector": "source.gdscript",
             }
         }


### PR DESCRIPTION
closes #2445

Use default port for LSP suggested by godot-editor ->
https://docs.godotengine.org/en/stable/tutorials/editor/external_editor.html#lsp-dap-support