### PR TITLE
Fix Discord link

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -66,4 +66,4 @@ nav:
 extra:
   social:
     - icon: fontawesome/brands/discord
-      link: https://discordapp.com/channels/280102180189634562/645268178397560865
+      link: https://discord.gg/TZ5WN8t


### PR DESCRIPTION
Reported on Discord.

> FichteFoll — Yesterday at 11:31 AM
FYI, I just noticed that you have a discord link to a channel in the footer of the docs (i.e. https://lsp.sublimetext.io/). This does not work for people not already part of the server. Please use the invite link in the channel topic instead (also mentioned in