### PR TITLE
fix: check semantic capability through session buffer

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1815,8 +1815,8 @@ class Session(TransportCallbacks):
 
     def decode_semantic_token(
         self,
-        types_legend: Tuple[str],
-        modifiers_legend: Tuple[str],
+        types_legend: Tuple[str, ...],
+        modifiers_legend: Tuple[str, ...],
         token_type_encoded: int,
         token_modifiers_encoded: int
     ) -> Tuple[str, List[str], Optional[str]]:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1814,9 +1814,12 @@ class Session(TransportCallbacks):
             self.window.focus_sheet(sheet)
 
     def decode_semantic_token(
-            self, token_type_encoded: int, token_modifiers_encoded: int) -> Tuple[str, List[str], Optional[str]]:
-        types_legend = tuple(cast(List[str], self.get_capability('semanticTokensProvider.legend.tokenTypes')))
-        modifiers_legend = tuple(cast(List[str], self.get_capability('semanticTokensProvider.legend.tokenModifiers')))
+        self,
+        types_legend: Tuple[List[str]],
+        modifiers_legend: Tuple[List[str]],
+        token_type_encoded: int,
+        token_modifiers_encoded: int
+    ) -> Tuple[str, List[str], Optional[str]]:
         return decode_semantic_token(
             types_legend, modifiers_legend, self._semantic_tokens_map, token_type_encoded, token_modifiers_encoded)
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1815,8 +1815,8 @@ class Session(TransportCallbacks):
 
     def decode_semantic_token(
         self,
-        types_legend: Tuple[List[str]],
-        modifiers_legend: Tuple[List[str]],
+        types_legend: Tuple[str],
+        modifiers_legend: Tuple[str],
         token_type_encoded: int,
         token_modifiers_encoded: int
     ) -> Tuple[str, List[str], Optional[str]]:

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -630,6 +630,8 @@ class SessionBuffer:
         scope_regions = dict()  # type: Dict[int, Tuple[str, List[sublime.Region]]]
         prev_line = 0
         prev_col_utf16 = 0
+        types_legend = tuple(cast(List[str], self.get_capability('semanticTokensProvider.legend.tokenTypes')))
+        modifiers_legend = tuple(cast(List[str], self.get_capability('semanticTokensProvider.legend.tokenModifiers')))
         for idx in range(0, len(self.semantic_tokens.data), 5):
             delta_line = self.semantic_tokens.data[idx]
             delta_start_utf16 = self.semantic_tokens.data[idx + 1]
@@ -644,7 +646,7 @@ class SessionBuffer:
             prev_line = line
             prev_col_utf16 = col_utf16
             token_type, token_modifiers, scope = self.session.decode_semantic_token(
-                token_type_encoded, token_modifiers_encoded)
+                types_legend, modifiers_legend, token_type_encoded, token_modifiers_encoded)
             if scope is None:
                 # We can still use the meta scope and draw highlighting regions for custom token types if there is a
                 # color scheme rule for this particular token type.


### PR DESCRIPTION
It's always more correct to first check capability through session buffer in case server registers capability dynamically with a selector.

Resolves #2452