### PR TITLE
Import __future__ annotations

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 import sublime
 import sublime_plugin

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .core.promise import Promise
 from .core.protocol import CodeAction
 from .core.protocol import CodeActionKind

--- a/plugin/code_lens.py
+++ b/plugin/code_lens.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .core.constants import CODE_LENS_ENABLED_KEY
 from .core.protocol import CodeLens
 from .core.protocol import CodeLensExtended

--- a/plugin/color.py
+++ b/plugin/color.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .core.edit import apply_text_edits
 from .core.protocol import ColorInformation
 from .core.protocol import ColorPresentation

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .core.constants import COMPLETION_KINDS
 from .core.edit import apply_text_edits
 from .core.logging import debug
@@ -28,17 +29,17 @@ from .core.views import text_document_position_params
 from .core.views import update_lsp_popup
 from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
 from typing import cast
-from typing_extensions import TypeGuard
+from typing_extensions import TypeAlias, TypeGuard
 import functools
 import html
 import sublime
 import weakref
 import webbrowser
 
-SessionName = str
-CompletionResponse = Union[List[CompletionItem], CompletionList, None]
-ResolvedCompletions = Tuple[Union[CompletionResponse, Error], 'weakref.ref[Session]']
-CompletionsStore = Tuple[List[CompletionItem], CompletionItemDefaults]
+SessionName: TypeAlias = str
+CompletionResponse: TypeAlias = Union[List[CompletionItem], CompletionList, None]
+ResolvedCompletions: TypeAlias = Tuple[Union[CompletionResponse, Error], 'weakref.ref[Session]']
+CompletionsStore: TypeAlias = Tuple[List[CompletionItem], CompletionItemDefaults]
 
 
 def format_completion(
@@ -199,7 +200,7 @@ class QueryCompletionsTask:
         return promise.then(lambda response: self._on_completion_response_async(response, request_id, weak_session))
 
     def _on_completion_response_async(
-        self, response: CompletionResponse, request_id: int, weak_session: 'weakref.ref[Session]'
+        self, response: CompletionResponse, request_id: int, weak_session: weakref.ref[Session]
     ) -> ResolvedCompletions:
         self._pending_completion_requests.pop(request_id, None)
         return (response, weak_session)

--- a/plugin/configuration.py
+++ b/plugin/configuration.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .core.registry import windows
 from .core.settings import client_configs
 from .core.windows import WindowManager

--- a/plugin/core/active_request.py
+++ b/plugin/core/active_request.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .sessions import SessionViewProtocol
 from .progress import ProgressReporter
 from .progress import ViewProgressReporter

--- a/plugin/core/collections.py
+++ b/plugin/core/collections.py
@@ -1,6 +1,7 @@
 """
 Module with additional collections.
 """
+from __future__ import annotations
 from copy import deepcopy
 from typing import Any, Dict, Generator, Optional
 import sublime

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .logging import debug
 from .logging import exception_log
 from .logging import printf

--- a/plugin/core/constants.py
+++ b/plugin/core/constants.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .protocol import CodeActionKind
 from .protocol import CompletionItemKind
 from .protocol import DiagnosticSeverity

--- a/plugin/core/css.py
+++ b/plugin/core/css.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Optional
 import sublime
 

--- a/plugin/core/diagnostics_storage.py
+++ b/plugin/core/diagnostics_storage.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .protocol import Diagnostic, DiagnosticSeverity, DocumentUri
 from .url import parse_uri
 from .views import diagnostic_severity

--- a/plugin/core/edit.py
+++ b/plugin/core/edit.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .logging import debug
 from .protocol import Position
 from .protocol import TextEdit

--- a/plugin/core/file_watcher.py
+++ b/plugin/core/file_watcher.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .protocol import FileChangeType
 from .protocol import WatchKind
 from abc import ABCMeta

--- a/plugin/core/file_watcher.py
+++ b/plugin/core/file_watcher.py
@@ -59,7 +59,7 @@ class FileWatcher(metaclass=ABCMeta):
         events: List[FileWatcherEventType],
         ignores: List[str],
         handler: FileWatcherProtocol
-    ) -> 'FileWatcher':
+    ) -> FileWatcher:
         """
         Creates a new instance of the file watcher.
 

--- a/plugin/core/input_handlers.py
+++ b/plugin/core/input_handlers.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .constants import ST_VERSION
 from abc import ABCMeta
 from abc import abstractmethod

--- a/plugin/core/logging.py
+++ b/plugin/core/logging.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Any
 import traceback
 import inspect

--- a/plugin/core/message_request_handler.py
+++ b/plugin/core/message_request_handler.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .protocol import MessageType
 from .protocol import Response
 from .protocol import ShowMessageRequestParams

--- a/plugin/core/open.py
+++ b/plugin/core/open.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .constants import ST_VERSION
 from .logging import exception_log
 from .promise import Promise

--- a/plugin/core/panels.py
+++ b/plugin/core/panels.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .types import PANEL_FILE_REGEX
 from .types import PANEL_LINE_REGEX
 from typing import Iterable, Optional

--- a/plugin/core/paths.py
+++ b/plugin/core/paths.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .protocol import DocumentUri
 from .sessions import Session
 from .views import parse_uri

--- a/plugin/core/progress.py
+++ b/plugin/core/progress.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Optional, Union
 import sublime
 

--- a/plugin/core/promise.py
+++ b/plugin/core/promise.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Callable, Generic, List, Optional, Protocol, Tuple, TypeVar, Union
 import functools
 import threading

--- a/plugin/core/promise.py
+++ b/plugin/core/promise.py
@@ -66,7 +66,7 @@ class Promise(Generic[T]):
     """
 
     @staticmethod
-    def resolve(resolve_value: S) -> 'Promise[S]':
+    def resolve(resolve_value: S) -> Promise[S]:
         """Immediately resolves a Promise.
 
         Convenience function for creating a Promise that gets immediately
@@ -100,7 +100,7 @@ class Promise(Generic[T]):
 
     # Could also support passing plain S.
     @staticmethod
-    def all(promises: List['Promise[S]']) -> 'Promise[List[S]]':
+    def all(promises: List[Promise[S]]) -> Promise[List[S]]:
         """
         Takes a list of promises and returns a Promise that gets resolved when all promises
         gets resolved.
@@ -148,7 +148,7 @@ class Promise(Generic[T]):
             return 'Promise({})'.format(self.value)
         return 'Promise(<pending>)'
 
-    def then(self, onfullfilled: FullfillFunc[T, TResult]) -> 'Promise[TResult]':
+    def then(self, onfullfilled: FullfillFunc[T, TResult]) -> Promise[TResult]:
         """Create a new promise and chain it with this promise.
 
         When this promise gets resolved, the callback will be called with the

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .typing import StrEnum
 from enum import IntEnum, IntFlag
 from functools import total_ordering
@@ -6036,133 +6037,133 @@ class Request(Generic[R]):
         self.partial_results = partial_results
 
     @classmethod
-    def initialize(cls, params: InitializeParams) -> 'Request':
+    def initialize(cls, params: InitializeParams) -> Request:
         return Request("initialize", params)
 
     @classmethod
-    def complete(cls, params: CompletionParams, view: sublime.View) -> 'Request':
+    def complete(cls, params: CompletionParams, view: sublime.View) -> Request:
         return Request("textDocument/completion", params, view)
 
     @classmethod
-    def signatureHelp(cls, params: SignatureHelpParams, view: sublime.View) -> 'Request':
+    def signatureHelp(cls, params: SignatureHelpParams, view: sublime.View) -> Request:
         return Request("textDocument/signatureHelp", params, view)
 
     @classmethod
-    def codeAction(cls, params: CodeActionParams, view: sublime.View) -> 'Request':
+    def codeAction(cls, params: CodeActionParams, view: sublime.View) -> Request:
         return Request("textDocument/codeAction", params, view)
 
     @classmethod
-    def documentColor(cls, params: DocumentColorParams, view: sublime.View) -> 'Request':
+    def documentColor(cls, params: DocumentColorParams, view: sublime.View) -> Request:
         return Request('textDocument/documentColor', params, view)
 
     @classmethod
-    def colorPresentation(cls, params: ColorPresentationParams, view: sublime.View) -> 'Request':
+    def colorPresentation(cls, params: ColorPresentationParams, view: sublime.View) -> Request:
         return Request('textDocument/colorPresentation', params, view)
 
     @classmethod
-    def willSaveWaitUntil(cls, params: WillSaveTextDocumentParams, view: sublime.View) -> 'Request':
+    def willSaveWaitUntil(cls, params: WillSaveTextDocumentParams, view: sublime.View) -> Request:
         return Request("textDocument/willSaveWaitUntil", params, view)
 
     @classmethod
-    def documentSymbols(cls, params: DocumentSymbolParams, view: sublime.View) -> 'Request':
+    def documentSymbols(cls, params: DocumentSymbolParams, view: sublime.View) -> Request:
         return Request("textDocument/documentSymbol", params, view, progress=True)
 
     @classmethod
-    def documentHighlight(cls, params: DocumentHighlightParams, view: sublime.View) -> 'Request':
+    def documentHighlight(cls, params: DocumentHighlightParams, view: sublime.View) -> Request:
         return Request("textDocument/documentHighlight", params, view)
 
     @classmethod
-    def documentLink(cls, params: DocumentLinkParams, view: sublime.View) -> 'Request':
+    def documentLink(cls, params: DocumentLinkParams, view: sublime.View) -> Request:
         return Request("textDocument/documentLink", params, view)
 
     @classmethod
-    def semanticTokensFull(cls, params: SemanticTokensParams, view: sublime.View) -> 'Request':
+    def semanticTokensFull(cls, params: SemanticTokensParams, view: sublime.View) -> Request:
         return Request("textDocument/semanticTokens/full", params, view)
 
     @classmethod
-    def semanticTokensFullDelta(cls, params: SemanticTokensDeltaParams, view: sublime.View) -> 'Request':
+    def semanticTokensFullDelta(cls, params: SemanticTokensDeltaParams, view: sublime.View) -> Request:
         return Request("textDocument/semanticTokens/full/delta", params, view)
 
     @classmethod
-    def semanticTokensRange(cls, params: SemanticTokensRangeParams, view: sublime.View) -> 'Request':
+    def semanticTokensRange(cls, params: SemanticTokensRangeParams, view: sublime.View) -> Request:
         return Request("textDocument/semanticTokens/range", params, view)
 
     @classmethod
     def prepareCallHierarchy(
         cls, params: CallHierarchyPrepareParams, view: sublime.View
-    ) -> 'Request[Union[List[CallHierarchyItem], Error, None]]':
+    ) -> Request[Union[List[CallHierarchyItem], Error, None]]:
         return Request("textDocument/prepareCallHierarchy", params, view, progress=True)
 
     @classmethod
-    def incomingCalls(cls, params: CallHierarchyIncomingCallsParams) -> 'Request':
+    def incomingCalls(cls, params: CallHierarchyIncomingCallsParams) -> Request:
         return Request("callHierarchy/incomingCalls", params, None)
 
     @classmethod
-    def outgoingCalls(cls, params: CallHierarchyOutgoingCallsParams) -> 'Request':
+    def outgoingCalls(cls, params: CallHierarchyOutgoingCallsParams) -> Request:
         return Request("callHierarchy/outgoingCalls", params, None)
 
     @classmethod
-    def prepareTypeHierarchy(cls, params: TypeHierarchyPrepareParams, view: sublime.View) -> 'Request':
+    def prepareTypeHierarchy(cls, params: TypeHierarchyPrepareParams, view: sublime.View) -> Request:
         return Request("textDocument/prepareTypeHierarchy", params, view, progress=True)
 
     @classmethod
-    def supertypes(cls, params: TypeHierarchySupertypesParams) -> 'Request':
+    def supertypes(cls, params: TypeHierarchySupertypesParams) -> Request:
         return Request("typeHierarchy/supertypes", params, None)
 
     @classmethod
-    def subtypes(cls, params: TypeHierarchySubtypesParams) -> 'Request':
+    def subtypes(cls, params: TypeHierarchySubtypesParams) -> Request:
         return Request("typeHierarchy/subtypes", params, None)
 
     @classmethod
-    def resolveCompletionItem(cls, params: CompletionItem, view: sublime.View) -> 'Request':
+    def resolveCompletionItem(cls, params: CompletionItem, view: sublime.View) -> Request:
         return Request("completionItem/resolve", params, view)
 
     @classmethod
-    def resolveDocumentLink(cls, params: DocumentLink, view: sublime.View) -> 'Request':
+    def resolveDocumentLink(cls, params: DocumentLink, view: sublime.View) -> Request:
         return Request("documentLink/resolve", params, view)
 
     @classmethod
-    def inlayHint(cls, params: InlayHintParams, view: sublime.View) -> 'Request':
+    def inlayHint(cls, params: InlayHintParams, view: sublime.View) -> Request:
         return Request('textDocument/inlayHint', params, view)
 
     @classmethod
-    def resolveInlayHint(cls, params: InlayHint, view: sublime.View) -> 'Request':
+    def resolveInlayHint(cls, params: InlayHint, view: sublime.View) -> Request:
         return Request('inlayHint/resolve', params, view)
 
     @classmethod
-    def rename(cls, params: RenameParams, view: sublime.View, progress: bool = False) -> 'Request':
+    def rename(cls, params: RenameParams, view: sublime.View, progress: bool = False) -> Request:
         return Request('textDocument/rename', params, view, progress)
 
     @classmethod
-    def prepareRename(cls, params: PrepareRenameParams, view: sublime.View, progress: bool = False) -> 'Request':
+    def prepareRename(cls, params: PrepareRenameParams, view: sublime.View, progress: bool = False) -> Request:
         return Request('textDocument/prepareRename', params, view, progress)
 
     @classmethod
-    def selectionRange(cls, params: SelectionRangeParams) -> 'Request':
+    def selectionRange(cls, params: SelectionRangeParams) -> Request:
         return Request('textDocument/selectionRange', params)
 
     @classmethod
-    def foldingRange(cls, params: FoldingRangeParams, view: sublime.View) -> 'Request':
+    def foldingRange(cls, params: FoldingRangeParams, view: sublime.View) -> Request:
         return Request('textDocument/foldingRange', params, view)
 
     @classmethod
-    def workspaceSymbol(cls, params: WorkspaceSymbolParams) -> 'Request':
+    def workspaceSymbol(cls, params: WorkspaceSymbolParams) -> Request:
         return Request("workspace/symbol", params, None, progress=True)
 
     @classmethod
-    def resolveWorkspaceSymbol(cls, params: WorkspaceSymbol) -> 'Request':
+    def resolveWorkspaceSymbol(cls, params: WorkspaceSymbol) -> Request:
         return Request('workspaceSymbol/resolve', params)
 
     @classmethod
-    def documentDiagnostic(cls, params: DocumentDiagnosticParams, view: sublime.View) -> 'Request':
+    def documentDiagnostic(cls, params: DocumentDiagnosticParams, view: sublime.View) -> Request:
         return Request('textDocument/diagnostic', params, view)
 
     @classmethod
-    def workspaceDiagnostic(cls, params: WorkspaceDiagnosticParams) -> 'Request':
+    def workspaceDiagnostic(cls, params: WorkspaceDiagnosticParams) -> Request:
         return Request('workspace/diagnostic', params, partial_results=True)
 
     @classmethod
-    def shutdown(cls) -> 'Request':
+    def shutdown(cls) -> Request:
         return Request("shutdown")
 
     def __repr__(self) -> str:
@@ -6187,7 +6188,7 @@ class Error(Exception):
         self.data = data
 
     @classmethod
-    def from_lsp(cls, params: Any) -> "Error":
+    def from_lsp(cls, params: Any) -> Error:
         return Error(params["code"], params["message"], params.get("data"))
 
     def to_lsp(self) -> Dict[str, Any]:
@@ -6200,7 +6201,7 @@ class Error(Exception):
         return "{} ({})".format(super().__str__(), self.code)
 
     @classmethod
-    def from_exception(cls, ex: Exception) -> 'Error':
+    def from_exception(cls, ex: Exception) -> Error:
         return Error(ErrorCodes.InternalError, str(ex))
 
 
@@ -6232,43 +6233,43 @@ class Notification:
         self.params = params
 
     @classmethod
-    def initialized(cls) -> 'Notification':
+    def initialized(cls) -> Notification:
         return Notification("initialized", {})
 
     @classmethod
-    def didOpen(cls, params: DidOpenTextDocumentParams) -> 'Notification':
+    def didOpen(cls, params: DidOpenTextDocumentParams) -> Notification:
         return Notification("textDocument/didOpen", params)
 
     @classmethod
-    def didChange(cls, params: DidChangeTextDocumentParams) -> 'Notification':
+    def didChange(cls, params: DidChangeTextDocumentParams) -> Notification:
         return Notification("textDocument/didChange", params)
 
     @classmethod
-    def willSave(cls, params: WillSaveTextDocumentParams) -> 'Notification':
+    def willSave(cls, params: WillSaveTextDocumentParams) -> Notification:
         return Notification("textDocument/willSave", params)
 
     @classmethod
-    def didSave(cls, params: DidSaveTextDocumentParams) -> 'Notification':
+    def didSave(cls, params: DidSaveTextDocumentParams) -> Notification:
         return Notification("textDocument/didSave", params)
 
     @classmethod
-    def didClose(cls, params: DidCloseTextDocumentParams) -> 'Notification':
+    def didClose(cls, params: DidCloseTextDocumentParams) -> Notification:
         return Notification("textDocument/didClose", params)
 
     @classmethod
-    def didChangeConfiguration(cls, params: DidChangeConfigurationParams) -> 'Notification':
+    def didChangeConfiguration(cls, params: DidChangeConfigurationParams) -> Notification:
         return Notification("workspace/didChangeConfiguration", params)
 
     @classmethod
-    def didChangeWatchedFiles(cls, params: DidChangeWatchedFilesParams) -> 'Notification':
+    def didChangeWatchedFiles(cls, params: DidChangeWatchedFilesParams) -> Notification:
         return Notification("workspace/didChangeWatchedFiles", params)
 
     @classmethod
-    def didChangeWorkspaceFolders(cls, params: DidChangeWorkspaceFoldersParams) -> 'Notification':
+    def didChangeWorkspaceFolders(cls, params: DidChangeWorkspaceFoldersParams) -> Notification:
         return Notification("workspace/didChangeWorkspaceFolders", params)
 
     @classmethod
-    def exit(cls) -> 'Notification':
+    def exit(cls) -> Notification:
         return Notification("exit")
 
     def __repr__(self) -> str:
@@ -6304,10 +6305,10 @@ class Point(object):
         return (self.row, self.col) < (other.row, other.col)
 
     @classmethod
-    def from_lsp(cls, point: 'Position') -> 'Point':
+    def from_lsp(cls, point: Position) -> Point:
         return Point(point['line'], point['character'])
 
-    def to_lsp(self) -> 'Position':
+    def to_lsp(self) -> Position:
         return {
             "line": self.row,
             "character": self.col

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .protocol import Diagnostic
 from .protocol import Location
 from .protocol import LocationLink

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -196,7 +196,7 @@ class Manager(metaclass=ABCMeta):
         raise NotImplementedError()
 
     @abstractmethod
-    def sessions(self, view: sublime.View, capability: Optional[str] = None) -> 'Generator[Session, None, None]':
+    def sessions(self, view: sublime.View, capability: Optional[str] = None) -> Generator[Session, None, None]:
         """
         Iterate over the sessions stored in this manager, applicable to the given view, with the given capability.
         """
@@ -534,7 +534,7 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
 class SessionViewProtocol(Protocol):
 
     @property
-    def session(self) -> 'Session':
+    def session(self) -> Session:
         ...
 
     @property
@@ -542,11 +542,11 @@ class SessionViewProtocol(Protocol):
         ...
 
     @property
-    def listener(self) -> 'weakref.ref[AbstractViewListener]':
+    def listener(self) -> weakref.ref[AbstractViewListener]:
         ...
 
     @property
-    def session_buffer(self) -> 'SessionBufferProtocol':
+    def session_buffer(self) -> SessionBufferProtocol:
         ...
 
     def get_uri(self) -> Optional[DocumentUri]:
@@ -603,11 +603,11 @@ class SessionViewProtocol(Protocol):
 class SessionBufferProtocol(Protocol):
 
     @property
-    def session(self) -> 'Session':
+    def session(self) -> Session:
         ...
 
     @property
-    def session_views(self) -> 'WeakSet[SessionViewProtocol]':
+    def session_views(self) -> WeakSet[SessionViewProtocol]:
         ...
 
     @property

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .collections import DottedDict
 from .constants import SEMANTIC_TOKENS_MAP
 from .diagnostics_storage import DiagnosticsStorage
@@ -113,7 +114,7 @@ from abc import abstractproperty
 from enum import IntEnum
 from typing import Any, Callable, Dict, Generator, List, Optional, Protocol, Set, Tuple, Type, TypeVar, Union
 from typing import cast
-from typing_extensions import TypeGuard
+from typing_extensions import TypeAlias, TypeGuard
 from weakref import WeakSet
 import functools
 import mdpopups
@@ -121,7 +122,7 @@ import os
 import sublime
 import weakref
 
-InitCallback = Callable[['Session', bool], None]
+InitCallback: TypeAlias = Callable[['Session', bool], None]
 T = TypeVar('T')
 
 
@@ -234,7 +235,7 @@ class Manager(metaclass=ABCMeta):
     # Event callbacks
 
     @abstractmethod
-    def on_post_exit_async(self, session: 'Session', exit_code: int, exception: Optional[Exception]) -> None:
+    def on_post_exit_async(self, session: Session, exit_code: int, exception: Optional[Exception]) -> None:
         """
         The given Session has stopped with the given exit code.
         """
@@ -689,19 +690,19 @@ class AbstractViewListener(metaclass=ABCMeta):
     hover_provider_count = 0
 
     @abstractmethod
-    def session_async(self, capability: str, point: Optional[int] = None) -> Optional['Session']:
+    def session_async(self, capability: str, point: Optional[int] = None) -> Optional[Session]:
         raise NotImplementedError()
 
     @abstractmethod
-    def sessions_async(self, capability: Optional[str] = None) -> Generator['Session', None, None]:
+    def sessions_async(self, capability: Optional[str] = None) -> Generator[Session, None, None]:
         raise NotImplementedError()
 
     @abstractmethod
-    def session_buffers_async(self, capability: Optional[str] = None) -> Generator['SessionBufferProtocol', None, None]:
+    def session_buffers_async(self, capability: Optional[str] = None) -> Generator[SessionBufferProtocol, None, None]:
         raise NotImplementedError()
 
     @abstractmethod
-    def session_views_async(self) -> Generator['SessionViewProtocol', None, None]:
+    def session_views_async(self) -> Generator[SessionViewProtocol, None, None]:
         raise NotImplementedError()
 
     @abstractmethod
@@ -709,18 +710,18 @@ class AbstractViewListener(metaclass=ABCMeta):
         raise NotImplementedError()
 
     @abstractmethod
-    def on_session_initialized_async(self, session: 'Session') -> None:
+    def on_session_initialized_async(self, session: Session) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    def on_session_shutdown_async(self, session: 'Session') -> None:
+    def on_session_shutdown_async(self, session: Session) -> None:
         raise NotImplementedError()
 
     @abstractmethod
     def diagnostics_intersecting_region_async(
         self,
         region: sublime.Region
-    ) -> Tuple[List[Tuple['SessionBufferProtocol', List[Diagnostic]]], sublime.Region]:
+    ) -> Tuple[List[Tuple[SessionBufferProtocol, List[Diagnostic]]], sublime.Region]:
         raise NotImplementedError()
 
     @abstractmethod
@@ -728,13 +729,13 @@ class AbstractViewListener(metaclass=ABCMeta):
         self,
         pt: int,
         max_diagnostic_severity_level: int = DiagnosticSeverity.Hint
-    ) -> Tuple[List[Tuple['SessionBufferProtocol', List[Diagnostic]]], sublime.Region]:
+    ) -> Tuple[List[Tuple[SessionBufferProtocol, List[Diagnostic]]], sublime.Region]:
         raise NotImplementedError()
 
     def diagnostics_intersecting_async(
         self,
         region_or_point: Union[sublime.Region, int]
-    ) -> Tuple[List[Tuple['SessionBufferProtocol', List[Diagnostic]]], sublime.Region]:
+    ) -> Tuple[List[Tuple[SessionBufferProtocol, List[Diagnostic]]], sublime.Region]:
         if isinstance(region_or_point, int):
             return self.diagnostics_touching_point_async(region_or_point)
         elif region_or_point.empty():
@@ -968,7 +969,7 @@ class AbstractPlugin(metaclass=ABCMeta):
         """
         return None
 
-    def __init__(self, weaksession: 'weakref.ref[Session]') -> None:
+    def __init__(self, weaksession: weakref.ref[Session]) -> None:
         """
         Constructs a new instance. Your instance is constructed after a response to the initialize request.
 

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .collections import DottedDict
 from .logging import debug
 from .types import ClientConfig, debounced

--- a/plugin/core/signature_help.py
+++ b/plugin/core/signature_help.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .logging import debug
 from .protocol import SignatureHelp
 from .protocol import SignatureInformation

--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .logging import exception_log, debug
 from .types import TCP_CONNECT_TIMEOUT
 from .types import TransportConfig
@@ -281,7 +282,7 @@ def create_transport(config: TransportConfig, cwd: Optional[str],
         config.name, process, sock, reader, writer, stderr, json_rpc_processor, callback_object)  # type: ignore
 
 
-_subprocesses: 'weakref.WeakSet[subprocess.Popen]' = weakref.WeakSet()
+_subprocesses: weakref.WeakSet[subprocess.Popen] = weakref.WeakSet()
 
 
 def kill_all_subprocesses() -> None:

--- a/plugin/core/tree_view.py
+++ b/plugin/core/tree_view.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .constants import SublimeKind
 from .css import css
 from .promise import Promise

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .collections import DottedDict
 from .file_watcher import FileWatcherEventType
 from .logging import debug, set_debug_logging

--- a/plugin/core/typing.py
+++ b/plugin/core/typing.py
@@ -43,11 +43,11 @@ else:
     def final(func):  # type: ignore
         return func
 
-    def _make_type(name: str) -> _TypeMeta:
+    def _make_type(name: str) -> '_TypeMeta':
         return _TypeMeta(name, (Type,), {})  # type: ignore
 
     class _TypeMeta(type):
-        def __getitem__(self, args: Any) -> Any:
+        def __getitem__(self, args: 'Any') -> 'Any':
             if not isinstance(args, tuple):
                 args = (args,)
 

--- a/plugin/core/typing.py
+++ b/plugin/core/typing.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 
 if sys.version_info >= (3, 11, 0):
@@ -42,11 +43,11 @@ else:
     def final(func):  # type: ignore
         return func
 
-    def _make_type(name: str) -> '_TypeMeta':
+    def _make_type(name: str) -> _TypeMeta:
         return _TypeMeta(name, (Type,), {})  # type: ignore
 
     class _TypeMeta(type):
-        def __getitem__(self, args: 'Any') -> 'Any':
+        def __getitem__(self, args: Any) -> Any:
             if not isinstance(args, tuple):
                 args = (args,)
 

--- a/plugin/core/url.py
+++ b/plugin/core/url.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Any, Tuple
 from urllib.parse import urljoin
 from urllib.parse import urlparse

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .constants import CODE_ACTION_KINDS
 from .constants import SUBLIME_KIND_SCOPES
 from .constants import SublimeKind

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from ...third_party import WebsocketServer  # type: ignore
 from .configurations import RETRY_COUNT_TIMEDELTA
 from .configurations import RETRY_MAX_COUNT

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -27,7 +27,7 @@ class WorkspaceFolder:
         self.path = path
 
     @classmethod
-    def from_path(cls, path: str) -> 'WorkspaceFolder':
+    def from_path(cls, path: str) -> WorkspaceFolder:
         return cls(os.path.basename(path) or path, path)
 
     def __hash__(self) -> int:

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .protocol import WorkspaceFolder as LspWorkspaceFolder
 from .types import diff
 from .types import matches_pattern

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .core.constants import DIAGNOSTIC_KINDS
 from .core.constants import REGIONS_INITIALIZE_FLAGS
 from .core.protocol import Diagnostic

--- a/plugin/document_link.py
+++ b/plugin/document_link.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .core.logging import debug
 from .core.open import open_file_uri
 from .core.open import open_in_browser

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .code_actions import actions_manager
 from .code_actions import CodeActionOrCommand
 from .code_actions import CodeActionsByConfigName
@@ -91,7 +92,7 @@ def previous_non_whitespace_char(view: sublime.View, pt: int) -> str:
 
 class TextChangeListener(sublime_plugin.TextChangeListener):
 
-    ids_to_listeners: 'WeakValueDictionary[int, TextChangeListener]' = WeakValueDictionary()
+    ids_to_listeners: WeakValueDictionary[int, TextChangeListener] = WeakValueDictionary()
 
     @classmethod
     def is_applicable(cls, buffer: sublime.Buffer) -> bool:

--- a/plugin/edit.py
+++ b/plugin/edit.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .core.edit import parse_range
 from .core.logging import debug
 from .core.protocol import TextEdit

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .core.protocol import Error
 from .core.protocol import ExecuteCommandParams
 from .core.registry import LspTextCommand

--- a/plugin/folding_range.py
+++ b/plugin/folding_range.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .core.protocol import FoldingRange
 from .core.protocol import FoldingRangeKind
 from .core.protocol import FoldingRangeParams

--- a/plugin/formatting.py
+++ b/plugin/formatting.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .core.collections import DottedDict
 from .core.edit import apply_text_edits
 from .core.promise import Promise

--- a/plugin/goto.py
+++ b/plugin/goto.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .core.protocol import Location
 from .core.protocol import LocationLink
 from .core.protocol import Request

--- a/plugin/goto_diagnostic.py
+++ b/plugin/goto_diagnostic.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .core.constants import DIAGNOSTIC_KINDS
 from .core.diagnostics_storage import is_severity_included
 from .core.diagnostics_storage import ParsedUri

--- a/plugin/hierarchy.py
+++ b/plugin/hierarchy.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .core.constants import SYMBOL_KINDS
 from .core.paths import simple_path
 from .core.promise import Promise
@@ -41,7 +42,7 @@ class HierarchyDataProvider(TreeDataProvider):
 
     def __init__(
         self,
-        weaksession: 'weakref.ref[Session]',
+        weaksession: weakref.ref[Session],
         request: Callable[..., Request],
         request_handler: Callable[..., List[HierarchyItemWrapper]],
         root_elements: List[HierarchyItemWrapper]
@@ -84,7 +85,7 @@ class HierarchyDataProvider(TreeDataProvider):
 
 
 def make_data_provider(
-    weaksession: 'weakref.ref[Session]', sheet_name: str, direction: int, response: List[HierarchyItemWrapper]
+    weaksession: weakref.ref[Session], sheet_name: str, direction: int, response: List[HierarchyItemWrapper]
 ) -> HierarchyDataProvider:
     if sheet_name == "Call Hierarchy":
         request = Request.incomingCalls if direction == 1 else Request.outgoingCalls
@@ -166,7 +167,7 @@ class LspHierarchyCommand(LspTextCommand, metaclass=ABCMeta):
             self.request(params, self.view), partial(self._handle_response_async, weakref.ref(session)))
 
     def _handle_response_async(
-        self, weaksession: 'weakref.ref[Session]', response: Optional[List[HierarchyItem]]
+        self, weaksession: weakref.ref[Session], response: Optional[List[HierarchyItem]]
     ) -> None:
         if not self._window or not self._window.is_valid():
             return

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .code_actions import actions_manager
 from .code_actions import CodeActionOrCommand
 from .code_actions import CodeActionsByConfigName

--- a/plugin/inlay_hint.py
+++ b/plugin/inlay_hint.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .core.css import css
 from .core.edit import apply_text_edits
 from .core.protocol import InlayHint

--- a/plugin/locationpicker.py
+++ b/plugin/locationpicker.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .core.constants import SublimeKind
 from .core.logging import debug
 from .core.protocol import DocumentUri

--- a/plugin/panels.py
+++ b/plugin/panels.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .core.panels import LOG_LINES_LIMIT_SETTING_NAME
 from .core.panels import PanelName
 from .core.registry import windows

--- a/plugin/references.py
+++ b/plugin/references.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .core.protocol import Location
 from .core.protocol import Point
 from .core.protocol import Request

--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .core.edit import parse_range
 from .core.edit import parse_workspace_edit
 from .core.edit import WorkspaceChanges

--- a/plugin/save_command.py
+++ b/plugin/save_command.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .core.registry import LspTextCommand
 from .core.settings import userprefs
 from abc import ABCMeta, abstractmethod

--- a/plugin/selection_range.py
+++ b/plugin/selection_range.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .core.protocol import Request
 from .core.protocol import SelectionRange
 from .core.registry import get_position

--- a/plugin/semantic_highlighting.py
+++ b/plugin/semantic_highlighting.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .core.registry import LspTextCommand
 from typing import Any, List, Tuple
 from typing import cast

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -142,7 +142,7 @@ class SessionBuffer:
         return self._session
 
     @property
-    def session_views(self) -> 'WeakSet[SessionViewProtocol]':
+    def session_views(self) -> WeakSet[SessionViewProtocol]:
         return self._session_views
 
     @property

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .core.constants import DOCUMENT_LINK_FLAGS
 from .core.constants import SEMANTIC_TOKEN_FLAGS
 from .core.protocol import ColorInformation

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .code_lens import CodeLensView
 from .code_lens import LspToggleCodeLensesCommand
 from .core.active_request import ActiveRequest
@@ -50,7 +51,7 @@ class SessionView:
     TRIGGER_CHARACTERS_KEY = "completionProvider.triggerCharacters"
     CODE_ACTIONS_KEY = "lsp_code_action"
 
-    _session_buffers: 'WeakValueDictionary[Tuple[int, int], SessionBuffer]' = WeakValueDictionary()
+    _session_buffers: WeakValueDictionary[Tuple[int, int], SessionBuffer] = WeakValueDictionary()
 
     def __init__(self, listener: AbstractViewListener, session: Session, uri: DocumentUri) -> None:
         self._view = listener.view
@@ -114,7 +115,7 @@ class SessionView:
         return self._view
 
     @property
-    def listener(self) -> 'ref[AbstractViewListener]':
+    def listener(self) -> ref[AbstractViewListener]:
         return self._listener
 
     @property

--- a/plugin/symbols.py
+++ b/plugin/symbols.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .core.constants import SYMBOL_KINDS
 from .core.input_handlers import DynamicListInputHandler
 from .core.input_handlers import PreselectedListInputHandler

--- a/plugin/tooling.py
+++ b/plugin/tooling.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .core.css import css
 from .core.logging import debug
 from .core.registry import windows

--- a/tests/server.py
+++ b/tests/server.py
@@ -76,7 +76,7 @@ class Error(Exception):
         return {"code": self.code, "message": super().__str__()}
 
     @classmethod
-    def from_lsp(cls, d: StringDict) -> 'Error':
+    def from_lsp(cls, d: StringDict) -> Error:
         return Error(d["code"], d["message"])
 
     def __str__(self) -> str:

--- a/tests/server.py
+++ b/tests/server.py
@@ -20,6 +20,7 @@ resumes (since response to request will arrive after requested notification).
 
 TODO: Untested on Windows.
 """
+from __future__ import annotations
 from argparse import ArgumentParser
 from enum import IntEnum
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, Iterable, Awaitable

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -69,7 +69,7 @@ def remove_config(config):
     client_configs.remove_for_testing(config)
 
 
-def close_test_view(view: Optional[sublime.View]) -> 'Generator':
+def close_test_view(view: Optional[sublime.View]) -> Generator:
     if view:
         view.set_scratch(True)
         yield {"condition": lambda: not view.is_loading(), "timeout": TIMEOUT_TIME}
@@ -157,7 +157,7 @@ class TextDocumentTestCase(DeferrableTestCase):
         return False
 
     @classmethod
-    def await_message(cls, method: str, promise: Optional[YieldPromise] = None) -> 'Generator':
+    def await_message(cls, method: str, promise: Optional[YieldPromise] = None) -> Generator:
         """
         Awaits until server receives a request with a specified method.
 
@@ -235,7 +235,7 @@ class TextDocumentTestCase(DeferrableTestCase):
         self.session.send_request(Request("$test/setResponses", payload), handler, error_handler)
         yield from self.await_promise(promise)
 
-    def await_client_notification(self, method: str, params: Any = None) -> 'Generator':
+    def await_client_notification(self, method: str, params: Any = None) -> Generator:
         self.assertIsNotNone(self.session)
         assert self.session  # mypy
         promise = YieldPromise()
@@ -250,7 +250,7 @@ class TextDocumentTestCase(DeferrableTestCase):
         self.session.send_request(req, handler, error_handler)
         yield from self.await_promise(promise)
 
-    def await_clear_view_and_save(self) -> 'Generator':
+    def await_clear_view_and_save(self) -> Generator:
         assert self.view  # type: Optional[sublime.View]
         self.view.run_command("select_all")
         self.view.run_command("left_delete")
@@ -258,7 +258,7 @@ class TextDocumentTestCase(DeferrableTestCase):
         yield from self.await_message("textDocument/didChange")
         yield from self.await_message("textDocument/didSave")
 
-    def await_view_change(self, expected_change_count: int) -> 'Generator':
+    def await_view_change(self, expected_change_count: int) -> Generator:
         assert self.view  # type: Optional[sublime.View]
 
         def condition() -> bool:
@@ -276,7 +276,7 @@ class TextDocumentTestCase(DeferrableTestCase):
         return self.view.change_count()
 
     @classmethod
-    def tearDownClass(cls) -> 'Generator':
+    def tearDownClass(cls) -> Generator:
         if cls.session and cls.wm:
             sublime.set_timeout_async(cls.session.end_async)
             yield lambda: cls.session.state == ClientStates.STOPPING
@@ -288,7 +288,7 @@ class TextDocumentTestCase(DeferrableTestCase):
         remove_config(cls.config)
         super().tearDownClass()
 
-    def doCleanups(self) -> 'Generator':
+    def doCleanups(self) -> Generator:
         if self.view and self.view.is_valid():
             yield from close_test_view(self.view)
         yield from super().doCleanups()

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from LSP.plugin.core.promise import Promise
 from LSP.plugin.core.logging import debug
 from LSP.plugin.core.protocol import Notification, Request

--- a/tests/test_code_actions.py
+++ b/tests/test_code_actions.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from copy import deepcopy
 from LSP.plugin.code_actions import get_matching_on_save_kinds, kinds_include_kind
 from LSP.plugin.core.protocol import Point, Range

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from LSP.plugin.core.collections import DottedDict
 from typing import Any
 from unittest import TestCase

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from copy import deepcopy
 from LSP.plugin.completion import format_completion
 from LSP.plugin.completion import completion_with_defaults

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -68,11 +68,11 @@ class CompletionsTestsBase(TextDocumentTestCase):
 
         return commit_completion
 
-    def select_completion(self) -> 'Generator':
+    def select_completion(self) -> Generator:
         self.view.run_command('auto_complete')
         yield self.create_commit_completion_closure()
 
-    def shift_select_completion(self) -> 'Generator':
+    def shift_select_completion(self) -> Generator:
         self.view.run_command('auto_complete')
         yield self.create_commit_completion_closure("lsp_commit_completion_with_opposite_insert_mode")
 
@@ -90,24 +90,24 @@ class CompletionsTestsBase(TextDocumentTestCase):
 
 
 class QueryCompletionsTests(CompletionsTestsBase):
-    def test_none(self) -> 'Generator':
+    def test_none(self) -> Generator:
         self.set_response("textDocument/completion", None)
         self.view.run_command('auto_complete')
         yield lambda: self.view.is_auto_complete_visible() is False
 
-    def test_simple_label(self) -> 'Generator':
+    def test_simple_label(self) -> Generator:
         yield from self.verify(
             completion_items=[{'label': 'asdf'}, {'label': 'efcgh'}],
             insert_text='',
             expected_text='asdf')
 
-    def test_prefer_insert_text_over_label(self) -> 'Generator':
+    def test_prefer_insert_text_over_label(self) -> Generator:
         yield from self.verify(
             completion_items=[{"label": "Label text", "insertText": "Insert text"}],
             insert_text='',
             expected_text='Insert text')
 
-    def test_prefer_text_edit_over_insert_text(self) -> 'Generator':
+    def test_prefer_text_edit_over_insert_text(self) -> Generator:
         yield from self.verify(
             completion_items=[{
                 "label": "Label text",
@@ -129,16 +129,16 @@ class QueryCompletionsTests(CompletionsTestsBase):
             insert_text='',
             expected_text='Text edit')
 
-    def test_simple_insert_text(self) -> 'Generator':
+    def test_simple_insert_text(self) -> Generator:
         yield from self.verify(
             completion_items=[{'label': 'asdf', 'insertText': 'asdf()'}],
             insert_text="a",
             expected_text='asdf()')
 
-    def test_var_prefix_using_label(self) -> 'Generator':
+    def test_var_prefix_using_label(self) -> Generator:
         yield from self.verify(completion_items=[{'label': '$what'}], insert_text="$", expected_text="$what")
 
-    def test_var_prefix_added_in_insertText(self) -> 'Generator':
+    def test_var_prefix_added_in_insertText(self) -> Generator:
         """
         https://github.com/sublimelsp/LSP/issues/294
 
@@ -168,7 +168,7 @@ class QueryCompletionsTests(CompletionsTestsBase):
             insert_text="$env:U",
             expected_text="$env:USERPROFILE")
 
-    def test_pure_insertion_text_edit(self) -> 'Generator':
+    def test_pure_insertion_text_edit(self) -> Generator:
         """
         https://github.com/sublimelsp/LSP/issues/368
 
@@ -198,7 +198,7 @@ class QueryCompletionsTests(CompletionsTestsBase):
             insert_text="$so",
             expected_text="$someParam")
 
-    def test_space_added_in_label(self) -> 'Generator':
+    def test_space_added_in_label(self) -> Generator:
         """
         Clangd: label=" const", insertText="const" (https://github.com/sublimelsp/LSP/issues/368)
         """
@@ -228,7 +228,7 @@ class QueryCompletionsTests(CompletionsTestsBase):
             insert_text=' co',
             expected_text=" const")  # NOT 'const'
 
-    def test_dash_missing_from_label(self) -> 'Generator':
+    def test_dash_missing_from_label(self) -> Generator:
         """
         Powershell: label="UniqueId", trigger="-UniqueIdd, text to be inserted = "-UniqueId"
 
@@ -260,7 +260,7 @@ class QueryCompletionsTests(CompletionsTestsBase):
             insert_text="u",
             expected_text="-UniqueId")
 
-    def test_edit_before_cursor(self) -> 'Generator':
+    def test_edit_before_cursor(self) -> Generator:
         """
         https://github.com/sublimelsp/LSP/issues/536
         """
@@ -295,7 +295,7 @@ class QueryCompletionsTests(CompletionsTestsBase):
             insert_text='def myF',
             expected_text='override def myFunction(): Unit = ???')
 
-    def test_edit_after_nonword(self) -> 'Generator':
+    def test_edit_after_nonword(self) -> Generator:
         """
         https://github.com/sublimelsp/LSP/issues/645
         """
@@ -328,7 +328,7 @@ class QueryCompletionsTests(CompletionsTestsBase):
             insert_text="List.",
             expected_text='List.apply()')
 
-    def test_filter_text_is_not_a_prefix_of_label(self) -> 'Generator':
+    def test_filter_text_is_not_a_prefix_of_label(self) -> Generator:
         """
         Metals: "Implement all members"
 
@@ -366,7 +366,7 @@ class QueryCompletionsTests(CompletionsTestsBase):
             insert_text='e',
             expected_text='def foo: Int \u003d ???\n   def boo: Int \u003d ???')
 
-    def test_additional_edits_if_session_has_the_resolve_capability(self) -> 'Generator':
+    def test_additional_edits_if_session_has_the_resolve_capability(self) -> Generator:
         completion_item = {
             'label': 'asdf'
         }
@@ -393,7 +393,7 @@ class QueryCompletionsTests(CompletionsTestsBase):
             insert_text='',
             expected_text='import asdf;\nasdf')
 
-    def test_prefix_should_include_the_dollar_sign(self) -> 'Generator':
+    def test_prefix_should_include_the_dollar_sign(self) -> Generator:
         self.set_response(
             'textDocument/completion',
             {
@@ -423,7 +423,7 @@ class QueryCompletionsTests(CompletionsTestsBase):
 
         self.assertEquals(self.read_file(), '<?php\n$hello = "world";\n$hello\n?>\n')
 
-    def test_fuzzy_match_plaintext_insert_text(self) -> 'Generator':
+    def test_fuzzy_match_plaintext_insert_text(self) -> Generator:
         yield from self.verify(
             completion_items=[{
                 'insertTextFormat': 1,
@@ -433,7 +433,7 @@ class QueryCompletionsTests(CompletionsTestsBase):
             insert_text='aa',
             expected_text='aaca')
 
-    def test_fuzzy_match_plaintext_text_edit(self) -> 'Generator':
+    def test_fuzzy_match_plaintext_text_edit(self) -> Generator:
         yield from self.verify(
             completion_items=[{
                 'insertTextFormat': 1,
@@ -445,7 +445,7 @@ class QueryCompletionsTests(CompletionsTestsBase):
             insert_text='aab',
             expected_text='aaca')
 
-    def test_fuzzy_match_snippet_insert_text(self) -> 'Generator':
+    def test_fuzzy_match_snippet_insert_text(self) -> Generator:
         yield from self.verify(
             completion_items=[{
                 'insertTextFormat': 2,
@@ -455,7 +455,7 @@ class QueryCompletionsTests(CompletionsTestsBase):
             insert_text='aab',
             expected_text='aaca')
 
-    def test_fuzzy_match_snippet_text_edit(self) -> 'Generator':
+    def test_fuzzy_match_snippet_text_edit(self) -> Generator:
         yield from self.verify(
             completion_items=[{
                 'insertTextFormat': 2,
@@ -467,7 +467,7 @@ class QueryCompletionsTests(CompletionsTestsBase):
             insert_text='aab',
             expected_text='aaca')
 
-    def verify_multi_cursor(self, completion: Dict[str, Any]) -> 'Generator':
+    def verify_multi_cursor(self, completion: Dict[str, Any]) -> Generator:
         """
         This checks whether `fd` gets replaced by `fmod` when the cursor is at `fd|`.
         Turning the `d` into an `m` is an important part of the test.
@@ -486,14 +486,14 @@ class QueryCompletionsTests(CompletionsTestsBase):
         yield from self.await_message("textDocument/completion")
         self.assertEqual(self.read_file(), 'fmod()\nfmod()\nfmod()')
 
-    def test_multi_cursor_plaintext_insert_text(self) -> 'Generator':
+    def test_multi_cursor_plaintext_insert_text(self) -> Generator:
         yield from self.verify_multi_cursor({
             'insertTextFormat': 1,
             'label': 'fmod(a, b)',
             'insertText': 'fmod()'
         })
 
-    def test_multi_cursor_plaintext_text_edit(self) -> 'Generator':
+    def test_multi_cursor_plaintext_text_edit(self) -> Generator:
         yield from self.verify_multi_cursor({
             'insertTextFormat': 1,
             'label': 'fmod(a, b)',
@@ -503,14 +503,14 @@ class QueryCompletionsTests(CompletionsTestsBase):
             }
         })
 
-    def test_multi_cursor_snippet_insert_text(self) -> 'Generator':
+    def test_multi_cursor_snippet_insert_text(self) -> Generator:
         yield from self.verify_multi_cursor({
             'insertTextFormat': 2,
             'label': 'fmod(a, b)',
             'insertText': 'fmod($0)'
         })
 
-    def test_multi_cursor_snippet_text_edit(self) -> 'Generator':
+    def test_multi_cursor_snippet_text_edit(self) -> Generator:
         yield from self.verify_multi_cursor({
             'insertTextFormat': 2,
             'label': 'fmod(a, b)',
@@ -520,7 +520,7 @@ class QueryCompletionsTests(CompletionsTestsBase):
             }
         })
 
-    def test_nontrivial_text_edit_removal(self) -> 'Generator':
+    def test_nontrivial_text_edit_removal(self) -> Generator:
         self.type('#include <u>')
         self.move_cursor(0, 11)  # Put the cursor inbetween 'u' and '>'
         self.set_response("textDocument/completion", [{
@@ -539,7 +539,7 @@ class QueryCompletionsTests(CompletionsTestsBase):
         yield from self.await_message("textDocument/completion")
         self.assertEqual(self.read_file(), '#include <uchar.h>')
 
-    def test_nontrivial_text_edit_removal_with_buffer_modifications_clangd(self) -> 'Generator':
+    def test_nontrivial_text_edit_removal_with_buffer_modifications_clangd(self) -> Generator:
         self.type('#include <u>')
         self.move_cursor(0, 11)  # Put the cursor inbetween 'u' and '>'
         self.set_response("textDocument/completion", [{
@@ -568,7 +568,7 @@ class QueryCompletionsTests(CompletionsTestsBase):
         yield self.create_commit_completion_closure()
         self.assertEqual(self.read_file(), '#include <uchar.h>')
 
-    def test_nontrivial_text_edit_removal_with_buffer_modifications_json(self) -> 'Generator':
+    def test_nontrivial_text_edit_removal_with_buffer_modifications_json(self) -> Generator:
         self.type('{"k"}')
         self.move_cursor(0, 3)  # Put the cursor inbetween 'k' and '"'
         self.set_response("textDocument/completion", [{
@@ -612,7 +612,7 @@ class QueryCompletionsTests(CompletionsTestsBase):
         # the "b" should be intended one level deeper
         self.assertEqual(self.read_file(), '\t\n\ta\n\t\tb')
 
-    def test_insert_insert_mode(self) -> 'Generator':
+    def test_insert_insert_mode(self) -> Generator:
         self.type('{{ title }}')
         self.move_cursor(0, 5)  # Put the cursor inbetween 'i' and 't'
         self.set_response("textDocument/completion", [{
@@ -627,7 +627,7 @@ class QueryCompletionsTests(CompletionsTestsBase):
         yield from self.await_message("textDocument/completion")
         self.assertEqual(self.read_file(), '{{ titletle }}')
 
-    def test_replace_insert_mode(self) -> 'Generator':
+    def test_replace_insert_mode(self) -> Generator:
         self.type('{{ title }}')
         self.move_cursor(0, 4)  # Put the cursor inbetween 't' and 'i'
         self.set_response("textDocument/completion", [{
@@ -660,7 +660,7 @@ class QueryCompletionsTests(CompletionsTestsBase):
         formatted_completion_item = format_completion(item_with_deprecated_tags, 0, False, "", {}, self.view.id())
         self.assertIn("DEPRECATED", formatted_completion_item.annotation)
 
-    def test_strips_carriage_return_in_insert_text(self) -> 'Generator':
+    def test_strips_carriage_return_in_insert_text(self) -> Generator:
         yield from self.verify(
             completion_items=[{
                 'label': 'greeting',
@@ -669,7 +669,7 @@ class QueryCompletionsTests(CompletionsTestsBase):
             insert_text='',
             expected_text='hello\nworld')
 
-    def test_strips_carriage_return_in_text_edit(self) -> 'Generator':
+    def test_strips_carriage_return_in_text_edit(self) -> Generator:
         yield from self.verify(
             completion_items=[{
                 'label': 'greeting',
@@ -778,7 +778,7 @@ class QueryCompletionsNoResolverTests(CompletionsTestsBase):
         capabilities['capabilities']['completionProvider']['resolveProvider'] = False
         return capabilities
 
-    def test_additional_edits_if_session_does_not_have_the_resolve_capability(self) -> 'Generator':
+    def test_additional_edits_if_session_does_not_have_the_resolve_capability(self) -> Generator:
         completion_item = {
             'label': 'ghjk',
             'additionalTextEdits': [

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sublime
 from LSP.plugin.core.settings import read_client_config, update_client_config
 from LSP.plugin.core.views import get_uri_and_position_from_location

--- a/tests/test_configurations.py
+++ b/tests/test_configurations.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from LSP.plugin.core.configurations import WindowConfigManager
 from test_mocks import DISABLED_CONFIG
 from test_mocks import TEST_CONFIG

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from LSP.plugin.core.logging import debug
 from LSP.plugin.core.protocol import Request
 from LSP.plugin.core.registry import windows
@@ -125,7 +126,7 @@ class WindowDocumentHandlerTests(DeferrableTestCase):
         def handler2(params: Any) -> None:
             promise2.fulfill(params)
 
-        def error_handler(params: 'Any') -> None:
+        def error_handler(params: Any) -> None:
             debug("Got error:", params, "awaiting timeout :(")
 
         self.session1.send_request(Request("$test/getReceived", {"method": method}), handler1, error_handler)

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from LSP.plugin import apply_text_edits
 from LSP.plugin.core.edit import parse_workspace_edit
 from LSP.plugin.core.protocol import TextDocumentEdit, TextEdit, WorkspaceEdit

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from LSP.plugin import FileWatcher
 from LSP.plugin import FileWatcherEvent
 from LSP.plugin import FileWatcherEventType

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -33,7 +33,7 @@ def setup_workspace_folder() -> str:
 class TestFileWatcher(FileWatcher):
 
     # The list of watchers created by active sessions.
-    _active_watchers: List['TestFileWatcher'] = []
+    _active_watchers: List[TestFileWatcher] = []
 
     @classmethod
     def create(
@@ -43,7 +43,7 @@ class TestFileWatcher(FileWatcher):
         events: List[FileWatcherEventType],
         ignores: List[str],
         handler: FileWatcherProtocol
-    ) -> 'TestFileWatcher':
+    ) -> TestFileWatcher:
         watcher = TestFileWatcher(root_path, patterns, events, ignores, handler)
         cls._active_watchers.append(watcher)
         return watcher

--- a/tests/test_message_request_handler.py
+++ b/tests/test_message_request_handler.py
@@ -1,7 +1,8 @@
-import unittest
-from test_mocks import MockSession
+from __future__ import annotations
 from LSP.plugin.core.message_request_handler import MessageRequestHandler
+from test_mocks import MockSession
 import sublime
+import unittest
 
 
 class MessageRequestHandlerTest(unittest.TestCase):

--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from LSP.plugin.core.logging import debug
 from LSP.plugin.core.protocol import Notification
 from LSP.plugin.core.protocol import Request

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from LSP.plugin.core.protocol import Point, Position, Range, Request, Notification
 from LSP.plugin.core.transports import JsonRpcProcessor
 import unittest

--- a/tests/test_rename_panel.py
+++ b/tests/test_rename_panel.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from LSP.plugin.rename import utf16_to_code_points
 import unittest
 

--- a/tests/test_server_notifications.py
+++ b/tests/test_server_notifications.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from LSP.plugin.core.protocol import DiagnosticSeverity
 from LSP.plugin.core.protocol import DiagnosticTag
 from LSP.plugin.core.protocol import PublishDiagnosticsParams

--- a/tests/test_server_panel_circular.py
+++ b/tests/test_server_panel_circular.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from LSP.plugin.core.panels import MAX_LOG_LINES_LIMIT_ON
 from LSP.plugin.core.panels import PanelName
 from LSP.plugin.core.registry import windows

--- a/tests/test_server_requests.py
+++ b/tests/test_server_requests.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from LSP.plugin.core.protocol import ErrorCodes
 from LSP.plugin.core.protocol import TextDocumentSyncKind
 from LSP.plugin.core.sessions import SessionBufferProtocol

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from LSP.plugin.core.collections import DottedDict
 from LSP.plugin.core.protocol import Diagnostic
 from LSP.plugin.core.protocol import DocumentUri

--- a/tests/test_signature_help.py
+++ b/tests/test_signature_help.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from LSP.plugin.core.protocol import SignatureHelp
 from LSP.plugin.core.signature_help import SigHelp
 import sublime

--- a/tests/test_single_document.py
+++ b/tests/test_single_document.py
@@ -79,13 +79,13 @@ class SingleDocumentTestCase(TextDocumentTestCase):
         ])
         self.assertEqual(entire_content(self.view), "a\nhello there\nc\n")
 
-    def test_did_close(self) -> 'Generator':
+    def test_did_close(self) -> Generator:
         self.assertTrue(self.view)
         self.assertTrue(self.view.is_valid())
         self.view.close()
         yield from self.await_message("textDocument/didClose")
 
-    def test_sends_save_with_purge(self) -> 'Generator':
+    def test_sends_save_with_purge(self) -> Generator:
         assert self.view
         self.view.settings().set("lsp_format_on_save", False)
         self.insert_characters("A")
@@ -94,7 +94,7 @@ class SingleDocumentTestCase(TextDocumentTestCase):
         yield from self.await_message("textDocument/didSave")
         yield from self.await_clear_view_and_save()
 
-    def test_formats_on_save(self) -> 'Generator':
+    def test_formats_on_save(self) -> Generator:
         assert self.view
         self.view.settings().set("lsp_format_on_save", True)
         self.insert_characters("A")
@@ -114,7 +114,7 @@ class SingleDocumentTestCase(TextDocumentTestCase):
         self.assertEquals("BBB", text)
         yield from self.await_clear_view_and_save()
 
-    def test_hover_info(self) -> 'Generator':
+    def test_hover_info(self) -> Generator:
         assert self.view
         self.set_response('textDocument/hover', {"contents": "greeting"})
         self.view.run_command('insert', {"characters": "Hello Wrld"})
@@ -124,7 +124,7 @@ class SingleDocumentTestCase(TextDocumentTestCase):
         last_content = _test_contents[-1]
         self.assertTrue("greeting" in last_content)
 
-    def test_remove_line_and_then_insert_at_that_line_at_end(self) -> 'Generator':
+    def test_remove_line_and_then_insert_at_that_line_at_end(self) -> Generator:
         original = (
             'a\n'
             'b\n'
@@ -147,7 +147,7 @@ class SingleDocumentTestCase(TextDocumentTestCase):
         # 2) deletes line index 2.
         yield from self.__run_formatting_test(original, expected, file_changes)
 
-    def test_apply_formatting(self) -> 'Generator':
+    def test_apply_formatting(self) -> Generator:
         original = (
             '<dom-module id="some-thing">\n'
             '<style></style>\n'
@@ -169,7 +169,7 @@ class SingleDocumentTestCase(TextDocumentTestCase):
         )
         yield from self.__run_formatting_test(original, expected, file_changes)
 
-    def test_apply_formatting_and_preserve_order(self) -> 'Generator':
+    def test_apply_formatting_and_preserve_order(self) -> Generator:
         original = (
             'abcde\n'
             'fghij\n'
@@ -189,7 +189,7 @@ class SingleDocumentTestCase(TextDocumentTestCase):
         )
         yield from self.__run_formatting_test(original, expected, file_changes)
 
-    def test_tabs_are_respected_even_when_translate_tabs_to_spaces_is_set_to_true(self) -> 'Generator':
+    def test_tabs_are_respected_even_when_translate_tabs_to_spaces_is_set_to_true(self) -> Generator:
         original = ' ' * 4
         file_changes = [((0, 0), (0, 4), '\t')]
         expected = '\t'
@@ -204,7 +204,7 @@ class SingleDocumentTestCase(TextDocumentTestCase):
         original: 'Iterable[str]',
         expected: 'Iterable[str]',
         file_changes: 'List[Tuple[Tuple[int, int], Tuple[int, int], str]]'
-    ) -> 'Generator':
+    ) -> Generator:
         assert self.view
         original_change_count = self.insert_characters(''.join(original))
         # self.assertEqual(original_change_count, 1)
@@ -219,7 +219,7 @@ class SingleDocumentTestCase(TextDocumentTestCase):
         edited_content = self.view.substr(sublime.Region(0, self.view.size()))
         self.assertEquals(edited_content, ''.join(expected))
 
-    def __run_goto_test(self, response: list, text_document_request: str, subl_command_suffix: str) -> 'Generator':
+    def __run_goto_test(self, response: list, text_document_request: str, subl_command_suffix: str) -> Generator:
         assert self.view
         self.insert_characters(GOTO_CONTENT)
         # Put the cursor back at the start of the buffer, otherwise is_at_word fails in goto.py.
@@ -242,31 +242,31 @@ class SingleDocumentTestCase(TextDocumentTestCase):
         first = self.view.sel()[0].begin()
         self.assertEqual(self.view.substr(sublime.Region(first, first + 1)), "F")
 
-    def test_definition(self) -> 'Generator':
+    def test_definition(self) -> Generator:
         yield from self.__run_goto_test(GOTO_RESPONSE, 'definition', 'definition')
 
-    def test_definition_location_link(self) -> 'Generator':
+    def test_definition_location_link(self) -> Generator:
         yield from self.__run_goto_test(GOTO_RESPONSE_LOCATION_LINK, 'definition', 'definition')
 
-    def test_type_definition(self) -> 'Generator':
+    def test_type_definition(self) -> Generator:
         yield from self.__run_goto_test(GOTO_RESPONSE, 'typeDefinition', 'type_definition')
 
-    def test_type_definition_location_link(self) -> 'Generator':
+    def test_type_definition_location_link(self) -> Generator:
         yield from self.__run_goto_test(GOTO_RESPONSE_LOCATION_LINK, 'typeDefinition', 'type_definition')
 
-    def test_declaration(self) -> 'Generator':
+    def test_declaration(self) -> Generator:
         yield from self.__run_goto_test(GOTO_RESPONSE, 'declaration', 'declaration')
 
-    def test_declaration_location_link(self) -> 'Generator':
+    def test_declaration_location_link(self) -> Generator:
         yield from self.__run_goto_test(GOTO_RESPONSE_LOCATION_LINK, 'declaration', 'declaration')
 
-    def test_implementation(self) -> 'Generator':
+    def test_implementation(self) -> Generator:
         yield from self.__run_goto_test(GOTO_RESPONSE, 'implementation', 'implementation')
 
-    def test_implementation_location_link(self) -> 'Generator':
+    def test_implementation_location_link(self) -> Generator:
         yield from self.__run_goto_test(GOTO_RESPONSE_LOCATION_LINK, 'implementation', 'implementation')
 
-    def test_expand_selection(self) -> 'Generator':
+    def test_expand_selection(self) -> Generator:
         self.insert_characters("abcba\nabcba\nabcba\n")
         self.view.run_command("lsp_selection_set", {"regions": [(2, 2)]})
         self.assertEqual(len(self.view.sel()), 1)
@@ -282,7 +282,7 @@ class SingleDocumentTestCase(TextDocumentTestCase):
             "range": {"start": {"line": 0, "character": 2}, "end": {"line": 0, "character": 3}}
         }]
 
-        def expand_and_check(a: int, b: int) -> 'Generator':
+        def expand_and_check(a: int, b: int) -> Generator:
             self.set_response("textDocument/selectionRange", response)
             self.view.run_command("lsp_expand_selection")
             yield from self.await_message("textDocument/selectionRange")
@@ -292,7 +292,7 @@ class SingleDocumentTestCase(TextDocumentTestCase):
         yield from expand_and_check(1, 3)
         yield from expand_and_check(0, 5)
 
-    def test_rename(self) -> 'Generator':
+    def test_rename(self) -> Generator:
         self.insert_characters("foo\nfoo\nfoo\n")
         self.set_response("textDocument/rename", {
                 'changes': {
@@ -324,7 +324,7 @@ class SingleDocumentTestCase(TextDocumentTestCase):
         yield from self.await_view_change(9)
         self.assertEqual(self.view.substr(sublime.Region(0, self.view.size())), "bar\nbar\nbar\n")
 
-    def test_run_command(self) -> 'Generator':
+    def test_run_command(self) -> Generator:
         self.set_response("workspace/executeCommand", {"canReturnAnythingHere": "asdf"})
         promise = YieldPromise()
         sublime.set_timeout_async(
@@ -338,7 +338,7 @@ class SingleDocumentTestCase(TextDocumentTestCase):
         yield from self.await_message("workspace/executeCommand")
         self.assertEqual(promise.result(), {"canReturnAnythingHere": "asdf"})
 
-    def test_progress(self) -> 'Generator':
+    def test_progress(self) -> Generator:
         request = Request("foobar", {"hello": "world"}, self.view, progress=True)
         self.set_response("foobar", {"general": "kenobi"})
         promise = self.session.send_request_task(request)
@@ -349,7 +349,7 @@ class SingleDocumentTestCase(TextDocumentTestCase):
 
 class SingleDocumentTestCase2(TextDocumentTestCase):
 
-    def test_did_change(self) -> 'Generator':
+    def test_did_change(self) -> Generator:
         assert self.view
         self.maxDiff = None
         self.insert_characters("A")
@@ -381,7 +381,7 @@ class SingleDocumentTestCase3(TextDocumentTestCase):
     def get_test_name(cls) -> str:
         return "testfile2"
 
-    def test_did_change_before_did_close(self) -> 'Generator':
+    def test_did_change_before_did_close(self) -> Generator:
         assert self.view
         self.view.window().run_command("chain", {
             "commands": [
@@ -403,7 +403,7 @@ class WillSaveWaitUntilTestCase(TextDocumentTestCase):
         capabilities['capabilities']['textDocumentSync']['willSaveWaitUntil'] = True
         return capabilities
 
-    def test_will_save_wait_until(self) -> 'Generator':
+    def test_will_save_wait_until(self) -> Generator:
         assert self.view
         self.insert_characters("A")
         yield from self.await_message("textDocument/didChange")

--- a/tests/test_single_document.py
+++ b/tests/test_single_document.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from copy import deepcopy
 from LSP.plugin import apply_text_edits, Request
 from LSP.plugin.core.protocol import UINT_MAX

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from LSP.plugin.core.types import diff
 from LSP.plugin.core.types import basescope2languageid
 from LSP.plugin.core.types import DocumentSelector

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from LSP.plugin.core.url import filename_to_uri
 from LSP.plugin.core.url import parse_uri
 from LSP.plugin.core.url import view_to_uri

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from copy import deepcopy
 from LSP.plugin.core.protocol import CodeActionKind
 from LSP.plugin.core.protocol import Diagnostic

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from LSP.plugin.core.workspace import sorted_workspace_folders, is_subpath_of, WorkspaceFolder
 import os
 import unittest


### PR DESCRIPTION
This commit...

1. adds `from __future__ import annotations` to each relevant module in order to enable language level type annotation support.
2. as a result most quotation marks can be removed from type annotations.