### PR TITLE
Make more use of typing_extensions module

### DIFF
--- a/plugin/core/typing.py
+++ b/plugin/core/typing.py
@@ -37,7 +37,12 @@ if sys.version_info >= (3, 11):
         TypeGuard,
     )
 else:
-    _T = TypeVar("_T")
+    from typing_extensions import (  # noqa: F401
+        NotRequired,
+        ParamSpec,
+        Required,
+        TypeGuard,
+    )
 
     class StrEnum(str, Enum):
         """
@@ -48,19 +53,3 @@ else:
 
         __format__ = str.__format__
         __str__ = str.__str__
-
-    class NotRequired(Type, Generic[_T]):  # type: ignore
-        pass
-
-    class ParamSpec(Type):  # type: ignore
-        args = ...
-        kwargs = ...
-
-        def __init__(*args, **kwargs) -> None:  # type: ignore
-            pass
-
-    class Required(Type, Generic[_T]):  # type: ignore
-        pass
-
-    class TypeGuard(Type, Generic[_T]):  # type: ignore
-        pass

--- a/plugin/core/typing.py
+++ b/plugin/core/typing.py
@@ -27,23 +27,16 @@ from typing import (  # noqa: F401
     cast,
     final,
 )
+from typing_extensions import (  # noqa: F401
+    NotRequired,
+    ParamSpec,
+    Required,
+    TypeGuard,
+)
 
 if sys.version_info >= (3, 11):
     from enum import StrEnum  # noqa: F401
-    from typing import (  # noqa: F401
-        NotRequired,
-        ParamSpec,
-        Required,
-        TypeGuard,
-    )
 else:
-    from typing_extensions import (  # noqa: F401
-        NotRequired,
-        ParamSpec,
-        Required,
-        TypeGuard,
-    )
-
     class StrEnum(str, Enum):
         """
         Naive polyfill for Python 3.11's StrEnum.


### PR DESCRIPTION
This commit replaces various homegrown type definitions by imports from typing_extensions module.