### PR TITLE
Disable CI on Mac

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: SublimeText/UnitTesting/actions/setup@v1
       - uses: SublimeText/UnitTesting/actions/run-tests@v1
+        with:
+          coverage: true
 
   Lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os:
+          - ubuntu-latest
+          # - macOS-latest
+          - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: SublimeText/UnitTesting/actions/setup@v1
       - uses: SublimeText/UnitTesting/actions/run-tests@v1
-        with:
-          coverage: true
 
   Lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It seems like the UnitTesting action is currently broken on Mac in some way.
> Package Control: The library "coverage" is not available for Python 3.3

Let's try if this fixes it, and I don't think we need or have used the coverage report anyway.

```
Terminated Sublime Text
Package Control: Installing 6 libraries...
Package Control: The library "coverage" is not available for Python 3.3
Package Control: Installed library "wcmatch" 1.2.1 for Python 3.8
Package Control: Installed library "coverage" 7.5.0 for Python 3.8
Package Control: Installed library "bracex" 2.1.1 for Python 3.8
Package Control: Installed library "mdpopups" 4.2.2 for Python 3.8
Package Control: Installed library "typing_extensions" 4.11.0 for Python 3.8
Package Control

Sublime Text needs to be restarted for installed or updated libraries to take effect. Otherwise some packages may not work properly..
missing libraries:
Traceback (most recent call last):
  File "/Users/runner/Library/Application Support/Sublime Text/Packages/0_install_package_control_helper/install_package_control_helper.py", line 70, in check_libraries
    log.write(" ".join(sorted(missing_libraries)) + "\n")
TypeError: sequence item 0: expected str instance, Library found
Package Control: The library "coverage" is not available for Python 3.3
missing libraries:
Traceback (most recent call last):
  File "/Users/runner/Library/Application Support/Sublime Text/Packages/0_install_package_control_helper/install_package_control_helper.py", line 70, in check_libraries
    log.write(" ".join(sorted(missing_libraries)) + "\n")
TypeError: sequence item 0: expected str instance, Library found
Package Control: The library "coverage" is not available for Python 3.3
missing libraries:
Traceback (most recent call last):
  File "/Users/runner/Library/Application Support/Sublime Text/Packages/0_install_package_control_helper/install_package_control_helper.py", line 70, in check_libraries
    log.write(" ".join(sorted(missing_libraries)) + "\n")
TypeError: sequence item 0: expected str instance, Library found
Timeout: Fail to install Package Control.
Error: Process completed with exit code 1.
```