### PR TITLE
feat: add note for sublimelsp/lsp_utils#118

### DIFF
--- a/lsp_utils.sublime-settings
+++ b/lsp_utils.sublime-settings
@@ -3,6 +3,7 @@
     // The allowed values are:
     //  - 'system' - a Node.js runtime found on the PATH
     //  - 'local' - a Node.js runtime managed by LSP that doesn't affect the system
+    //  - '/path/to/nodejs/bin/node' - a Node.js runtime at the specified path
     // The order in which the values are specified determines which one is tried first,
     // with the later one being used as a fallback.
     // You can also specify just a single value to disable the fallback.


### PR DESCRIPTION
Reference PR: [sublimelsp/lsp_utils#118](https://github.com/sublimelsp/lsp_utils/pull/118)

This PR updates the `lsp_utils.sublime-settings` to note support for specifying a filesystem path to a Node.js binary.