### PR TITLE
Check CI status on Mac

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          # - macOS-latest
+          - macOS-latest
           - windows-latest
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Here we can track whether CI is still broken on Mac (use Re-Run jobs button from the "checks" tab) and re-enable it once it gets fixed upstream.