### PR TITLE
Re-enable CI on Mac

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          # - macOS-latest
+          - macOS-latest
           - windows-latest
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
UnitTesting 1.8.1 excludes coverage dependency from python 3.3 on arm platform.

GH Actions seem to have switched MacOS to ARM platform recently.