### PR TITLE
Fix CodeActionTriggerKind enum access

### DIFF
--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -403,9 +403,10 @@ def text_document_code_action_params(
     only_kinds: list[CodeActionKind] | None = None,
     manual: bool = False
 ) -> CodeActionParams:
+    trigger_kind = CodeActionTriggerKind.Invoked.value if manual else CodeActionTriggerKind.Automatic.value
     context: CodeActionContext = {
         "diagnostics": diagnostics,
-        "triggerKind": CodeActionTriggerKind.Invoked if manual else CodeActionTriggerKind.Automatic,
+        "triggerKind": cast(CodeActionTriggerKind, trigger_kind),
     }
     if only_kinds:
         context["only"] = only_kinds


### PR DESCRIPTION
A bug that was missed, resulting from importing the `enum` stdlib on Python 3.8 (compare https://github.com/sublimelsp/LSP/pull/2446#issuecomment-2059553794).