### PR TITLE
Fix arguments error if commands are bound to mouse keys

### DIFF
--- a/plugin/code_lens.py
+++ b/plugin/code_lens.py
@@ -240,6 +240,9 @@ class LspCodeLensCommand(LspTextCommand):
                 lambda i: self.on_select(code_lenses, i)
             )
 
+    def want_event(self) -> bool:
+        return False
+
     def on_select(self, code_lenses: list[CodeLensExtended], index: int) -> None:
         try:
             code_lens = code_lenses[index]

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -368,6 +368,9 @@ class LspSelectCompletionCommand(LspTextCommand):
         else:
             self._on_resolved(session_name, item)
 
+    def want_event(self) -> bool:
+        return False
+
     def _on_resolved_async(self, session_name: str, item: CompletionItem) -> None:
         sublime.set_timeout(functools.partial(self._on_resolved, session_name, item))
 

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -219,6 +219,9 @@ class LspRestartServerCommand(LspTextCommand):
         else:
             wm.window.show_quick_panel(self._config_names, partial(self.restart_server, wm))
 
+    def want_event(self) -> bool:
+        return False
+
     def restart_server(self, wm: WindowManager, index: int) -> None:
         if index == -1:
             return
@@ -270,8 +273,14 @@ class LspNextDiagnosticCommand(LspTextCommand):
     def run(self, edit: sublime.Edit, point: int | None = None) -> None:
         navigate_diagnostics(self.view, point, forward=True)
 
+    def want_event(self) -> bool:
+        return False
+
 
 class LspPrevDiagnosticCommand(LspTextCommand):
 
     def run(self, edit: sublime.Edit, point: int | None = None) -> None:
         navigate_diagnostics(self.view, point, forward=False)
+
+    def want_event(self) -> bool:
+        return False

--- a/plugin/semantic_highlighting.py
+++ b/plugin/semantic_highlighting.py
@@ -30,6 +30,9 @@ class LspShowScopeNameCommand(LspTextCommand):
 
     capability = 'semanticTokensProvider'
 
+    def want_event(self) -> bool:
+        return False
+
     def run(self, _: sublime.Edit) -> None:
         point = self.view.sel()[-1].b
         scope = self.view.scope_name(point).rstrip()


### PR DESCRIPTION
LspTextCommands opt-in to mouse events, but not all are designed to handle required events. Therefore they fail, when being bound to mouse keys.

see https://forum.sublimetext.com/t/mouse-map-always-attach-current-event-in-its-args/72502/4

This commit opts-out those commands.