### PR TITLE
Use orjson to de-/serialize json-rpc messages

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -3,6 +3,7 @@
         ">=4096": [
             "bracex",
             "mdpopups",
+            "orjson",
             "typing_extensions",
             "wcmatch"
         ]


### PR DESCRIPTION
After a recent discussion about json serialization performance, I was curious about impact orjson makes on LSP processing performance.

This PR showcases how orjson as transport de-/serializer.

During recent 2 weeks of daily use, I haven't realized any issues, but also my projects are small enough to not realize any significant impact on overall performance.

Maybe someone using heavy language servers such as typescript can try to benchmark it.

