### PR TITLE
Add variable for VersionedTextDocumentIdentifier to use with lsp_execute

### DIFF
--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -43,14 +43,15 @@ You can include special variables in the `command_args` array that will be autom
 
 | Variable | Type | Description |
 | -------- | ---- | ----------- |
-| `"$document_id"` | object | JSON object `{ 'uri': string }` containing the file URI of the active view, see [Document Identifier](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentIdentifier) |
+| `"$document_id"` | object | JSON object `{ "uri": string }` containing the URI of the active view, see [TextDocumentIdentifier](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentIdentifier) |
+| `"$versioned_document_id"` | object | JSON object `{ "uri": string, "version": int }` containing the URI and version of the active view, see [VersionedTextDocumentIdentifier](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#versionedTextDocumentIdentifier) |
 | `"$file_uri"` | string | File URI of the active view |
 | `"$selection"` | string | Content of the (topmost) selection |
 | `"$offset"` | int | Character offset of the (topmost) cursor position |
 | `"$selection_begin"` | int | Character offset of the begin of the (topmost) selection |
 | `"$selection_end"` | int | Character offset of the end of the (topmost) selection |
-| `"$position"` | object | JSON object `{ 'line': int, 'character': int }` of the (topmost) cursor position, see [Position](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#position) |
+| `"$position"` | object | JSON object `{ "line": int, "character": int }` of the (topmost) cursor position, see [Position](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#position) |
 | `"$line"` | int | Zero-based line number of the (topmost) cursor position, see [Position](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#position) |
 | `"$character"` | int | Zero-based character offset relative to the current line of the (topmost) cursor position, see [Position](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#position) |
-| `"$range"` | object | JSON object with `'start'` and `'end'` positions of the (topmost) selection, see [Range](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#range) |
-| `"$text_document_position"` | object | JSON object with `'textDocument'` and `'position'` of the (topmost) selection, see [TextDocumentPositionParams](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentPositionParams) |
+| `"$range"` | object | JSON object with `"start"` and `"end"` positions of the (topmost) selection, see [Range](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#range) |
+| `"$text_document_position"` | object | JSON object with `"textDocument"` and `"position"` of the (topmost) selection, see [TextDocumentPositionParams](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentPositionParams) |

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -8,6 +8,7 @@ from .core.views import region_to_range
 from .core.views import text_document_identifier
 from .core.views import text_document_position_params
 from .core.views import uri_from_view
+from .core.views import versioned_text_document_identifier
 from typing import Any
 import sublime
 
@@ -65,6 +66,8 @@ class LspExecuteCommand(LspTextCommand):
         for i, arg in enumerate(command_args):
             if arg in ["$document_id", "${document_id}"]:
                 command_args[i] = text_document_identifier(view)
+            elif arg in ["$versioned_document_id", "${versioned_document_id}"]:
+                command_args[i] = versioned_text_document_identifier(view, view.change_count())
             elif arg in ["$file_uri", "${file_uri}"]:
                 command_args[i] = uri_from_view(view)
             elif region is not None:


### PR DESCRIPTION
Should close #2515

(And a small change in the docs to use proper double quotes `"` instead of `'` for the JSON objects.)