### PR TITLE
use session-unique region keys for semantic tokens

### DIFF
--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -677,16 +677,17 @@ class SessionBuffer:
         # don't update regions if there were additional changes to the buffer in the meantime
         if self.semantic_tokens.view_change_count != view.change_count():
             return
+        session_name = self.session.config.name
         for region_key in self.semantic_tokens.active_region_keys.copy():
             if region_key not in scope_regions.keys():
                 self.semantic_tokens.active_region_keys.remove(region_key)
                 for sv in self.session_views:
-                    sv.view.erase_regions(f"lsp_semantic_{self.session.config.name}_{region_key}")
+                    sv.view.erase_regions(f"lsp_semantic_{session_name}_{region_key}")
         for region_key, (scope, regions) in scope_regions.items():
             if region_key not in self.semantic_tokens.active_region_keys:
                 self.semantic_tokens.active_region_keys.add(region_key)
             for sv in self.session_views:
-                sv.view.add_regions(f"lsp_semantic_{self.session.config.name}_{region_key}", regions, scope, flags=SEMANTIC_TOKEN_FLAGS)
+                sv.view.add_regions(f"lsp_semantic_{session_name}_{region_key}", regions, scope, flags=SEMANTIC_TOKEN_FLAGS)
 
     def _get_semantic_region_key_for_scope(self, scope: str) -> int:
         if scope not in self._semantic_region_keys:
@@ -695,8 +696,9 @@ class SessionBuffer:
         return self._semantic_region_keys[scope]
 
     def _clear_semantic_token_regions(self, view: sublime.View) -> None:
+        session_name = self.session.config.name
         for region_key in self.semantic_tokens.active_region_keys:
-            view.erase_regions(f"lsp_semantic_{self.session.config.name}_{region_key}")
+            view.erase_regions(f"lsp_semantic_{session_name}_{region_key}")
 
     def set_semantic_tokens_pending_refresh(self, needs_refresh: bool = True) -> None:
         self.semantic_tokens.needs_refresh = needs_refresh

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -687,7 +687,8 @@ class SessionBuffer:
             if region_key not in self.semantic_tokens.active_region_keys:
                 self.semantic_tokens.active_region_keys.add(region_key)
             for sv in self.session_views:
-                sv.view.add_regions(f"lsp_semantic_{session_name}_{region_key}", regions, scope, flags=SEMANTIC_TOKEN_FLAGS)
+                sv.view.add_regions(
+                    f"lsp_semantic_{session_name}_{region_key}", regions, scope, flags=SEMANTIC_TOKEN_FLAGS)
 
     def _get_semantic_region_key_for_scope(self, scope: str) -> int:
         if scope not in self._semantic_region_keys:

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -681,12 +681,12 @@ class SessionBuffer:
             if region_key not in scope_regions.keys():
                 self.semantic_tokens.active_region_keys.remove(region_key)
                 for sv in self.session_views:
-                    sv.view.erase_regions(f"lsp_semantic_{region_key}")
+                    sv.view.erase_regions(f"lsp_semantic_{self.session.config.name}_{region_key}")
         for region_key, (scope, regions) in scope_regions.items():
             if region_key not in self.semantic_tokens.active_region_keys:
                 self.semantic_tokens.active_region_keys.add(region_key)
             for sv in self.session_views:
-                sv.view.add_regions(f"lsp_semantic_{region_key}", regions, scope, flags=SEMANTIC_TOKEN_FLAGS)
+                sv.view.add_regions(f"lsp_semantic_{self.session.config.name}_{region_key}", regions, scope, flags=SEMANTIC_TOKEN_FLAGS)
 
     def _get_semantic_region_key_for_scope(self, scope: str) -> int:
         if scope not in self._semantic_region_keys:
@@ -696,7 +696,7 @@ class SessionBuffer:
 
     def _clear_semantic_token_regions(self, view: sublime.View) -> None:
         for region_key in self.semantic_tokens.active_region_keys:
-            view.erase_regions(f"lsp_semantic_{region_key}")
+            view.erase_regions(f"lsp_semantic_{self.session.config.name}_{region_key}")
 
     def set_semantic_tokens_pending_refresh(self, needs_refresh: bool = True) -> None:
         self.semantic_tokens.needs_refresh = needs_refresh

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -140,8 +140,9 @@ class SessionView:
         hover_highlight_style = userprefs().hover_highlight_style
         line_modes = ["m", "s"]
         self.view.add_regions(self.CODE_ACTIONS_KEY, r)  # code actions lightbulb icon should always be on top
+        session_name = self.session.config.name
         for key in range(1, 100):
-            keys.append(f"lsp_semantic_{self.session.config.name}_{key}")
+            keys.append(f"lsp_semantic_{session_name}_{key}")
         if document_highlight_style in ("background", "fill"):
             for kind in DOCUMENT_HIGHLIGHT_KIND_NAMES.values():
                 for mode in line_modes:
@@ -151,14 +152,14 @@ class SessionView:
         for severity in range(1, 5):
             for mode in line_modes:
                 for tag in range(1, 3):
-                    keys.append(f"lsp{self.session.config.name}d{mode}{severity}_tags_{tag}")
+                    keys.append(f"lsp{session_name}d{mode}{severity}_tags_{tag}")
         keys.append("lsp_document_link")
         for severity in range(1, 5):
             for mode in line_modes:
-                keys.append(f"lsp{self.session.config.name}d{mode}{severity}_icon")
+                keys.append(f"lsp{session_name}d{mode}{severity}_icon")
         for severity in range(4, 0, -1):
             for mode in line_modes:
-                keys.append(f"lsp{self.session.config.name}d{mode}{severity}_underline")
+                keys.append(f"lsp{session_name}d{mode}{severity}_underline")
         if document_highlight_style in ("underline", "stippled"):
             for kind in DOCUMENT_HIGHLIGHT_KIND_NAMES.values():
                 for mode in line_modes:

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -141,7 +141,7 @@ class SessionView:
         line_modes = ["m", "s"]
         self.view.add_regions(self.CODE_ACTIONS_KEY, r)  # code actions lightbulb icon should always be on top
         for key in range(1, 100):
-            keys.append(f"lsp_semantic_{key}")
+            keys.append(f"lsp_semantic_{self.session.config.name}_{key}")
         if document_highlight_style in ("background", "fill"):
             for kind in DOCUMENT_HIGHLIGHT_KIND_NAMES.values():
                 for mode in line_modes:


### PR DESCRIPTION
I've noticed an issue with semantic tokens being removed when restarting a session that doesn't provide semantic tokens, when there is also another session active that provides semantic tokens.

In this case there are both LSP-typescript and LSP-volar sessions active in the view and LSP-typescript is the one that provides semantic tokens. On restarting LSP-volar, semantic tokens disappear and don't show up until changing the document or restarting LSP-typescript:

https://github.com/user-attachments/assets/c6021c53-a86c-4ed2-ab5d-31adf7fc894f

I've made semantic token regions session-specific so that initializing a session doesn't overwrite existing semantic token regions.