### PR TITLE
remove unnecessary use of generators for session retrieval

### DIFF
--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -12,7 +12,7 @@ from .views import uri_from_view
 from .windows import WindowManager
 from .windows import WindowRegistry
 from functools import partial
-from typing import Any, Generator, Iterable
+from typing import Any, Generator
 import operator
 import sublime
 import sublime_plugin
@@ -21,14 +21,14 @@ import sublime_plugin
 windows = WindowRegistry()
 
 
-def best_session(view: sublime.View, sessions: Iterable[Session], point: int | None = None) -> Session | None:
+def best_session(view: sublime.View, sessions: list[Session], point: int | None = None) -> Session | None:
     if point is None:
         try:
             point = view.sel()[0].b
         except IndexError:
             return None
     try:
-        return max(sessions, key=lambda s: view.score_selector(point, s.config.priority_selector))  # type: ignore
+        return max(sessions, key=lambda s: view.score_selector(point, s.config.priority_selector))
     except ValueError:
         return None
 

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -12,7 +12,7 @@ from .views import uri_from_view
 from .windows import WindowManager
 from .windows import WindowRegistry
 from functools import partial
-from typing import Any, Generator
+from typing import Any, Generator, Iterable
 import operator
 import sublime
 import sublime_plugin
@@ -21,7 +21,7 @@ import sublime_plugin
 windows = WindowRegistry()
 
 
-def best_session(view: sublime.View, sessions: list[Session], point: int | None = None) -> Session | None:
+def best_session(view: sublime.View, sessions: Iterable[Session], point: int | None = None) -> Session | None:
     if point is None:
         try:
             point = view.sel()[0].b

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -701,15 +701,15 @@ class AbstractViewListener(metaclass=ABCMeta):
         raise NotImplementedError()
 
     @abstractmethod
-    def sessions_async(self, capability: str | None = None) -> Generator[Session, None, None]:
+    def sessions_async(self, capability: str | None = None) -> list[Session]:
         raise NotImplementedError()
 
     @abstractmethod
-    def session_buffers_async(self, capability: str | None = None) -> Generator[SessionBufferProtocol, None, None]:
+    def session_buffers_async(self, capability: str | None = None) -> list[SessionBufferProtocol]:
         raise NotImplementedError()
 
     @abstractmethod
-    def session_views_async(self) -> Generator[SessionViewProtocol, None, None]:
+    def session_views_async(self) -> list[SessionViewProtocol]:
         raise NotImplementedError()
 
     @abstractmethod

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -319,13 +319,14 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
                             return
         self.view.erase_status(self.ACTIVE_DIAGNOSTIC)
 
-    def session_buffers_async(self, capability: str | None = None) -> Generator[SessionBuffer, None, None]:
-        for sv in self.session_views_async():
-            if capability is None or sv.has_capability_async(capability):
-                yield sv.session_buffer
+    def session_buffers_async(self, capability: str | None = None) -> list[SessionBuffer]:
+        return [
+            sv.session_buffer for sv in self.session_views_async()
+            if capability is None or sv.has_capability_async(capability)
+        ]
 
-    def session_views_async(self) -> Generator[SessionView, None, None]:
-        yield from self._session_views.values()
+    def session_views_async(self) -> list[SessionView]:
+        return list(self._session_views.values())
 
     def on_text_changed_async(self, change_count: int, changes: Iterable[sublime.TextChange]) -> None:
         if self.view.is_primary():
@@ -857,10 +858,11 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
     def session_async(self, capability: str, point: int | None = None) -> Session | None:
         return best_session(self.view, self.sessions_async(capability), point)
 
-    def sessions_async(self, capability: str | None = None) -> Generator[Session, None, None]:
-        for sb in self.session_buffers_async():
-            if capability is None or sb.has_capability(capability):
-                yield sb.session
+    def sessions_async(self, capability: str | None = None) -> list[Session]:
+        return [
+            sb.session for sb in self.session_buffers_async()
+            if capability is None or sb.has_capability(capability)
+        ]
 
     def session_by_name(self, name: str | None = None) -> Session | None:
         for sb in self.session_buffers_async():


### PR DESCRIPTION
Use of generators for retrieving the session is IMO completely unnecessary (correct me if I'm missing something).

1. This is not an expensive operation that would benefit from being interrupted early. Getting all sessions and returning a list is not gonna be slower. It will potentially even be faster as I imagine that generators have some overhead.
2. Passing generators around can lead to errors or at least confusion since the values can only be retrieved once from it. In cases like https://github.com/sublimelsp/LSP/blob/603632ea703d6296348680890859c148ac85229a/plugin/core/registry.py#L24-L33 where we pass generators and disguise it as `Iterable[Session]`, there is no way of knowing that the code will fail if trying to iterate sessions twice.