### PR TITLE
Make DocumentSyncListener more efficient if no server is running

### DIFF
--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -328,6 +328,8 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         return list(self._session_views.values())
 
     def on_text_changed_async(self, change_count: int, changes: Iterable[sublime.TextChange]) -> None:
+        if not self.sessions_async():
+            return
         if self.view.is_primary():
             for sv in self.session_views_async():
                 sv.on_text_changed_async(change_count, changes)
@@ -364,6 +366,8 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             return
         if not self._registered:
             self._register_async()
+        if not self.sessions_async():
+            return
         if userprefs().show_code_actions:
             self._do_code_actions_async()
         for sv in self.session_views_async():
@@ -382,6 +386,8 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
                 sb.do_inlay_hints_async(self.view)
 
     def on_selection_modified_async(self) -> None:
+        if not self.sessions_async():
+            return
         first_region, _ = self._update_stored_selection_async()
         if first_region is None:
             return
@@ -483,6 +489,8 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         return None
 
     def on_hover(self, point: int, hover_zone: int) -> None:
+        if not self.sessions_async():
+            return
         if self.view.is_popup_visible():
             return
         window = self.view.window()
@@ -525,6 +533,8 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
                 on_navigate=lambda href: self._on_navigate(href, point))
 
     def on_text_command(self, command_name: str, args: dict | None) -> tuple[str, dict] | None:
+        if not self.sessions_async():
+            return None
         if command_name == "auto_complete":
             self._auto_complete_triggered_manually = True
         elif command_name == "show_scope_name" and userprefs().semantic_highlighting:
@@ -540,6 +550,8 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         return None
 
     def on_post_text_command(self, command_name: str, args: dict[str, Any] | None) -> None:
+        if not self.sessions_async():
+            return
         if command_name == 'paste':
             format_on_paste = self.view.settings().get('lsp_format_on_paste', userprefs().lsp_format_on_paste)
             if format_on_paste and self.session_async("documentRangeFormattingProvider"):
@@ -553,6 +565,8 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             self.view.hide_popup()
 
     def on_query_completions(self, prefix: str, locations: list[int]) -> sublime.CompletionList | None:
+        if not self.sessions_async():
+            return None
         completion_list = sublime.CompletionList()
         triggered_manually = self._auto_complete_triggered_manually
         self._auto_complete_triggered_manually = False  # reset state for next completion popup

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -58,7 +58,7 @@ from functools import partial
 from functools import wraps
 from typing import Any, Callable, Generator, Iterable, TypeVar
 from typing import cast
-from typing_extensions import ParamSpec
+from typing_extensions import Concatenate, ParamSpec
 from weakref import WeakSet
 from weakref import WeakValueDictionary
 import itertools
@@ -74,7 +74,9 @@ P = ParamSpec('P')
 R = TypeVar('R')
 
 
-def requires_session(func: Callable[P, R]) -> Callable[P, R | None]:
+def requires_session(
+    func: Callable[Concatenate[DocumentSyncListener, P], R]
+) -> Callable[Concatenate[DocumentSyncListener, P], R | None]:
     """
     A decorator for the `DocumentSyncListener` event handlers, which immediately returns `None` if there are no
     `SessionView`s.
@@ -83,8 +85,8 @@ def requires_session(func: Callable[P, R]) -> Callable[P, R | None]:
     def wrapper(self: DocumentSyncListener, *args: P.args, **kwargs: P.kwargs) -> R | None:
         if not self.session_views_async():
             return None
-        return func(self, *args, **kwargs)  # pyright: ignore[reportCallIssue]
-    return wrapper  # pyright: ignore[reportReturnType]
+        return func(self, *args, **kwargs)
+    return wrapper
 
 
 def is_regular_view(v: sublime.View) -> bool:


### PR DESCRIPTION
Currently if LSP (this package) is installed, it runs quite some code in the background whenever the callbacks from [`DocumentSyncListener`](https://github.com/sublimelsp/LSP/blob/a6b17a4aa4d10d8ddc225413d221c4241b877f8b/plugin/documents.py#L139), which is a subclass of `sublime.ViewEventListener`, are triggered. This happens for *all* views, not only when a server is active. For example it creates an empty (if no server is running) `sublime.CompletionList` and schedules to run more code on the async thread in https://github.com/sublimelsp/LSP/blob/a6b17a4aa4d10d8ddc225413d221c4241b877f8b/plugin/documents.py#L555-L560
or it runs the debouncing in https://github.com/sublimelsp/LSP/blob/a6b17a4aa4d10d8ddc225413d221c4241b877f8b/plugin/documents.py#L384 via `sublime.set_timeout_async` each time when the cursor position changes.

All of this runs on the async thread, so you won't immediately experience any lag from this. But still it feels very inefficient and I wondered how it could be prevented or improved. We can't use the `is_applicable` classmethod for `DocumentSyncListener`, because if the view's syntax is changed later, an LSP session might still get attached to this view. So my idea would be to add a check in each of the ST callback methods and return early if there is no session running for this view. Does it make sense or is there a better solution?