### PR TITLE
fix: respect user-preferred flags when canceling completions

### DIFF
--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -258,11 +258,7 @@ class QueryCompletionsTask:
                 session.cancel_request(request_id, False)
         self._pending_completion_requests.clear()
 
-    def _resolve_task_async(
-        self,
-        completions: list[sublime.CompletionItem],
-        flags: sublime.AutoCompleteFlags = sublime.AutoCompleteFlags.NONE
-    ) -> None:
+    def _resolve_task_async(self, completions: list[sublime.CompletionItem], flags: sublime.AutoCompleteFlags) -> None:
         if not self._resolved:
             self._resolved = True
             self._on_done_async(completions, flags)

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -212,12 +212,7 @@ class QueryCompletionsTask:
         items: list[sublime.CompletionItem] = []
         item_defaults: CompletionItemDefaults = {}
         errors: list[Error] = []
-        flags = sublime.AutoCompleteFlags.NONE
-        prefs = userprefs()
-        if prefs.inhibit_snippet_completions:
-            flags |= sublime.AutoCompleteFlags.INHIBIT_EXPLICIT_COMPLETIONS
-        if prefs.inhibit_word_completions:
-            flags |= sublime.AutoCompleteFlags.INHIBIT_WORD_COMPLETIONS
+        flags = self._get_userpref_flags()
         view_settings = self._view.settings()
         include_snippets = view_settings.get("auto_complete_include_snippets") and \
             (self._triggered_manually or view_settings.get("auto_complete_include_snippets_when_typing"))
@@ -253,7 +248,7 @@ class QueryCompletionsTask:
         self._resolve_task_async(items, flags)
 
     def cancel_async(self) -> None:
-        self._resolve_task_async([])
+        self._resolve_task_async([], self._get_userpref_flags())
         self._cancel_pending_requests_async()
 
     def _cancel_pending_requests_async(self) -> None:
@@ -271,6 +266,15 @@ class QueryCompletionsTask:
         if not self._resolved:
             self._resolved = True
             self._on_done_async(completions, flags)
+
+    def _get_userpref_flags(self) -> sublime.AutoCompleteFlags:
+        prefs = userprefs()
+        flags = sublime.AutoCompleteFlags.NONE
+        if prefs.inhibit_snippet_completions:
+            flags |= sublime.AutoCompleteFlags.INHIBIT_EXPLICIT_COMPLETIONS
+        if prefs.inhibit_word_completions:
+            flags |= sublime.AutoCompleteFlags.INHIBIT_WORD_COMPLETIONS
+        return flags
 
 
 class LspResolveDocsCommand(LspTextCommand):


### PR DESCRIPTION
I haven't noticed this issue in practice (or if I did then it's subtle enough to not raise suspicion) but when looking at this code I've realized that the case when completions are canceled is not quite right since in that case we'd tell ST that we got empty completions and we'd pass the `sublime.AutoCompleteFlags.NONE` flag. The flag is the issue since we don't consider user's settings like `inhibit_snippet_completions` and `inhibit_word_completions` so in the case when completions would get canceled, we'd let ST show buffer and snippet completions which is not what the user expects.

It's kinda hard to test. I think this is only a potential issue for servers that return dynamic completions (like pyright) since then it's more likely that the completion request will get canceled on typing. But since pyright is very fast (at least in my small projects), it's hard to trigger that case (the new completions will come very fast after previous were canceled). I did a change like this to verify that what I said happens (user prefs are not respected):

```diff
diff --git a/plugin/completion.py b/plugin/completion.py
index 6e429290..68d83f45 100644
--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -197,6 +197,7 @@ class QueryCompletionsTask:
         promise, request_id = session.send_request_task_2(request)
         weak_session = weakref.ref(session)
         self._pending_completion_requests[request_id] = weak_session
+        self.cancel_async()
         return promise.then(lambda response: self._on_completion_response_async(response, request_id, weak_session))
 
     def _on_completion_response_async(
```