### PR TITLE
fix: cancel pending requests as early as possible

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -671,7 +671,7 @@ class SessionBufferProtocol(Protocol):
     def do_semantic_tokens_async(self, view: sublime.View) -> None:
         ...
 
-    def set_semantic_tokens_pending_refresh(self, needs_refresh: bool = True) -> None:
+    def set_semantic_tokens_pending_refresh(self, needs_refresh: bool = ...) -> None:
         ...
 
     def get_semantic_tokens(self) -> list[Any]:
@@ -680,16 +680,18 @@ class SessionBufferProtocol(Protocol):
     def do_inlay_hints_async(self, view: sublime.View) -> None:
         ...
 
-    def set_inlay_hints_pending_refresh(self, needs_refresh: bool = True) -> None:
+    def set_inlay_hints_pending_refresh(self, needs_refresh: bool = ...) -> None:
         ...
 
     def remove_inlay_hint_phantom(self, phantom_uuid: str) -> None:
         ...
 
-    def do_document_diagnostic_async(self, view: sublime.View, version: int | None = None) -> None:
+    def do_document_diagnostic_async(
+        self, view: sublime.View, version: int | None = ..., *, ignore_pending: bool = ...
+    ) -> None:
         ...
 
-    def set_document_diagnostic_pending_refresh(self, needs_refresh: bool = True) -> None:
+    def set_document_diagnostic_pending_refresh(self, needs_refresh: bool = ...) -> None:
         ...
 
 
@@ -2070,7 +2072,7 @@ class Session(TransportCallbacks):
         self.send_response(Response(request_id, None))
         visible_session_views, not_visible_session_views = self.session_views_by_visibility()
         for sv in visible_session_views:
-            sv.session_buffer.do_document_diagnostic_async(sv.view)
+            sv.session_buffer.do_document_diagnostic_async(sv.view, ignore_pending=True)
         for sv in not_visible_session_views:
             sv.session_buffer.set_document_diagnostic_pending_refresh()
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -687,7 +687,7 @@ class SessionBufferProtocol(Protocol):
         ...
 
     def do_document_diagnostic_async(
-        self, view: sublime.View, version: int | None = ..., *, ignore_pending: bool = ...
+        self, view: sublime.View, version: int | None = ..., *, forced_update: bool = ...
     ) -> None:
         ...
 
@@ -2072,7 +2072,7 @@ class Session(TransportCallbacks):
         self.send_response(Response(request_id, None))
         visible_session_views, not_visible_session_views = self.session_views_by_visibility()
         for sv in visible_session_views:
-            sv.session_buffer.do_document_diagnostic_async(sv.view, ignore_pending=True)
+            sv.session_buffer.do_document_diagnostic_async(sv.view, forced_update=True)
         for sv in not_visible_session_views:
             sv.session_buffer.set_document_diagnostic_pending_refresh()
 

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -487,7 +487,9 @@ class SessionBuffer:
 
     # --- textDocument/diagnostic --------------------------------------------------------------------------------------
 
-    def do_document_diagnostic_async(self, view: sublime.View, version: int | None = None) -> None:
+    def do_document_diagnostic_async(
+        self, view: sublime.View, version: int | None = None, ignore_pending: bool = False
+    ) -> None:
         mgr = self.session.manager()
         if not mgr or not self.has_capability("diagnosticProvider"):
             return
@@ -496,7 +498,7 @@ class SessionBuffer:
         if version is None:
             version = view.change_count()
         if self._document_diagnostic_pending_request:
-            if self._document_diagnostic_pending_request.version == version:
+            if self._document_diagnostic_pending_request.version == version and not ignore_pending:
                 return
             self.session.cancel_request(self._document_diagnostic_pending_request.request_id)
         params: DocumentDiagnosticParams = {'textDocument': text_document_identifier(view)}

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -488,7 +488,7 @@ class SessionBuffer:
     # --- textDocument/diagnostic --------------------------------------------------------------------------------------
 
     def do_document_diagnostic_async(
-        self, view: sublime.View, version: int | None = None, ignore_pending: bool = False
+        self, view: sublime.View, version: int | None = None, forced_update: bool = False
     ) -> None:
         mgr = self.session.manager()
         if not mgr or not self.has_capability("diagnosticProvider"):
@@ -498,7 +498,7 @@ class SessionBuffer:
         if version is None:
             version = view.change_count()
         if self._document_diagnostic_pending_request:
-            if self._document_diagnostic_pending_request.version == version and not ignore_pending:
+            if self._document_diagnostic_pending_request.version == version and not forced_update:
                 return
             self.session.cancel_request(self._document_diagnostic_pending_request.request_id)
         params: DocumentDiagnosticParams = {'textDocument': text_document_identifier(view)}


### PR DESCRIPTION
On document change, it makes sense to cancel pending semantic tokens/pull diagnostics requests as early as possible rather than waiting for the debounce timeout and potentially failing to cancel request on time and wasting resources on handling those.