### PR TITLE
Add commands to open user config/keybinds only

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -8,12 +8,28 @@
         }
     },
     {
+        "caption": "Preferences: LSP Settings User",
+        "command": "open_file",
+        "args": {
+            "file": "${packages}/User/LSP.sublime-settings",
+            "contents": "// Settings in here override those in \"LSP/LSP.sublime-settings\"\n{\n\t$0\n}\n"
+        }
+    },
+    {
         "caption": "Preferences: LSP Key Bindings",
         "command": "edit_settings",
         "args": {
             "base_file": "${packages}/LSP/Default.sublime-keymap",
             "user_file": "${packages}/User/Default ($platform).sublime-keymap",
             "default": "[\n\t$0\n]\n",
+        }
+    },
+    {
+        "caption": "Preferences: LSP Key Bindings User",
+        "command": "open_file",
+        "args": {
+            "file": "${packages}/User/Default ($platform).sublime-keymap",
+            "contents": "[\n\t$0\n]\n",
         }
     },
     {
@@ -26,11 +42,27 @@
         }
     },
     {
+        "caption": "Preferences: LSP Language ID Mapping Overrides User",
+        "command": "open_file",
+        "args": {
+            "file": "${packages}/User/language-ids.sublime-settings",
+            "contents": "// SublimeText base scope -> LSP Language ID overrides\n{\n\t// \"source.mylanguage\": \"mylang\"\n\t$0\n}\n"
+        }
+    },
+    {
         "caption": "Preferences: LSP Utils Settings",
         "command": "edit_settings",
         "args": {
             "base_file": "${packages}/LSP/lsp_utils.sublime-settings",
             "default": "// Settings in here override those in \"LSP/lsp_utils.sublime-settings\"\n{\n\t$0\n}\n"
+        }
+    },
+    {
+        "caption": "Preferences: LSP Utils Settings User",
+        "command": "open_file",
+        "args": {
+            "file": "${packages}/User/LSP/lsp_utils.sublime-settings",
+            "contents": "// Settings in here override those in \"LSP/lsp_utils.sublime-settings\"\n{\n\t$0\n}\n"
         }
     },
     {


### PR DESCRIPTION
The default Sublime way to open settings side-by-side is rather unergonomic as it wastes a lot of space, so it's sometimes easier to copy/paste/comment then edit the settings you want.

However, there is no command to open your user settings later without the defaults.

This PR adds such commands