### PR TITLE
feat: add fallback_kinds to lsp_code_actions

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -36,6 +36,13 @@
     //     "args": {"only_kinds": ["source"]},
     //     "context": [{"key": "lsp.session_with_capability", "operand": "codeActionProvider.codeActionKinds"}]
     // },
+    // Run Code Actions with Source Actions fallback
+    // {
+    //     "keys": ["UNBOUND"],
+    //     "command": "lsp_code_actions",
+    //     "args": {"fallback_kinds": ["source"]},
+    //     "context": [{"key": "lsp.session_with_capability", "operand": "codeActionProvider.codeActionKinds"}]
+    // },
     // Run Code Lens
     // {
     //     "keys": ["UNBOUND"],


### PR DESCRIPTION
An option to specify a fallthrough kind via `fallback_kinds` if `only_kinds`/default does not have a code action.

This is somewhat related to #1356, as it allows a fallback mechanism within a single keybinding, similar to `.sublime-keymap`'s handling of keybinding fallthrough. Maybe I've overlooked something and this is possible, but if not, here's a short video demo of it in action:

https://github.com/user-attachments/assets/b9de7fda-1721-467a-a564-e270a8bcddb2


The accompanying `.sublime-keymap`:
```
[{
  "keys": ["super+h"],
  "command": "lsp_code_actions",
  "args": {"fallback_kinds": ["source"]},
  "context": [{"key": "lsp.session_with_capability", "operand": "codeActionProvider.codeActionKinds"}]
}]
```


Typically achieved via something like this (does not work):
```
[{
  "keys": [ "super+h" ],
  "command": "lsp_code_actions",
  "args": {"only_kinds": ["source"]},
  "context": [
    { "key": "lsp.session_with_capability","operand": "codeActionProvider.codeActionKinds" }
  ]
}, {
  "keys": [ "super+h" ],
  "command": "lsp_code_actions",
  "context": [
    { "key": "lsp.session_with_capability","operand": "codeActionProvider.codeActionKinds" }
  ]
}]
```

That said, a simpler solution is to just use two separate key bindings, so it's a-ok if you decide not to merge this PR.