### PR TITLE
Bump flake8 to latest version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
           python-version: '3.8'
       - run: sudo apt update
       - run: sudo apt install --no-install-recommends -y x11-xserver-utils
-      - run: pip3 install mypy==1.7.1 flake8==5.0.4 pyright==1.1.381 orjson==3.10.7 --user
+      - run: pip3 install mypy==1.7.1 flake8==7.1.1 pyright==1.1.381 orjson==3.10.7 --user
       - run: echo "$HOME/.local/bin" >> $GITHUB_PATH
       - run: mypy stubs
       - run: flake8 plugin tests

--- a/plugin/references.py
+++ b/plugin/references.py
@@ -178,7 +178,7 @@ class LspSymbolReferencesCommand(LspTextCommand):
         placeholder = "References to " + word
         kind = get_symbol_kind_from_scope(self.view.scope_name(position))
         index = 0
-        locations.sort(key=lambda l: (l['uri'], Point.from_lsp(l['range']['start'])))
+        locations.sort(key=lambda location: (location['uri'], Point.from_lsp(location['range']['start'])))
         if len(selection):
             pt = selection[0].b
             view_filename = self.view.file_name()

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ per-file-ignores =
 [testenv]
 deps =
     mypy==1.7.1
-    flake8==5.0.4
+    flake8==7.1.1
     pyright==1.1.381
     orjson==3.10.7
 commands =


### PR DESCRIPTION
For me running `tox` locally was broken for quite some time because the outdated flake8 version reported many dubious errors (not sure why it didn't in the GitHub Actions CI). This should make it possible to run `tox` again without errors.

---

Also I wonder why the unit tests on Mac are randomly broken sometimes. It always seems to be caused by a timeout in a file watcher test. Maybe it would help to increase the timeout value, or could there be a different underlying issue?
https://github.com/sublimelsp/LSP/blob/55e2068eff99dc5e43019f9357137f8ac604c9d1/tests/setup.py#L20