### PR TITLE
Sorbet requires a directory be passed to the typecheck command

### DIFF
--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -617,7 +617,7 @@ There are multiple options:
         "clients": {
             "sorbet": {
                 "enabled": true,
-                "command": ["srb", "tc", "--typed", "true", "--enable-all-experimental-lsp-features", "--lsp", "--disable-watchman"],
+                "command": ["srb", "tc", "--typed", "true", "--enable-all-experimental-lsp-features", "--lsp", "--disable-watchman", "."],
                 "selector": "source.ruby | text.html.ruby",
             }
         }


### PR DESCRIPTION
Without passing the current directory, `srb` fails to start, with this error: 

```
Sorbet's language server requires a single input directory. However, 0 are configured: []
```

In Sublime, the LSP fails to start 5 times then quits.