### PR TITLE
Add docs for MediaWiki language server

### DIFF
--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -437,6 +437,7 @@ Follow installation instructions on [LSP-marksman](https://github.com/sublimelsp
     ```sh
     npm install -g wikitext-lsp
     ```
+
 3. Open `Preferences > Package Settings > LSP > Settings` and add the `"mediawiki"` client configuration to the `"clients"`:
 
 

--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -429,6 +429,36 @@ An LSP server for Markdown that provides completion, go to definition, find refe
 
 Follow installation instructions on [LSP-marksman](https://github.com/sublimelsp/LSP-marksman).
 
+## MediaWiki
+
+1. Install the [Mediawiker](https://packagecontrol.io/packages/Mediawiker) package from Package Control for syntax highlighting.
+2. Install the `wikitext-lsp` package:
+
+    ```sh
+    npm install -g wikitext-lsp
+    ```
+3. Open `Preferences > Package Settings > LSP > Settings` and add the `"mediawiki"` client configuration to the `"clients"`:
+
+
+    ```jsonc
+    {
+        "clients": {
+            "mediawiki": {
+                "enabled": true,
+                "command": [
+                    "/path/to/your/node", 
+                    "/path/to/your/globally/installed/wikitext-lsp",
+                    "--stdio"
+                ],
+                "selector": "text.html.mediawiki",
+                "settings": {
+                    // Please refer to https://www.npmjs.com/package/wikitext-lsp#configuration
+                }
+            }
+        }
+    }
+    ```
+
 ## Nim
 
 Follow installation instructions on [LSP-nimlangserver](https://github.com/sublimelsp/LSP-nimlangserver).


### PR DESCRIPTION
A [MediaWiki Wikitext](https://www.mediawiki.org/wiki/Wikitext) language server is available from [wikitext-lsp](https://npmjs.com/package/wikitext-lsp), which is also used in a [VSCode MediaWiki extension](https://marketplace.visualstudio.com/items?itemName=Bhsd.vscode-extension-wikiparser).