### PR TITLE
Implement storage path as global constant

### DIFF
--- a/plugin/core/constants.py
+++ b/plugin/core/constants.py
@@ -5,6 +5,7 @@ from .protocol import DiagnosticSeverity
 from .protocol import DocumentHighlightKind
 from .protocol import SymbolKind
 from .typing import StrEnum
+from os.path import dirname, join
 from typing import Tuple
 import sublime
 
@@ -17,6 +18,16 @@ ST_INSTALLED_PACKAGES_PATH = sublime.installed_packages_path()
 ST_PACKAGES_PATH = sublime.packages_path()
 ST_PLATFORM = sublime.platform()
 ST_VERSION = int(sublime.version())
+ST_STORAGE_PATH = join(dirname(ST_CACHE_PATH), "Package Storage")
+"""
+The "Package Storage" is a way to store server data without influencing the
+behavior of Sublime Text's "catalog". Its path is '$DATA/Package Storage',
+where $DATA means:
+
+- on macOS: ~/Library/Application Support/Sublime Text
+- on Windows: %LocalAppData%/Sublime Text
+- on Linux: ~/.cache/sublime-text
+"""
 
 
 class RegionKey(StrEnum):

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from .collections import DottedDict
 from .constants import SEMANTIC_TOKENS_MAP
+from .constants import ST_STORAGE_PATH
 from .diagnostics_storage import DiagnosticsStorage
 from .edit import apply_text_edits
 from .edit import parse_workspace_edit
@@ -104,7 +105,6 @@ from .url import parse_uri
 from .url import unparse_uri
 from .version import __version__
 from .views import extract_variables
-from .views import get_storage_path
 from .views import get_uri_and_range_from_location
 from .views import MarkdownLangMap
 from .workspace import is_subpath_of
@@ -892,7 +892,7 @@ class AbstractPlugin(metaclass=ABCMeta):
                 return os.path.join(cls.storage_path(), cls.name())
         ```
         """
-        return get_storage_path()
+        return ST_STORAGE_PATH
 
     @classmethod
     def needs_update_or_installation(cls) -> bool:

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from .constants import CODE_ACTION_KINDS
 from .constants import ST_CACHE_PATH
+from .constants import ST_STORAGE_PATH
 from .constants import SUBLIME_KIND_SCOPES
 from .constants import SublimeKind
 from .css import css as lsp_css
@@ -107,21 +108,9 @@ def get_line(window: sublime.Window, file_name: str, row: int, strip: bool = Tru
     return line.strip() if strip else line
 
 
-def get_storage_path() -> str:
-    """
-    The "Package Storage" is a way to store server data without influencing the behavior of Sublime Text's "catalog".
-    Its path is '$DATA/Package Storage', where $DATA means:
-
-    - on macOS: ~/Library/Application Support/Sublime Text
-    - on Windows: %LocalAppData%/Sublime Text
-    - on Linux: ~/.cache/sublime-text
-    """
-    return os.path.abspath(os.path.join(ST_CACHE_PATH, "..", "Package Storage"))
-
-
 def extract_variables(window: sublime.Window) -> dict[str, str]:
     variables = window.extract_variables()
-    variables["storage_path"] = get_storage_path()
+    variables["storage_path"] = ST_STORAGE_PATH
     variables["cache_path"] = ST_CACHE_PATH
     variables["temp_dir"] = tempfile.gettempdir()
     variables["home"] = os.path.expanduser('~')


### PR DESCRIPTION
This commit implements a global constant `ST_STORAGE_PATH` instead of evaluating the rather prominent path each time it is required. It might save some CPU cycles every here and then.