### PR TITLE
Copy hover response content and diagnostics text from the hover popup

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -56,6 +56,7 @@ from .plugin.goto_diagnostic import LspGotoDiagnosticCommand
 from .plugin.hierarchy import LspCallHierarchyCommand
 from .plugin.hierarchy import LspHierarchyToggleCommand
 from .plugin.hierarchy import LspTypeHierarchyCommand
+from .plugin.hover import LspCopyTextCommand
 from .plugin.hover import LspHoverCommand
 from .plugin.hover import LspToggleHoverPopupsCommand
 from .plugin.inlay_hint import LspInlayHintClickCommand
@@ -158,6 +159,7 @@ __all__ = (
     "LspUpdateLogPanelCommand",
     "LspUpdatePanelCommand",
     "LspWorkspaceSymbolsCommand",
+    'LspCopyTextCommand',
     "TextChangeListener",
     "plugin_loaded",
     "plugin_unloaded",

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -22,7 +22,6 @@ from .core.sessions import Session
 from .core.settings import userprefs
 from .core.views import copy_text_html
 from .core.views import FORMAT_STRING, FORMAT_MARKUP_CONTENT
-from .core.views import markup_to_string
 from .core.views import MarkdownLangMap
 from .core.views import minihtml
 from .core.views import range_to_region
@@ -308,8 +307,7 @@ class LspResolveDocsCommand(LspTextCommand):
             minihtml_content += copy_text_html(f"<div class='highlight'>{detail}</div>",
                                                copy_text=item.get('detail') or "")
         if documentation:
-            minihtml_content += copy_text_html(documentation,
-                                               copy_text=markup_to_string(item.get("documentation") or ""))
+            minihtml_content += copy_text_html(documentation, copy_text=item.get("documentation") or "")
 
         def run_main() -> None:
             if not self.view.is_valid():

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -305,9 +305,9 @@ class LspResolveDocsCommand(LspTextCommand):
             documentation = self._format_documentation(markdown, None)
         minihtml_content = ""
         if detail:
-            minihtml_content += copy_text_html(f"<div class='highlight'>{detail}</div>", copy_text=item.get('detail'))
+            minihtml_content += copy_text_html(f"<div class='highlight'>{detail}</div>", copy_text=item.get('detail') or "")
         if documentation:
-            minihtml_content += copy_text_html(documentation, markup_to_string(item.get("documentation") or ""))
+            minihtml_content += copy_text_html(documentation, copy_text=markup_to_string(item.get("documentation") or ""))
 
         def run_main() -> None:
             if not self.view.is_valid():

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -3,13 +3,13 @@ from .core.constants import COMPLETION_KINDS
 from .core.edit import apply_text_edits
 from .core.logging import debug
 from .core.promise import Promise
-from .core.protocol import EditRangeWithInsertReplace
 from .core.protocol import CompletionItem
 from .core.protocol import CompletionItemDefaults
 from .core.protocol import CompletionItemKind
 from .core.protocol import CompletionItemTag
 from .core.protocol import CompletionList
 from .core.protocol import CompletionParams
+from .core.protocol import EditRangeWithInsertReplace
 from .core.protocol import Error
 from .core.protocol import InsertReplaceEdit
 from .core.protocol import InsertTextFormat
@@ -20,7 +20,9 @@ from .core.protocol import TextEdit
 from .core.registry import LspTextCommand
 from .core.sessions import Session
 from .core.settings import userprefs
+from .core.views import copy_text_html_element
 from .core.views import FORMAT_STRING, FORMAT_MARKUP_CONTENT
+from .core.views import get_copy_text_from_markup
 from .core.views import MarkdownLangMap
 from .core.views import minihtml
 from .core.views import range_to_region
@@ -303,9 +305,9 @@ class LspResolveDocsCommand(LspTextCommand):
             documentation = self._format_documentation(markdown, None)
         minihtml_content = ""
         if detail:
-            minihtml_content += f"<div class='highlight'>{detail}</div>"
+            minihtml_content += copy_text_html_element(f"<div class='highlight'>{detail}</div>", copy_text=item.get('detail'))
         if documentation:
-            minihtml_content += documentation
+            minihtml_content += copy_text_html_element(documentation, get_copy_text_from_markup(item.get("documentation") or ""))
 
         def run_main() -> None:
             if not self.view.is_valid():

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -20,9 +20,9 @@ from .core.protocol import TextEdit
 from .core.registry import LspTextCommand
 from .core.sessions import Session
 from .core.settings import userprefs
-from .core.views import copy_text_html_element
+from .core.views import copy_text_html
 from .core.views import FORMAT_STRING, FORMAT_MARKUP_CONTENT
-from .core.views import get_copy_text_from_markup
+from .core.views import markup_to_string
 from .core.views import MarkdownLangMap
 from .core.views import minihtml
 from .core.views import range_to_region
@@ -305,9 +305,9 @@ class LspResolveDocsCommand(LspTextCommand):
             documentation = self._format_documentation(markdown, None)
         minihtml_content = ""
         if detail:
-            minihtml_content += copy_text_html_element(f"<div class='highlight'>{detail}</div>", copy_text=item.get('detail'))
+            minihtml_content += copy_text_html(f"<div class='highlight'>{detail}</div>", copy_text=item.get('detail'))
         if documentation:
-            minihtml_content += copy_text_html_element(documentation, get_copy_text_from_markup(item.get("documentation") or ""))
+            minihtml_content += copy_text_html(documentation, markup_to_string(item.get("documentation") or ""))
 
         def run_main() -> None:
             if not self.view.is_valid():

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -305,9 +305,11 @@ class LspResolveDocsCommand(LspTextCommand):
             documentation = self._format_documentation(markdown, None)
         minihtml_content = ""
         if detail:
-            minihtml_content += copy_text_html(f"<div class='highlight'>{detail}</div>", copy_text=item.get('detail') or "")
+            minihtml_content += copy_text_html(f"<div class='highlight'>{detail}</div>",
+                                               copy_text=item.get('detail') or "")
         if documentation:
-            minihtml_content += copy_text_html(documentation, copy_text=markup_to_string(item.get("documentation") or ""))
+            minihtml_content += copy_text_html(documentation,
+                                               copy_text=markup_to_string(item.get("documentation") or ""))
 
         def run_main() -> None:
             if not self.view.is_valid():

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -332,7 +332,8 @@ class LspResolveDocsCommand(LspTextCommand):
         return minihtml(self.view, content, FORMAT_STRING | FORMAT_MARKUP_CONTENT, language_map)
 
     def _on_navigate(self, url: str) -> None:
-        webbrowser.open(url)
+        if url.startswith("http"):
+            webbrowser.open(url)
 
 
 class LspCommitCompletionWithOppositeInsertMode(LspTextCommand):

--- a/plugin/core/signature_help.py
+++ b/plugin/core/signature_help.py
@@ -3,7 +3,7 @@ from .logging import debug
 from .protocol import SignatureHelp
 from .protocol import SignatureInformation
 from .registry import LspTextCommand
-from .views import FORMAT_MARKUP_CONTENT
+from .views import FORMAT_MARKUP_CONTENT, copy_text_html_element, get_copy_text_from_markup
 from .views import FORMAT_STRING
 from .views import MarkdownLangMap
 from .views import minihtml
@@ -83,7 +83,7 @@ class SigHelp:
         else:
             self._active_parameter_bold = active_parameter_style.get('bold', False)
             self._active_parameter_underline = active_parameter_style.get('underline', False)
-        formatted.extend(self._render_label(signature))
+        formatted.append(self._render_label(signature))
         formatted.extend(self._render_docs(view, signature))
         return "".join(formatted)
 
@@ -111,7 +111,7 @@ class SigHelp:
             len(self._signatures),
         )
 
-    def _render_label(self, signature: SignatureInformation) -> list[str]:
+    def _render_label(self, signature: SignatureInformation) -> str:
         formatted: list[str] = []
         # Note that this <div> class and the extra <pre> are copied from mdpopups' HTML output. When mdpopups changes
         # its output style, we must update this literal string accordingly.
@@ -147,7 +147,7 @@ class SigHelp:
         else:
             formatted.append(self._function(label))
         formatted.append("</pre></div>")
-        return formatted
+        return copy_text_html_element("".join(formatted), label)
 
     def _render_docs(self, view: sublime.View, signature: SignatureInformation) -> list[str]:
         formatted: list[str] = []
@@ -175,14 +175,14 @@ class SigHelp:
         documentation = parameter.get("documentation")
         if documentation:
             allowed_formats = FORMAT_STRING | FORMAT_MARKUP_CONTENT
-            return minihtml(view, documentation, allowed_formats, self._language_map)
+            return copy_text_html_element(minihtml(view, documentation, allowed_formats, self._language_map), copy_text=get_copy_text_from_markup(documentation))
         return None
 
     def _signature_documentation(self, view: sublime.View, signature: SignatureInformation) -> str | None:
         documentation = signature.get("documentation")
         if documentation:
             allowed_formats = FORMAT_STRING | FORMAT_MARKUP_CONTENT
-            return minihtml(view, documentation, allowed_formats, self._language_map)
+            return copy_text_html_element(minihtml(view, documentation, allowed_formats, self._language_map), copy_text=get_copy_text_from_markup(documentation))
         return None
 
     def _function(self, content: str) -> str:

--- a/plugin/core/signature_help.py
+++ b/plugin/core/signature_help.py
@@ -175,20 +175,16 @@ class SigHelp:
         documentation = parameter.get("documentation")
         if documentation:
             allowed_formats = FORMAT_STRING | FORMAT_MARKUP_CONTENT
-            return copy_text_html(
-                minihtml(view, documentation, allowed_formats, self._language_map),
-                copy_text=markup_to_string(documentation)
-            )
+            return copy_text_html(minihtml(view, documentation, allowed_formats, self._language_map),
+                                  copy_text=markup_to_string(documentation))
         return None
 
     def _signature_documentation(self, view: sublime.View, signature: SignatureInformation) -> str | None:
         documentation = signature.get("documentation")
         if documentation:
             allowed_formats = FORMAT_STRING | FORMAT_MARKUP_CONTENT
-            return copy_text_html(
-                minihtml(view, documentation, allowed_formats, self._language_map),
-                copy_text=markup_to_string(documentation)
-            )
+            return copy_text_html(minihtml(view, documentation, allowed_formats, self._language_map),
+                                  copy_text=markup_to_string(documentation))
         return None
 
     def _function(self, content: str) -> str:

--- a/plugin/core/signature_help.py
+++ b/plugin/core/signature_help.py
@@ -3,7 +3,8 @@ from .logging import debug
 from .protocol import SignatureHelp
 from .protocol import SignatureInformation
 from .registry import LspTextCommand
-from .views import FORMAT_MARKUP_CONTENT, copy_text_html
+from .views import copy_text_html
+from .views import FORMAT_MARKUP_CONTENT
 from .views import FORMAT_STRING
 from .views import MarkdownLangMap
 from .views import minihtml

--- a/plugin/core/signature_help.py
+++ b/plugin/core/signature_help.py
@@ -175,14 +175,20 @@ class SigHelp:
         documentation = parameter.get("documentation")
         if documentation:
             allowed_formats = FORMAT_STRING | FORMAT_MARKUP_CONTENT
-            return copy_text_html(minihtml(view, documentation, allowed_formats, self._language_map), copy_text=markup_to_string(documentation))
+            return copy_text_html(
+                minihtml(view, documentation, allowed_formats, self._language_map),
+                copy_text=markup_to_string(documentation)
+            )
         return None
 
     def _signature_documentation(self, view: sublime.View, signature: SignatureInformation) -> str | None:
         documentation = signature.get("documentation")
         if documentation:
             allowed_formats = FORMAT_STRING | FORMAT_MARKUP_CONTENT
-            return copy_text_html(minihtml(view, documentation, allowed_formats, self._language_map), copy_text=markup_to_string(documentation))
+            return copy_text_html(
+                minihtml(view, documentation, allowed_formats, self._language_map),
+                copy_text=markup_to_string(documentation)
+            )
         return None
 
     def _function(self, content: str) -> str:

--- a/plugin/core/signature_help.py
+++ b/plugin/core/signature_help.py
@@ -3,7 +3,7 @@ from .logging import debug
 from .protocol import SignatureHelp
 from .protocol import SignatureInformation
 from .registry import LspTextCommand
-from .views import FORMAT_MARKUP_CONTENT, copy_text_html, markup_to_string
+from .views import FORMAT_MARKUP_CONTENT, copy_text_html
 from .views import FORMAT_STRING
 from .views import MarkdownLangMap
 from .views import minihtml
@@ -176,7 +176,7 @@ class SigHelp:
         if documentation:
             allowed_formats = FORMAT_STRING | FORMAT_MARKUP_CONTENT
             return copy_text_html(minihtml(view, documentation, allowed_formats, self._language_map),
-                                  copy_text=markup_to_string(documentation))
+                                  copy_text=documentation)
         return None
 
     def _signature_documentation(self, view: sublime.View, signature: SignatureInformation) -> str | None:
@@ -184,7 +184,7 @@ class SigHelp:
         if documentation:
             allowed_formats = FORMAT_STRING | FORMAT_MARKUP_CONTENT
             return copy_text_html(minihtml(view, documentation, allowed_formats, self._language_map),
-                                  copy_text=markup_to_string(documentation))
+                                  copy_text=documentation)
         return None
 
     def _function(self, content: str) -> str:

--- a/plugin/core/signature_help.py
+++ b/plugin/core/signature_help.py
@@ -3,7 +3,7 @@ from .logging import debug
 from .protocol import SignatureHelp
 from .protocol import SignatureInformation
 from .registry import LspTextCommand
-from .views import FORMAT_MARKUP_CONTENT, copy_text_html_element, get_copy_text_from_markup
+from .views import FORMAT_MARKUP_CONTENT, copy_text_html, markup_to_string
 from .views import FORMAT_STRING
 from .views import MarkdownLangMap
 from .views import minihtml
@@ -147,7 +147,7 @@ class SigHelp:
         else:
             formatted.append(self._function(label))
         formatted.append("</pre></div>")
-        return copy_text_html_element("".join(formatted), label)
+        return copy_text_html("".join(formatted), label)
 
     def _render_docs(self, view: sublime.View, signature: SignatureInformation) -> list[str]:
         formatted: list[str] = []
@@ -175,14 +175,14 @@ class SigHelp:
         documentation = parameter.get("documentation")
         if documentation:
             allowed_formats = FORMAT_STRING | FORMAT_MARKUP_CONTENT
-            return copy_text_html_element(minihtml(view, documentation, allowed_formats, self._language_map), copy_text=get_copy_text_from_markup(documentation))
+            return copy_text_html(minihtml(view, documentation, allowed_formats, self._language_map), copy_text=markup_to_string(documentation))
         return None
 
     def _signature_documentation(self, view: sublime.View, signature: SignatureInformation) -> str | None:
         documentation = signature.get("documentation")
         if documentation:
             allowed_formats = FORMAT_STRING | FORMAT_MARKUP_CONTENT
-            return copy_text_html_element(minihtml(view, documentation, allowed_formats, self._language_map), copy_text=get_copy_text_from_markup(documentation))
+            return copy_text_html(minihtml(view, documentation, allowed_formats, self._language_map), copy_text=markup_to_string(documentation))
         return None
 
     def _function(self, content: str) -> str:

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -822,7 +822,10 @@ def _html_element(name: str, text: str, class_name: str | None = None, escape: b
 def format_diagnostic_for_html(config: ClientConfig, diagnostic: Diagnostic, base_dir: str | None = None) -> str:
     code = diagnostic.get("code")
     source = diagnostic.get("source") or ""
-    html = copy_text_html(_html_element('span', diagnostic["message"]), copy_text=f"{source} {diagnostic['message']}")
+    html = copy_text_html(
+        _html_element('span', diagnostic["message"]),
+        copy_text=f"{source} {diagnostic['message']}"
+    )
     if source or code is not None:
         meta_info = ""
         if source:

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -844,7 +844,7 @@ def format_diagnostic_for_html(config: ClientConfig, diagnostic: Diagnostic, bas
     return _html_element("pre", html, class_name=severity_class, escape=False)
 
 
-def markup_to_string(content: MarkupContent | MarkedString | list[MarkedString]) -> str:
+def _markup_to_string(content: MarkupContent | MarkedString | list[MarkedString]) -> str:
     if isinstance(content, str):
         return content
     elif isinstance(content, dict):
@@ -853,7 +853,8 @@ def markup_to_string(content: MarkupContent | MarkedString | list[MarkedString])
         return " ".join(content)   # pyright: ignore[reportCallIssue, reportUnknownVariableType, reportArgumentType]
 
 
-def copy_text_html(html_content: str, copy_text: str) -> str:
+def copy_text_html(html_content: str, copy_text: str | MarkupContent | MarkedString | list[MarkedString]) -> str:
+    copy_text = _markup_to_string(copy_text)
     if not len(copy_text):
         return html_content
     return f"""<a title="Click to Copy"

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -837,7 +837,7 @@ def format_diagnostic_for_html(config: ClientConfig, diagnostic: Diagnostic, bas
         html += " " + _html_element("span", meta_info, class_name="color-muted", escape=False)
     related_infos = diagnostic.get("relatedInformation")
     if related_infos:
-        info = "<br>".join(_format_diagnostic_related_info(config, info, base_dir) for info in related_infos)
+        info = "<br>".join(copy_text_html(_format_diagnostic_related_info(config, info, base_dir), copy_text=info['message']) for info in related_infos)
         html += '<br>' + _html_element("pre", info, class_name="related_info", escape=False)
     severity_class = DIAGNOSTIC_SEVERITY[diagnostic_severity(diagnostic) - 1][1]
     return _html_element("pre", html, class_name=severity_class, escape=False)
@@ -852,9 +852,9 @@ def markup_to_string(content: MarkupContent | MarkedString | list[MarkedString])
         return " ".join(content)   # pyright: ignore[reportCallIssue, reportUnknownVariableType, reportArgumentType]
 
 
-def copy_text_html(html_content: str, copy_text: str | None = None) -> str:
-    if copy_text is None:
-        copy_text = html_content
+def copy_text_html(html_content: str, copy_text: str) -> str:
+    if not len(copy_text):
+        return html_content
     return f"""<a title="Click to Copy"
        style='text-decoration: none; display: block; color: var(--foreground)'
        href='{sublime.command_url('lsp_copy_text', {

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -852,7 +852,7 @@ def get_copy_text_from_markup(content: MarkupContent | MarkedString | list[Marke
 def copy_text_html_element(html_content: str, copy_text: str | None = None) -> str:
     if copy_text is None:
         copy_text = html_content
-    return f"""<a title="Click to copy"
+    return f"""<a title="Click to Copy"
        style='text-decoration: none; display: block; color: var(--foreground)'
        href='{sublime.command_url('lsp_copy_text', {
         'text': html.unescape(copy_text.replace(' ', ' '))

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -843,14 +843,11 @@ def format_diagnostic_for_html(config: ClientConfig, diagnostic: Diagnostic, bas
 def copy_text_html_element(html_content: str, copy_text: str | None = None) -> str:
     if copy_text is None:
         copy_text = html_content
-    return f"""
-    <a title="Click to copy"
+    return f"""<a title="Click to copy"
        style='text-decoration: none; display: block; color: var(--foreground)'
        href='{sublime.command_url('lsp_copy_text', {
         'text': html.unescape(copy_text.replace(' ', ' '))
-       })}'>
-        {html_content}
-    </a>"""
+       })}'>{html_content}</a>"""
 
 
 def format_code_actions_for_quick_panel(

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -822,10 +822,8 @@ def _html_element(name: str, text: str, class_name: str | None = None, escape: b
 def format_diagnostic_for_html(config: ClientConfig, diagnostic: Diagnostic, base_dir: str | None = None) -> str:
     code = diagnostic.get("code")
     source = diagnostic.get("source") or ""
-    html = copy_text_html(
-        _html_element('span', diagnostic["message"]),
-        copy_text=f"{source} {diagnostic['message']}"
-    )
+    html = copy_text_html(_html_element('span', diagnostic["message"]),
+                          copy_text=f"{source} {diagnostic['message']}")
     if source or code is not None:
         meta_info = ""
         if source:
@@ -837,7 +835,10 @@ def format_diagnostic_for_html(config: ClientConfig, diagnostic: Diagnostic, bas
         html += " " + _html_element("span", meta_info, class_name="color-muted", escape=False)
     related_infos = diagnostic.get("relatedInformation")
     if related_infos:
-        info = "<br>".join(copy_text_html(_format_diagnostic_related_info(config, info, base_dir), copy_text=info['message']) for info in related_infos)
+        info = "<br>".join(copy_text_html(
+            _format_diagnostic_related_info(config, info, base_dir),
+            copy_text=info['message']
+        ) for info in related_infos)
         html += '<br>' + _html_element("pre", info, class_name="related_info", escape=False)
     severity_class = DIAGNOSTIC_SEVERITY[diagnostic_severity(diagnostic) - 1][1]
     return _html_element("pre", html, class_name=severity_class, escape=False)

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -820,9 +820,9 @@ def _html_element(name: str, text: str, class_name: str | None = None, escape: b
 
 
 def format_diagnostic_for_html(config: ClientConfig, diagnostic: Diagnostic, base_dir: str | None = None) -> str:
-    html = copy_text_html_element(_html_element('span', diagnostic["message"]), copy_text=diagnostic["message"])
     code = diagnostic.get("code")
-    source = diagnostic.get("source")
+    source = diagnostic.get("source") or ""
+    html = copy_text_html_element(_html_element('span', diagnostic["message"]), copy_text=f"{source} {diagnostic['message']}")
     if source or code is not None:
         meta_info = ""
         if source:

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -860,7 +860,7 @@ def copy_text_html(html_content: str, copy_text: str | MarkupContent | MarkedStr
     return f"""<a title="Click to Copy"
        style='text-decoration: none; display: block; color: inherit'
        href='{sublime.command_url('lsp_copy_text', {
-        'text': html.unescape(copy_text.replace(' ', ' '))
+        'text': copy_text.replace(' ', ' ')
        })}'>{html_content}</a>"""
 
 

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -820,7 +820,7 @@ def _html_element(name: str, text: str, class_name: str | None = None, escape: b
 
 
 def format_diagnostic_for_html(config: ClientConfig, diagnostic: Diagnostic, base_dir: str | None = None) -> str:
-    html = _html_element('span', diagnostic["message"])
+    html = copy_text_html_element(_html_element('span', diagnostic["message"]), copy_text=diagnostic["message"])
     code = diagnostic.get("code")
     source = diagnostic.get("source")
     if source or code is not None:
@@ -838,6 +838,19 @@ def format_diagnostic_for_html(config: ClientConfig, diagnostic: Diagnostic, bas
         html += '<br>' + _html_element("pre", info, class_name="related_info", escape=False)
     severity_class = DIAGNOSTIC_SEVERITY[diagnostic_severity(diagnostic) - 1][1]
     return _html_element("pre", html, class_name=severity_class, escape=False)
+
+
+def copy_text_html_element(html_content: str, copy_text: str | None = None) -> str:
+    if copy_text is None:
+        copy_text = html_content
+    return f"""
+    <a title="Click to copy"
+       style='text-decoration: none; display: block; color: var(--foreground)'
+       href='{sublime.command_url('lsp_copy_text', {
+        'text': html.unescape(copy_text.replace(' ', ' '))
+       })}'>
+        {html_content}
+    </a>"""
 
 
 def format_code_actions_for_quick_panel(

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -840,6 +840,15 @@ def format_diagnostic_for_html(config: ClientConfig, diagnostic: Diagnostic, bas
     return _html_element("pre", html, class_name=severity_class, escape=False)
 
 
+def get_copy_text_from_markup(content: MarkupContent | MarkedString | list[MarkedString]) -> str:
+    if isinstance(content, str):
+        return content
+    elif isinstance(content, dict):
+        return content.get('value', '')
+    elif isinstance(content, list):
+        return " ".join(content)   # pyright: ignore[reportCallIssue, reportUnknownVariableType, reportArgumentType]
+
+
 def copy_text_html_element(html_content: str, copy_text: str | None = None) -> str:
     if copy_text is None:
         copy_text = html_content

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -856,7 +856,7 @@ def copy_text_html(html_content: str, copy_text: str) -> str:
     if not len(copy_text):
         return html_content
     return f"""<a title="Click to Copy"
-       style='text-decoration: none; display: block; color: var(--foreground)'
+       style='text-decoration: none; display: block; color: inherit'
        href='{sublime.command_url('lsp_copy_text', {
         'text': html.unescape(copy_text.replace(' ', ' '))
        })}'>{html_content}</a>"""

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -822,7 +822,7 @@ def _html_element(name: str, text: str, class_name: str | None = None, escape: b
 def format_diagnostic_for_html(config: ClientConfig, diagnostic: Diagnostic, base_dir: str | None = None) -> str:
     code = diagnostic.get("code")
     source = diagnostic.get("source") or ""
-    html = copy_text_html_element(_html_element('span', diagnostic["message"]), copy_text=f"{source} {diagnostic['message']}")
+    html = copy_text_html(_html_element('span', diagnostic["message"]), copy_text=f"{source} {diagnostic['message']}")
     if source or code is not None:
         meta_info = ""
         if source:
@@ -840,7 +840,7 @@ def format_diagnostic_for_html(config: ClientConfig, diagnostic: Diagnostic, bas
     return _html_element("pre", html, class_name=severity_class, escape=False)
 
 
-def get_copy_text_from_markup(content: MarkupContent | MarkedString | list[MarkedString]) -> str:
+def markup_to_string(content: MarkupContent | MarkedString | list[MarkedString]) -> str:
     if isinstance(content, str):
         return content
     elif isinstance(content, dict):
@@ -849,7 +849,7 @@ def get_copy_text_from_markup(content: MarkupContent | MarkedString | list[Marke
         return " ".join(content)   # pyright: ignore[reportCallIssue, reportUnknownVariableType, reportArgumentType]
 
 
-def copy_text_html_element(html_content: str, copy_text: str | None = None) -> str:
+def copy_text_html(html_content: str, copy_text: str | None = None) -> str:
     if copy_text is None:
         copy_text = html_content
     return f"""<a title="Click to Copy"

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -822,8 +822,7 @@ def _html_element(name: str, text: str, class_name: str | None = None, escape: b
 def format_diagnostic_for_html(config: ClientConfig, diagnostic: Diagnostic, base_dir: str | None = None) -> str:
     code = diagnostic.get("code")
     source = diagnostic.get("source") or ""
-    html = copy_text_html(_html_element('span', diagnostic["message"]),
-                          copy_text=f"{source} {diagnostic['message']}")
+    html = _html_element('span', diagnostic["message"])
     if source or code is not None:
         meta_info = ""
         if source:
@@ -833,6 +832,7 @@ def format_diagnostic_for_html(config: ClientConfig, diagnostic: Diagnostic, bas
             meta_info += "({})".format(
                 make_link(code_description["href"], str(code)) if code_description else text2html(str(code)))
         html += " " + _html_element("span", meta_info, class_name="color-muted", escape=False)
+    html = copy_text_html(html, copy_text=f"{source} {diagnostic['message']}")
     related_infos = diagnostic.get("relatedInformation")
     if related_infos:
         info = "<br>".join(copy_text_html(

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -729,7 +729,8 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         self._sighelp = None
 
     def _on_sighelp_navigate(self, href: str) -> None:
-        webbrowser.open_new_tab(href)
+        if href.startswith("http"):
+            webbrowser.open_new_tab(href)
 
     # --- textDocument/codeAction --------------------------------------------------------------------------------------
 

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -29,7 +29,6 @@ from .core.views import format_code_actions_for_quick_panel
 from .core.views import format_diagnostic_for_html
 from .core.views import FORMAT_MARKED_STRING
 from .core.views import FORMAT_MARKUP_CONTENT
-from .core.views import markup_to_string
 from .core.views import is_location_href
 from .core.views import make_command_link
 from .core.views import make_link
@@ -264,9 +263,8 @@ class LspHoverCommand(LspTextCommand):
         for hover, language_map in self._hover_responses:
             content = (hover.get('contents') or '') if isinstance(hover, dict) else ''
             allowed_formats = FORMAT_MARKED_STRING | FORMAT_MARKUP_CONTENT
-            html_content = minihtml(self.view, content, allowed_formats, language_map)
-            copy_text = markup_to_string(content)
-            html_content = copy_text_html(html_content, copy_text)
+            html_content = copy_text_html(minihtml(self.view, content, allowed_formats, language_map),
+                                          copy_text=content)
             contents.append(html_content)
         return '<hr>'.join(contents)
 

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -428,10 +428,6 @@ class LspToggleHoverPopupsCommand(sublime_plugin.WindowCommand):
                     session_view.reset_show_definitions()
 
 
-
 class LspCopyTextCommand(sublime_plugin.TextCommand):
     def run(self, edit, text: str) -> None:
-        w = self.view.window()
-        if w:
-            w.status_message('Copied: ' + text[:20] + "...")
         sublime.set_clipboard(text)

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -429,3 +429,5 @@ class LspToggleHoverPopupsCommand(sublime_plugin.WindowCommand):
 class LspCopyTextCommand(sublime_plugin.TextCommand):
     def run(self, edit, text: str) -> None:
         sublime.set_clipboard(text)
+        text_length = len(text)
+        sublime.status_message(f"Copied {text_length} character{'s' if text_length > 1 else ''}")

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -13,8 +13,6 @@ from .core.protocol import Diagnostic
 from .core.protocol import DocumentLink
 from .core.protocol import Error
 from .core.protocol import Hover
-from .core.protocol import MarkedString
-from .core.protocol import MarkupContent
 from .core.protocol import Position
 from .core.protocol import Range
 from .core.protocol import Request

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -31,6 +31,7 @@ from .core.views import format_code_actions_for_quick_panel
 from .core.views import format_diagnostic_for_html
 from .core.views import FORMAT_MARKED_STRING
 from .core.views import FORMAT_MARKUP_CONTENT
+from .core.views import get_copy_text_from_markup
 from .core.views import is_location_href
 from .core.views import make_command_link
 from .core.views import make_link
@@ -266,7 +267,7 @@ class LspHoverCommand(LspTextCommand):
             content = (hover.get('contents') or '') if isinstance(hover, dict) else ''
             allowed_formats = FORMAT_MARKED_STRING | FORMAT_MARKUP_CONTENT
             html_content = minihtml(self.view, content, allowed_formats, language_map)
-            copy_text = get_copy_text_from_hover_contents(content)
+            copy_text = get_copy_text_from_markup(content)
             html_content = copy_text_html_element(html_content, copy_text)
             contents.append(html_content)
         return '<hr>'.join(contents)
@@ -426,14 +427,6 @@ class LspToggleHoverPopupsCommand(sublime_plugin.WindowCommand):
                 else:
                     session_view.reset_show_definitions()
 
-
-def get_copy_text_from_hover_contents(content: MarkupContent | MarkedString | list[MarkedString]) -> str:
-    if isinstance(content, str):
-        return content
-    elif isinstance(content, dict):
-        return content.get('value', '')
-    elif isinstance(content, list):
-        return " ".join(content)   # pyright: ignore[reportCallIssue, reportUnknownVariableType, reportArgumentType]
 
 
 class LspCopyTextCommand(sublime_plugin.TextCommand):

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -25,13 +25,13 @@ from .core.sessions import AbstractViewListener
 from .core.sessions import SessionBufferProtocol
 from .core.settings import userprefs
 from .core.url import parse_uri
-from .core.views import copy_text_html_element
+from .core.views import copy_text_html
 from .core.views import diagnostic_severity
 from .core.views import format_code_actions_for_quick_panel
 from .core.views import format_diagnostic_for_html
 from .core.views import FORMAT_MARKED_STRING
 from .core.views import FORMAT_MARKUP_CONTENT
-from .core.views import get_copy_text_from_markup
+from .core.views import markup_to_string
 from .core.views import is_location_href
 from .core.views import make_command_link
 from .core.views import make_link
@@ -267,8 +267,8 @@ class LspHoverCommand(LspTextCommand):
             content = (hover.get('contents') or '') if isinstance(hover, dict) else ''
             allowed_formats = FORMAT_MARKED_STRING | FORMAT_MARKUP_CONTENT
             html_content = minihtml(self.view, content, allowed_formats, language_map)
-            copy_text = get_copy_text_from_markup(content)
-            html_content = copy_text_html_element(html_content, copy_text)
+            copy_text = markup_to_string(content)
+            html_content = copy_text_html(html_content, copy_text)
             contents.append(html_content)
         return '<hr>'.join(contents)
 


### PR DESCRIPTION
This is a POC that could address #2600

https://github.com/user-attachments/assets/ca73753f-6497-43c3-9a33-9f4a4a27bf2c

This enables coping hover responses from server,
and diagnostics text, at the moment.

TODO:
- [x] Error diagnostics look broken, need to fix that.()
<img width="621" height="227" alt="Screenshot 2025-08-16 at 11 14 27" src="https://github.com/user-attachments/assets/e17f5693-178d-437f-a1f0-7a531ccdfb73" />
-[] Add logic to copy signature help as well.


closes #2600

