### PR TITLE
Add on_configuration_loaded API in AbstractPlugin

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -863,6 +863,25 @@ class AbstractPlugin(metaclass=ABCMeta):
         return sublime.load_settings(basename), filepath
 
     @classmethod
+    def on_configuration_loaded(cls, window: sublime.Window, workspace_folders: list[WorkspaceFolder],
+                                configuration: ClientConfig) -> None:
+        """
+        Notify when client configuration has loaded to allow for last-minute "configuration" adjustments.
+
+        Triggered initially on plugin initialization and later when the user explicity changes plugin configuration
+        within the Sublime settings or the project file. Note that the provided configuration object does not contain
+        any changes that might have been done previously from within this notification. Every time it's called the
+        configuration is re-read from scratch.
+
+        Prefer this notification over `on_pre_start` for adjusting "configuration".
+
+        :param      window:             The window
+        :param      workspace_folders:  The workspace folders
+        :param      configuration:      The configuration
+        """
+        return
+
+    @classmethod
     def additional_variables(cls) -> dict[str, str] | None:
         """
         In addition to the above variables, add more variables here to be expanded.
@@ -933,9 +952,10 @@ class AbstractPlugin(metaclass=ABCMeta):
                      workspace_folders: list[WorkspaceFolder], configuration: ClientConfig) -> str | None:
         """
         Callback invoked just before the language server subprocess is started. This is the place to do last-minute
-        adjustments to your "command" or "init_options" in the passed-in "configuration" argument, or change the
-        order of the workspace folders. You can also choose to return a custom working directory, but consider that a
-        language server should not care about the working directory.
+        adjustment to the order of the workspace folders. You can also choose to return a custom working directory,
+        but consider that a language server should not care about the working directory.
+
+        Prefer `on_configuration_loaded` for adjusting the "configuration" object.
 
         :param      window:             The window
         :param      initiating_view:    The initiating view

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -163,7 +163,8 @@ class WindowManager(Manager, WindowConfigChangeListener):
                 listener = self._pending_listeners.pop()
                 if not listener.view.is_valid():
                     # debug("listener", listener, "is no longer valid")
-                    return self._dequeue_listener_async()
+                    self._dequeue_listener_async()
+                    return
                 # debug("adding new pending listener", listener)
                 self._listeners.add(listener)
             except IndexError:
@@ -269,7 +270,8 @@ class WindowManager(Manager, WindowConfigChangeListener):
                     # Continue with handling pending listeners
                     self._new_session = None
                     sublime.set_timeout_async(self._dequeue_listener_async)
-                    return self._window.status_message(message)
+                    self._window.status_message(message)
+                    return
                 cwd = plugin_class.on_pre_start(self._window, initiating_view, workspace_folders, config)
             config.set_view_status(initiating_view, "starting...")
             session = Session(self, self._create_logger(config.name), workspace_folders, config, plugin_class)
@@ -341,17 +343,17 @@ class WindowManager(Manager, WindowConfigChangeListener):
         if view:
             MessageRequestHandler(view, session, request_id, params, session.config.name).show()
 
-    def restart_sessions_async(self, config_name: str | None = None) -> None:
-        self._end_sessions_async(config_name)
+    def restart_sessions_async(self, config_names: list[str]) -> None:
+        self._end_sessions_async(config_names)
         listeners = list(self._listeners)
         self._listeners.clear()
         for listener in listeners:
             self.register_listener_async(listener)
 
-    def _end_sessions_async(self, config_name: str | None = None) -> None:
+    def _end_sessions_async(self, config_names: list[str] | None = None) -> None:
         sessions = list(self._sessions)
         for session in sessions:
-            if config_name is None or config_name == session.config.name:
+            if config_names is None or session.config.name in config_names:
                 session.end_async()
                 self._sessions.discard(session)
 
@@ -515,8 +517,13 @@ class WindowManager(Manager, WindowConfigChangeListener):
 
     # --- Implements WindowConfigChangeListener ------------------------------------------------------------------------
 
-    def on_configs_changed(self, config_name: str | None = None) -> None:
-        sublime.set_timeout_async(lambda: self.restart_sessions_async(config_name))
+    def on_configs_changed(self, configs: list[ClientConfig]) -> None:
+        for config in configs:
+            plugin = get_plugin(config.name)
+            if plugin:
+                plugin.on_configuration_loaded(self._window, self._workspace.get_workspace_folders(), config)
+        config_names = [config.name for config in configs]
+        sublime.set_timeout_async(lambda: self.restart_sessions_async(config_names))
 
 
 class WindowRegistry(LspSettingsChangeListener):


### PR DESCRIPTION
Add a better API for modifying the client connfiguration programmatically.

Before it was possible to modify the client configuration programmatically from `on_pre_start` but that's too late in case we want to modify the `selector` which decides whether plugin can get started in the first place.