### PR TITLE
fix: skip diagnostics pull if diagnostics already received

### DIFF
--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -277,9 +277,8 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
     def _diagnostics_async(
         self, allow_stale: bool = False
     ) -> Generator[tuple[SessionBufferProtocol, list[tuple[Diagnostic, sublime.Region]]], None, None]:
-        change_count = self.view.change_count()
         for sb in self.session_buffers_async():
-            if sb.diagnostics_version == change_count or allow_stale:
+            if sb.has_latest_diagnostics() or allow_stale:
                 yield sb, sb.diagnostics
 
     def diagnostics_intersecting_region_async(

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -612,8 +612,7 @@ class SessionBuffer:
         view = self.some_view()
         if view is None:
             return False
-        change_count = view.change_count()
-        return self._diagnostics_version == change_count
+        return self._diagnostics_version == view.change_count()
 
     # --- textDocument/semanticTokens ----------------------------------------------------------------------------------
 


### PR DESCRIPTION
Skip `textDocument/diagnostic` request if we have already received diagnostics for the current view version.

For servers that support pull diagnostics, we would re-ask for diagnostics on each selection change (through the code that requests code actions), even if the view hasn't changed.

In the case of the bug linked below, this would even trigger an infinite loop as the cache in the `CodeActionsManager` that caches the response would not cut the loop short if two views into the same file are opened and selection range is different in each.

Fixes #2609 