### PR TITLE
fix: resolve completion BEFORE applying changes but a bit differently

### DIFF
--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -355,9 +355,11 @@ class LspSelectCompletionCommand(LspTextCommand):
         if session and not additional_text_edits:
             # send completionItem/resolve before the view is edited with view.erase, "insert_snippet" and "insert"
             # fixes #https://github.com/sublimelsp/LSP/issues/2631
-            session.send_request_async(
+            def e():
+                session.send_request_async(
                 Request.resolveCompletionItem(item, self.view),
                 functools.partial(self._on_resolved_async, session_name))
+            sublime.set_timeout(e, 1000)
         text_edit = item.get("textEdit")
         if text_edit:
             new_text = text_edit["newText"].replace("\r", "")


### PR DESCRIPTION
This PR tries to make minimal changes but in an attempt to address #2631

fixes https://github.com/sublimelsp/LSP/issues/2631

The following was reported:
> ...will sometimes not add the use std::collections::HashMap; to the top of the file. When this happens, it causes compilation to fail and I have to retry the completion or manually import the type.


The logs from the issue:
```
:: [00:04:44.929] --> rust-analyzer completionItem/resolve (280): {'label': 'HashMap<…>', 'labelDetails': {'detail': '(use std::collections::HashMap)', 'description': 'HashMap<{unknown}, {unknown}, {unknown}>'}, 'kind': 22, 'sortText': '7ffffffb', 'filterText': 'HashMap', 'insertTextFormat': 2, 'textEdit': {'newText': 'HashMap<$0>', 'insert': {'start': {'line': 1, 'character': 8}, 'end': {'line': 1, 'character': 10}}, 'replace': {'start': {'line': 1, 'character': 8}, 'end': {'line': 1, 'character': 10}}}, 'data': {'position': {'textDocument': {'uri': 'file:///tmp/tmp.T2DMBiber5/src/main.rs'}, 'position': {'line': 1, 'character': 10}}, 'imports': [{'full_import_path': 'std::collections::HashMap'}], 'version': 75, 'for_ref': False, 'hash': 'mm36QqldsBsu0Cbb6owvDZ8T8q8='}}
:: [00:04:44.933]  -> rust-analyzer textDocument/didChange: {'textDocument': {'uri': 'file:///tmp/tmp.T2DMBiber5/src/main.rs', 'version': 77}, 'contentChanges': [{'range': {'start': {'line': 1, 'character': 8}, 'end': {'line': 1, 'character': 10}}, 'rangeLength': 2, 'text': ''}, {'range': {'start': {'line': 1, 'character': 8}, 'end': {'line': 1, 'character': 8}}, 'rangeLength': 0, 'text': 'HashMap<>'}]}
...some requests
:: [00:04:45.017] <<< rust-analyzer (280) (duration: 88ms): {'label': 'HashMap<…>', 'labelDetails': {'detail': '(use std::collections::HashMap)', 'description': 'HashMap<{unknown}, {unknown}, {unknown}>'}, 'kind': 22, 'sortText': '7ffffffb', 'filterText': 'HashMap', 'insertTextFormat': 2, 'textEdit': {'newText': 'HashMap<$0>', 'insert': {'start': {'line': 1, 'character': 8}, 'end': {'line': 1, 'character': 10}}, 'replace': {'start': {'line': 1, 'character': 8}, 'end': {'line': 1, 'character': 10}}}}
```
Note the order -> completionItem/resolve, then textDocument/didChangem then response for completionItem/resolve.

But I cannot reproduce it (even with the main branch), I always get have this order of requests:
```
:: [18:02:15.186] --> rust-analyzer completionItem/resolve (50): {'label': 'HashMap', 'labelDetails': {'detail': '(use std::collections::HashMap)', 'description': 'HashMap<{unknown}, {unknown}, {unknown}>'}, 'kind': 22, 'sortText': '80000000', 'filterText': 'HashMap', 'textEdit': {'newText': 'HashMap', 'insert': {'start': {'line': 2, 'character': 4}, 'end': {'line': 2, 'character': 11}}, 'replace': {'start': {'line': 2, 'character': 4}, 'end': {'line': 2, 'character': 11}}}, 'data': {'position': {'textDocument': {'uri': 'file:///Users/predrag/Documents/sandbox/hello-rust/src/main.rs'}, 'position': {'line': 2, 'character': 11}}, 'imports': [{'full_import_path': 'std::collections::HashMap'}], 'version': 9, 'for_ref': False, 'hash': 'KvE/Xr0g6PYlVHZD48WzUW1AqUM='}}
:: [18:02:15.197] <<< rust-analyzer (50) (duration: 10ms): {'label': 'HashMap', 'labelDetails': {'detail': '(use std::collections::HashMap)', 'description': 'HashMap<{unknown}, {unknown}, {unknown}>'}, 'kind': 22, 'detail': 'HashMap<{unknown}, {unknown}, {unknown}>', 'documentation': {'kind': 'markdown', 'value': 'A [hash map] implemented with quadratic probing and SIMD lookup.\n\nBy default, `HashMap` uses a hashing algorithm selected to provide\nresistance against HashDoS attacks. The algorithm is randomly seeded, and a\nreasonable best-effort is made to generate this seed from a high quality,\nsecure source of randomness provided by the host without blocking the\nprogram. Because of this, the randomness of the seed depends on the output\nquality of the system\'s random number coroutine when the seed is created.\nIn particular, seeds generated when the system\'s entropy pool is abnormally\nlow such as during system boot may be of a lower quality.\n\nThe default hashing algorithm is currently SipHash 1-3, though this is\nsubject to change at any point in the future. While its performance is very\ncompetitive for medium sized keys, other hashing algorithms will outperform\nit for small keys such as integers as well as large keys such as long\nstrings, though those algorithms will typically *not* protect against\nattacks such as HashDoS.\n\nThe hashing algorithm can be replaced on a per-`HashMap` basis using the\n[`default`], [`with_hasher`], and [`with_capacity_and_hasher`] methods.\nThere are many alternative [hashing algorithms available on crates.io].\n\nIt is required that the keys implement the [`Eq`] and [`Hash`] traits, although\nthis can frequently be achieved by using `#[derive(PartialEq, Eq, Hash)]`.\nIf you implement these yourself, it is important that the following\nproperty holds:\n\n```text\nk1 == k2 -> hash(k1) == hash(k2)\n```\n\nIn other words, if two keys are equal, their hashes must be equal.\nViolating this property is a logic error.\n\nIt is also a logic error for a key to be modified in such a way that the key\'s\nhash, as determined by the [`Hash`] trait, or its equality, as determined by\nthe [`Eq`] trait, changes while it is in the map. This is normally only\npossible through [`Cell`], [`RefCell`], global state, I/O, or unsafe code.\n\nThe behavior resulting from either logic error is not specified, but will\nbe encapsulated to the `HashMap` that observed the logic error and not\nresult in undefined behavior. This could include panics, incorrect results,\naborts, memory leaks, and non-termination.\n\nThe hash table implementation is a Rust port of Google\'s [SwissTable].\nThe original C++ version of SwissTable can be found [here], and this\n[CppCon talk] gives an overview of how the algorithm works.\n\n[hash map]: crate::collections#use-a-hashmap-when\n[hashing algorithms available on crates.io]: https://crates.io/keywords/hasher\n[SwissTable]: https://abseil.io/blog/20180927-swisstables\n[here]: https://github.com/abseil/abseil-cpp/blob/master/absl/container/internal/raw_hash_set.h\n[CppCon talk]: https://www.youtube.com/watch?v=ncHmEUmJZf4\n\n# Examples\n\n```rust\nuse std::collections::HashMap;\n\n// Type inference lets us omit an explicit type signature (which\n// would be `HashMap<String, String>` in this example).\nlet mut book_reviews = HashMap::new();\n\n// Review some books.\nbook_reviews.insert(\n    "Adventures of Huckleberry Finn".to_string(),\n    "My favorite book.".to_string(),\n);\nbook_reviews.insert(\n    "Grimms\' Fairy Tales".to_string(),\n    "Masterpiece.".to_string(),\n);\nbook_reviews.insert(\n    "Pride and Prejudice".to_string(),\n    "Very enjoyable.".to_string(),\n);\nbook_reviews.insert(\n    "The Adventures of Sherlock Holmes".to_string(),\n    "Eye lyked it alot.".to_string(),\n);\n\n// Check for a specific one.\n// When collections store owned values (String), they can still be\n// queried using references (&str).\nif !book_reviews.contains_key("Les Misérables") {\n    println!("We\'ve got {} reviews, but Les Misérables ain\'t one.",\n             book_reviews.len());\n}\n\n// oops, this review has a lot of spelling mistakes, let\'s delete it.\nbook_reviews.remove("The Adventures of Sherlock Holmes");\n\n// Look up the values associated with some keys.\nlet to_find = ["Pride and Prejudice", "Alice\'s Adventure in Wonderland"];\nfor &book in &to_find {\n    match book_reviews.get(book) {\n        Some(review) => println!("{book}: {review}"),\n        None => println!("{book} is unreviewed.")\n    }\n}\n\n// Look up the value for a key (will panic if the key is not found).\nprintln!("Review for Jane: {}", book_reviews["Pride and Prejudice"]);\n\n// Iterate over everything.\nfor (book, review) in &book_reviews {\n    println!("{book}: \\"{review}\\"");\n}\n```\n\nA `HashMap` with a known list of items can be initialized from an array:\n\n```rust\nuse std::collections::HashMap;\n\nlet solar_distance = HashMap::from([\n    ("Mercury", 0.4),\n    ("Venus", 0.7),\n    ("Earth", 1.0),\n    ("Mars", 1.5),\n]);\n```\n\n`HashMap` implements an [`Entry` API](#method.entry), which allows\nfor complex methods of getting, setting, updating and removing keys and\ntheir values:\n\n```rust\nuse std::collections::HashMap;\n\n// type inference lets us omit an explicit type signature (which\n// would be `HashMap<&str, u8>` in this example).\nlet mut player_stats = HashMap::new();\n\nfn random_stat_buff() -> u8 {\n    // could actually return some random value here - let\'s just return\n    // some fixed value for now\n    42\n}\n\n// insert a key only if it doesn\'t already exist\nplayer_stats.entry("health").or_insert(100);\n\n// insert a key using a function that provides a new value only if it\n// doesn\'t already exist\nplayer_stats.entry("defence").or_insert_with(random_stat_buff);\n\n// update a key, guarding against the key possibly not being set\nlet stat = player_stats.entry("attack").or_insert(100);\n*stat += random_stat_buff();\n\n// modify an entry before an insert with in-place mutation\nplayer_stats.entry("mana").and_modify(|mana| *mana += 200).or_insert(100);\n```\n\nThe easiest way to use `HashMap` with a custom key type is to derive [`Eq`] and [`Hash`].\nWe must also derive [`PartialEq`].\n\n[`RefCell`]: crate::cell::RefCell\n[`Cell`]: crate::cell::Cell\n[`default`]: Default::default\n[`with_hasher`]: Self::with_hasher\n[`with_capacity_and_hasher`]: Self::with_capacity_and_hasher\n\n```rust\nuse std::collections::HashMap;\n\n#[derive(Hash, Eq, PartialEq, Debug)]\nstruct Viking {\n    name: String,\n    country: String,\n}\n\nimpl Viking {\n    /// Creates a new Viking.\n    fn new(name: &str, country: &str) -> Viking {\n        Viking { name: name.to_string(), country: country.to_string() }\n    }\n}\n\n// Use a HashMap to store the vikings\' health points.\nlet vikings = HashMap::from([\n    (Viking::new("Einar", "Norway"), 25),\n    (Viking::new("Olaf", "Denmark"), 24),\n    (Viking::new("Harald", "Iceland"), 12),\n]);\n\n// Use derived implementation to print the status of the vikings.\nfor (viking, health) in &vikings {\n    println!("{viking:?} has {health} hp");\n}\n```\n\n# Usage in `const` and `static`\n\nAs explained above, `HashMap` is randomly seeded: each `HashMap` instance uses a different seed,\nwhich means that `HashMap::new` cannot be used in const context. To construct a `HashMap` in the\ninitializer of a `const` or `static` item, you will have to use a different hasher that does not\ninvolve a random seed, as demonstrated in the following example. **A `HashMap` constructed this\nway is not resistant against HashDoS!**\n\n```rust\nuse std::collections::HashMap;\nuse std::hash::{BuildHasherDefault, DefaultHasher};\nuse std::sync::Mutex;\n\nconst EMPTY_MAP: HashMap<String, Vec<i32>, BuildHasherDefault<DefaultHasher>> =\n    HashMap::with_hasher(BuildHasherDefault::new());\nstatic MAP: Mutex<HashMap<String, Vec<i32>, BuildHasherDefault<DefaultHasher>>> =\n    Mutex::new(HashMap::with_hasher(BuildHasherDefault::new()));\n```'}, 'sortText': '80000000', 'filterText': 'HashMap', 'textEdit': {'newText': 'HashMap', 'insert': {'start': {'line': 2, 'character': 4}, 'end': {'line': 2, 'character': 11}}, 'replace': {'start': {'line': 2, 'character': 4}, 'end': {'line': 2, 'character': 11}}}, 'additionalTextEdits': [{'range': {'start': {'line': 0, 'character': 0}, 'end': {'line': 0, 'character': 0}}, 'newText': 'use std::collections::HashMap;\n\n'}], 'data': {'position': {'textDocument': {'uri': 'file:///Users/predrag/Documents/sandbox/hello-rust/src/main.rs'}, 'position': {'line': 2, 'character': 11}}, 'imports': [{'full_import_path': 'std::collections::HashMap'}], 'version': 9, 'for_ref': False, 'hash': 'KvE/Xr0g6PYlVHZD48WzUW1AqUM='}}
:: [18:02:15.501]  -> LSP-cspell textDocument/didChange: {'textDocument': {'uri': 'file:///Users/predrag/Documents/sandbox/hello-rust/src/main.rs', 'version': 12}, 'contentChanges': [{'range': {'start': {'line': 2, 'character': 4}, 'end': {'line': 2, 'character': 11}}, 'rangeLength': 7, 'text': ''}, {'range': {'start': {'line': 2, 'character': 4}, 'end': {'line': 2, 'character': 4}}, 'rangeLength': 0, 'text': 'HashMap'}, {'range': {'start': {'line': 0, 'character': 0}, 'end': {'line': 0, 'character': 0}}, 'rangeLength': 0, 'text': 'use std::collections::HashMap;\n\n'}]}
```
Note the order -> completionItem/resolve, then response for completionItem/resolve, then textDocument/didChange.

