### PR TITLE
Don't show error dialog for failed workspace command

### DIFF
--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from .core.logging import debug
 from .core.protocol import Error
 from .core.protocol import ExecuteCommandParams
 from .core.registry import LspTextCommand
@@ -58,7 +59,11 @@ class LspExecuteCommand(LspTextCommand):
         :param error: The Error object.
         :param command_name: The name of the command that was executed.
         """
-        sublime.message_dialog(f"command {command_name} failed. Reason: {str(error)}")
+        msg = f"command {command_name} failed: {str(error)}"
+        debug(msg)
+        window = self.view.window()
+        if window:
+            window.status_message(msg)
 
     def _expand_variables(self, command_args: list[Any]) -> list[Any]:
         view = self.view


### PR DESCRIPTION
The error dialog that occurs when trying to run `workspace/executeCommand` (for example from a code lens) with a command that is not implemented on the server side is pretty annoying, so let's print to the status bar instead.

I wonder if we should maybe even prevent the request for commands that are not listed in the server capabilities (from initialize response or dynamic registration), and directly print a "command not implemented" message instead. Or are there any servers which handle commands that are not advertised its capabilities?