### PR TITLE
Send 'erb' as language id for ERB files

### DIFF
--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -646,7 +646,7 @@ There are multiple options:
             "ruby": {
                 "enabled": true,
                 "command": ["solargraph", "stdio"],
-                "selector": "source.ruby | text.html.ruby",
+                "selector": "source.ruby",
                 "initializationOptions": {
                     "diagnostics": true
                 }
@@ -678,7 +678,7 @@ There are multiple options:
             "sorbet": {
                 "enabled": true,
                 "command": ["srb", "tc", "--typed", "true", "--enable-all-experimental-lsp-features", "--lsp", "--disable-watchman", "."],
-                "selector": "source.ruby | text.html.ruby",
+                "selector": "source.ruby",
             }
         }
     }
@@ -722,7 +722,7 @@ There are multiple options:
             "ruby-lsp": {
                 "enabled": true,
                 "command": ["ruby-lsp"],
-                "selector": "source.ruby | text.html.ruby",
+                "selector": "source.ruby | text.html.rails",
                 "initializationOptions": {
                     "enabledFeatures": {
                         "diagnostics": true
@@ -750,7 +750,7 @@ There are multiple options:
             "steep": {
                 "enabled": true,
                 "command": ["steep", "langserver"],
-                "selector": "source.ruby | text.html.ruby",
+                "selector": "source.ruby",
             }
         }
     }

--- a/plugin/core/constants.py
+++ b/plugin/core/constants.py
@@ -220,6 +220,7 @@ LANGUAGE_IDENTIFIERS = {
     "text.html.handlebars": "handlebars",
     "text.html.markdown": "markdown",
     "text.html.markdown.rmarkdown": "r",  # https://github.com/REditorSupport/sublime-ide-r
+    "text.html.rails": "erb",
     "text.html.vue": "vue",
     "text.jinja": "html",  # https://github.com/Sublime-Instincts/BetterJinja
     "text.plain": "plaintext",


### PR DESCRIPTION
## Background

The documentation uses the selector `text.html.ruby` to refer to ERB files. However, this scope was changed to `text.html.rails` in early 2022 ([commit](https://github.com/sublimehq/Packages/commit/b2553fcfd99ff95ebfda975358c37ae6e43d6505)), so most users have a broken config.

The reason this is not so bad is because most Ruby language servers don't actually support ERB files. I went through the list from the docs:

- Solargraph: No support (couldn't find code with implementation or issues/PRs to reference)
- Sorbet: No support planned https://github.com/sorbet/sorbet/issues/8148
- Stimulus: Only supports ERB (as part of the wider HTML support). They do not explicitly check for language id: https://github.com/marcoroth/stimulus-lsp/blob/6e2b8e957ee29a505f804588c6823eda253af255/server/src/diagnostics.ts#L422-L426 (more on that later)
- Steep: No support (yet?) https://github.com/soutaro/steep/issues/1409
- Ruby LSP: Supports ERB! But needs a specific language_id

So for starters I went over the documentation, removed the selector for the servers that do not support ERB and replaced it for those that do.

## Ruby LSP

This brings me to language IDs. If you simply update the selector, Ruby LSP will start printing errors all over the place. This is because it tries to parse it as a normal Ruby file. Looking at the code, they expect the language ID of ERB files to be `"erb"`. So I've also added the mapping where I think is the right place.

- Initial PR adding the support for ERB https://github.com/Shopify/ruby-lsp/pull/2235
- Currently still using "erb" as the language id in their vsc plugin: https://github.com/Shopify/ruby-lsp/blob/vscode-ruby-lsp-v0.9.32/vscode/src/common.ts#L76

## Open questions

1. I'm not sure what the stance on backwards compatibility is here, would it be better to advise setting this where appropriate?
```json
"selector": "source.ruby | text.html.ruby | text.html.rails",
```
2. I know "erb" is not in the list linked in the [code's comments](https://microsoft.github.io/language-server-protocol/specification#textDocumentItem). I can try to raise a PR there but I'm not sure how much traction it'd get. Seeing how RubyLSP (the most mature option here) has taken initiative, are we fine with committing to it?