### PR TITLE
fix: respect `refactoring_auto_save` in more cases

### DIFF
--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -5,7 +5,7 @@ from .core.protocol import CodeActionKind
 from .core.protocol import Command
 from .core.protocol import Diagnostic
 from .core.protocol import Error
-from .core.protocol import kind_includes_other_kind
+from .core.protocol import kind_contains_other_kind
 from .core.protocol import Request
 from .core.registry import LspTextCommand
 from .core.registry import LspWindowCommand
@@ -93,13 +93,13 @@ class CodeActionsManager:
                 if manual and only_kinds == MENU_ACTIONS_KINDS:
                     for action in code_actions:
                         kind = action.get('kind')
-                        if kind and kind_includes_other_kind(kind, CodeActionKind.Refactor):
+                        if kind and kind_contains_other_kind(CodeActionKind.Refactor, kind):
                             self.refactor_actions_cache.append((sb.session.config.name, action))
-                        elif kind and kind_includes_other_kind(kind, CodeActionKind.Source):
+                        elif kind and kind_contains_other_kind(CodeActionKind.Source, kind):
                             self.source_actions_cache.append((sb.session.config.name, action))
                 return [
                     action for action in code_actions
-                    if any(kind_includes_other_kind(action.get('kind', ''), other_kind) for other_kind in only_kinds)
+                    if any(kind_contains_other_kind(only_kind, action.get('kind', '')) for only_kind in only_kinds)
                 ]
             if manual:
                 return [a for a in actions if not a.get('disabled')]
@@ -108,7 +108,7 @@ class CodeActionsManager:
                 a for a in actions
                 if is_command(a) or (
                     not a.get('disabled') and
-                    kind_includes_other_kind(a.get('kind', CodeActionKind.QuickFix), CodeActionKind.QuickFix)
+                    kind_contains_other_kind(CodeActionKind.QuickFix, a.get('kind', CodeActionKind.QuickFix))
                 )
             ]
 

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -5,7 +5,6 @@ from .core.protocol import CodeActionKind
 from .core.protocol import Command
 from .core.protocol import Diagnostic
 from .core.protocol import Error
-from .core.protocol import kind_contains_other_kind
 from .core.protocol import Request
 from .core.registry import LspTextCommand
 from .core.registry import LspWindowCommand
@@ -16,6 +15,7 @@ from .core.settings import userprefs
 from .core.views import entire_content_region
 from .core.views import first_selection_region
 from .core.views import format_code_actions_for_quick_panel
+from .core.views import kind_contains_other_kind
 from .core.views import text_document_code_action_params
 from .save_command import LspSaveCommand
 from .save_command import SaveTask

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -6519,16 +6519,3 @@ CodeLensExtended = TypedDict('CodeLensExtended', {
 
 # Temporary for backward compatibility with LSP packages.
 RangeLsp = Range
-
-
-def kind_contains_other_kind(kind: str, other_kind: str) -> bool:
-    """
-    Check if `other_kind` is a sub-kind of `kind`.
-
-    The kind `"refactor.extract"` for example contains `"refactor.extract"` and ``"refactor.extract.function"`,
-    but not `"unicorn.refactor.extract"`, or `"refactor.extractAll"` or `refactor`.
-    """
-    if kind == other_kind:
-        return True
-    kind_len = len(kind)
-    return len(other_kind) > kind_len and other_kind.startswith(kind + '.')

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -6521,11 +6521,14 @@ CodeLensExtended = TypedDict('CodeLensExtended', {
 RangeLsp = Range
 
 
-def kind_includes_other_kind(kind: str, other_kind: str) -> bool:
+def kind_contains_other_kind(kind: str, other_kind: str) -> bool:
     """
-    Return True if "kind" includes "other_kind". For example: kind "a.b" includes kind "a" and "a.b" but not "a.b.c".
+    Check if `other_kind` is a sub-kind of this `kind`.
+
+    The kind `"refactor.extract"` for example contains `"refactor.extract"` and ``"refactor.extract.function"`,
+    but not `"unicorn.refactor.extract"`, or `"refactor.extractAll"` or `refactor`.
     """
     if kind == other_kind:
         return True
-    other_kind_len = len(other_kind)
-    return len(kind) > other_kind_len and kind.startswith(other_kind) and kind[other_kind_len] == '.'
+    kind_len = len(kind)
+    return len(other_kind) > kind_len and other_kind.startswith(kind + '.')

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -6519,3 +6519,14 @@ CodeLensExtended = TypedDict('CodeLensExtended', {
 
 # Temporary for backward compatibility with LSP packages.
 RangeLsp = Range
+
+
+def kind_includes_other_kind(kind: str, other_kind: str) -> bool:
+    """
+    The Code Action "kind" includes "other_kind" if "kind" matches "other_kind" exactly or "other_kind" is a subset
+    of "kind".
+    """
+    if kind == other_kind:
+        return True
+    other_kind_len = len(other_kind)
+    return len(kind) > other_kind_len and kind.startswith(other_kind) and kind[other_kind_len] == '.'

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -6523,7 +6523,7 @@ RangeLsp = Range
 
 def kind_contains_other_kind(kind: str, other_kind: str) -> bool:
     """
-    Check if `other_kind` is a sub-kind of this `kind`.
+    Check if `other_kind` is a sub-kind of `kind`.
 
     The kind `"refactor.extract"` for example contains `"refactor.extract"` and ``"refactor.extract.function"`,
     but not `"unicorn.refactor.extract"`, or `"refactor.extractAll"` or `refactor`.

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -6523,8 +6523,7 @@ RangeLsp = Range
 
 def kind_includes_other_kind(kind: str, other_kind: str) -> bool:
     """
-    The Code Action "kind" includes "other_kind" if "kind" matches "other_kind" exactly or "other_kind" is a subset
-    of "kind".
+    Return True if "kind" includes "other_kind". For example: kind "a.b" includes kind "a" and "a.b" but not "a.b.c".
     """
     if kind == other_kind:
         return True

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1680,7 +1680,8 @@ class Session(TransportCallbacks):
 
             sublime.set_timeout_async(run_async)
             return Promise.resolve(None)
-        self._is_executing_refactoring_command = is_refactoring
+        if is_refactoring:
+            self._is_executing_refactoring_command = True
         # TODO: Our Promise class should be able to handle errors/exceptions
         execute_command = Promise(
             lambda resolve: self.send_request(

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -46,7 +46,7 @@ from .protocol import InitializeError
 from .protocol import InitializeParams
 from .protocol import InitializeResult
 from .protocol import InsertTextMode
-from .protocol import kind_includes_other_kind
+from .protocol import kind_contains_other_kind
 from .protocol import Location
 from .protocol import LocationLink
 from .protocol import LogMessageParams
@@ -1706,7 +1706,7 @@ class Session(TransportCallbacks):
             arguments = code_action.get('arguments', None)
             if isinstance(arguments, list):
                 command_params['arguments'] = arguments
-            is_refactoring = kind_includes_other_kind(code_action.get('kind', ''), CodeActionKind.Refactor)
+            is_refactoring = kind_contains_other_kind(CodeActionKind.Refactor, code_action.get('kind', ''))
             return self.execute_command(command_params, progress=progress, view=view, is_refactoring=is_refactoring)
         # At this point it cannot be a command anymore, it has to be a proper code action.
         # A code action can have an edit and/or command. Note that it can have *both*. In case both are present, we
@@ -1836,7 +1836,7 @@ class Session(TransportCallbacks):
             self.window.status_message(f"Failed to apply code action: {code_action}")
             return Promise.resolve(None)
         edit = code_action.get("edit")
-        is_refactoring = kind_includes_other_kind(code_action.get('kind', ''), CodeActionKind.Refactor)
+        is_refactoring = kind_contains_other_kind(CodeActionKind.Refactor, code_action.get('kind', ''))
         promise = self.apply_workspace_edit_async(edit, is_refactoring) if edit else Promise.resolve(None)
         command = code_action.get("command")
         if command is not None:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1689,7 +1689,8 @@ class Session(TransportCallbacks):
                 lambda err: resolve(Error(err["code"], err["message"], err.get("data")))
             )
         )
-        execute_command.then(lambda _: self._reset_is_executing_refactoring_command())
+        if is_refactoring:
+            execute_command.then(lambda _: self._reset_is_executing_refactoring_command())
         return execute_command
 
     def _reset_is_executing_refactoring_command(self) -> None:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1680,8 +1680,6 @@ class Session(TransportCallbacks):
 
             sublime.set_timeout_async(run_async)
             return Promise.resolve(None)
-        if is_refactoring:
-            self._is_executing_refactoring_command = True
         # TODO: Our Promise class should be able to handle errors/exceptions
         execute_command = Promise(
             lambda resolve: self.send_request(
@@ -1691,6 +1689,7 @@ class Session(TransportCallbacks):
             )
         )
         if is_refactoring:
+            self._is_executing_refactoring_command = True
             execute_command.then(lambda _: self._reset_is_executing_refactoring_command())
         return execute_command
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -46,7 +46,6 @@ from .protocol import InitializeError
 from .protocol import InitializeParams
 from .protocol import InitializeResult
 from .protocol import InsertTextMode
-from .protocol import kind_contains_other_kind
 from .protocol import Location
 from .protocol import LocationLink
 from .protocol import LogMessageParams
@@ -107,6 +106,7 @@ from .url import unparse_uri
 from .version import __version__
 from .views import extract_variables
 from .views import get_uri_and_range_from_location
+from .views import kind_contains_other_kind
 from .views import MarkdownLangMap
 from .workspace import is_subpath_of
 from .workspace import WorkspaceFolder

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1652,7 +1652,7 @@ class Session(TransportCallbacks):
         return variables
 
     def execute_command(
-        self, command: ExecuteCommandParams, *, progress: bool, view: sublime.View | None = None,
+        self, command: ExecuteCommandParams, *, progress: bool = False, view: sublime.View | None = None,
         is_refactoring: bool = False,
     ) -> Promise:
         """Run a command from any thread. Your .then() continuations will run in Sublime's worker thread."""

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -853,3 +853,16 @@ def format_code_actions_for_quick_panel(
         if code_action.get('isPreferred', False):
             selected_index = idx
     return items, selected_index
+
+
+def kind_contains_other_kind(kind: str, other_kind: str) -> bool:
+    """
+    Check if `other_kind` is a sub-kind of `kind`.
+
+    The kind `"refactor.extract"` for example contains `"refactor.extract"` and ``"refactor.extract.function"`,
+    but not `"unicorn.refactor.extract"`, or `"refactor.extractAll"` or `refactor`.
+    """
+    if kind == other_kind:
+        return True
+    kind_len = len(kind)
+    return len(other_kind) > kind_len and other_kind.startswith(kind + '.')

--- a/tests/test_code_actions.py
+++ b/tests/test_code_actions.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 from copy import deepcopy
-from LSP.plugin.code_actions import get_matching_on_save_kinds, kinds_include_kind
+from LSP.plugin.code_actions import get_matching_on_save_kinds
 from LSP.plugin.core.constants import RegionKey
-from LSP.plugin.core.protocol import Point, Range
+from LSP.plugin.core.protocol import Point, Range, kind_includes_other_kind
 from LSP.plugin.core.url import filename_to_uri
 from LSP.plugin.core.views import entire_content
 from LSP.plugin.documents import DocumentSyncListener
@@ -254,16 +254,15 @@ class CodeActionMatchingTestCase(unittest.TestCase):
 
     def test_kind_matching(self) -> None:
         # Positive
-        self.assertTrue(kinds_include_kind(['a'], 'a.b'))
-        self.assertTrue(kinds_include_kind(['a.b'], 'a.b'))
-        self.assertTrue(kinds_include_kind(['a.b', 'b'], 'b.c'))
+        self.assertTrue(kind_includes_other_kind('a.b', 'a'))
+        self.assertTrue(kind_includes_other_kind('a.b', 'a.b'))
         # Negative
-        self.assertFalse(kinds_include_kind(['a'], 'b.a'))
-        self.assertFalse(kinds_include_kind(['a.b'], 'b'))
-        self.assertFalse(kinds_include_kind(['a.b'], 'a'))
-        self.assertFalse(kinds_include_kind(['aa'], 'a'))
-        self.assertFalse(kinds_include_kind(['aa.b'], 'a'))
-        self.assertFalse(kinds_include_kind(['aa.b'], 'b'))
+        self.assertFalse(kind_includes_other_kind('a', 'a.b'))
+        self.assertFalse(kind_includes_other_kind('a', 'aa'))
+        self.assertFalse(kind_includes_other_kind('a', 'aa.b'))
+        self.assertFalse(kind_includes_other_kind('b', 'a.b'))
+        self.assertFalse(kind_includes_other_kind('b', 'aa.b'))
+        self.assertFalse(kind_includes_other_kind('b.a', 'a'))
 
 
 class CodeActionsListenerTestCase(TextDocumentTestCase):

--- a/tests/test_code_actions.py
+++ b/tests/test_code_actions.py
@@ -262,7 +262,7 @@ class CodeActionMatchingTestCase(unittest.TestCase):
         self.assertFalse(kind_contains_other_kind('aa.b', 'a'))
         self.assertFalse(kind_contains_other_kind('a.b', 'b'))
         self.assertFalse(kind_contains_other_kind('aa.b', 'b'))
-        self.assertFalse(kind_contains_other_kind('a' 'b.a'))
+        self.assertFalse(kind_contains_other_kind('a', 'b.a'))
 
 
 class CodeActionsListenerTestCase(TextDocumentTestCase):

--- a/tests/test_code_actions.py
+++ b/tests/test_code_actions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from copy import deepcopy
 from LSP.plugin.code_actions import get_matching_on_save_kinds
 from LSP.plugin.core.constants import RegionKey
-from LSP.plugin.core.protocol import Point, Range, kind_includes_other_kind
+from LSP.plugin.core.protocol import Point, Range, kind_contains_other_kind
 from LSP.plugin.core.url import filename_to_uri
 from LSP.plugin.core.views import entire_content
 from LSP.plugin.documents import DocumentSyncListener
@@ -254,15 +254,15 @@ class CodeActionMatchingTestCase(unittest.TestCase):
 
     def test_kind_matching(self) -> None:
         # Positive
-        self.assertTrue(kind_includes_other_kind('a.b', 'a'))
-        self.assertTrue(kind_includes_other_kind('a.b', 'a.b'))
+        self.assertTrue(kind_contains_other_kind('a', 'a.b'))
+        self.assertTrue(kind_contains_other_kind('a.b', 'a.b'))
         # Negative
-        self.assertFalse(kind_includes_other_kind('a', 'a.b'))
-        self.assertFalse(kind_includes_other_kind('a', 'aa'))
-        self.assertFalse(kind_includes_other_kind('a', 'aa.b'))
-        self.assertFalse(kind_includes_other_kind('b', 'a.b'))
-        self.assertFalse(kind_includes_other_kind('b', 'aa.b'))
-        self.assertFalse(kind_includes_other_kind('b.a', 'a'))
+        self.assertFalse(kind_contains_other_kind('a.b', 'a'))
+        self.assertFalse(kind_contains_other_kind('aa', 'a'))
+        self.assertFalse(kind_contains_other_kind('aa.b', 'a'))
+        self.assertFalse(kind_contains_other_kind('a.b', 'b'))
+        self.assertFalse(kind_contains_other_kind('aa.b', 'b'))
+        self.assertFalse(kind_contains_other_kind('a' 'b.a'))
 
 
 class CodeActionsListenerTestCase(TextDocumentTestCase):

--- a/tests/test_code_actions.py
+++ b/tests/test_code_actions.py
@@ -257,12 +257,12 @@ class CodeActionMatchingTestCase(unittest.TestCase):
         self.assertTrue(kind_contains_other_kind('a', 'a.b'))
         self.assertTrue(kind_contains_other_kind('a.b', 'a.b'))
         # Negative
+        self.assertFalse(kind_contains_other_kind('a', 'b.a'))
+        self.assertFalse(kind_contains_other_kind('a.b', 'b'))
         self.assertFalse(kind_contains_other_kind('a.b', 'a'))
         self.assertFalse(kind_contains_other_kind('aa', 'a'))
         self.assertFalse(kind_contains_other_kind('aa.b', 'a'))
-        self.assertFalse(kind_contains_other_kind('a.b', 'b'))
         self.assertFalse(kind_contains_other_kind('aa.b', 'b'))
-        self.assertFalse(kind_contains_other_kind('a', 'b.a'))
 
 
 class CodeActionsListenerTestCase(TextDocumentTestCase):

--- a/tests/test_code_actions.py
+++ b/tests/test_code_actions.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 from copy import deepcopy
 from LSP.plugin.code_actions import get_matching_on_save_kinds
 from LSP.plugin.core.constants import RegionKey
-from LSP.plugin.core.protocol import Point, Range, kind_contains_other_kind
 from LSP.plugin.core.url import filename_to_uri
 from LSP.plugin.core.views import entire_content
-from LSP.plugin.documents import DocumentSyncListener
+from LSP.plugin.core.views import kind_contains_other_kind
+from LSP.plugin.core.views import Point
+from LSP.plugin.core.views import Range
 from LSP.plugin.core.views import versioned_text_document_identifier
+from LSP.plugin.documents import DocumentSyncListener
 from setup import TextDocumentTestCase
 from test_single_document import TEST_FILE_PATH
 from typing import Any, Generator


### PR DESCRIPTION
### `code_actions.py`
- the logic should be unchanged here. I just had to extract the "kind includes other kind" logic out of this code and place it somewhere where `Session` could access it.
### `protocol.py`
- added `kind_includes_other_kind` function
### `sessions.py`
  - Fixed a bug where a refactoring code action would not always trigger save with `refactoring_auto_save` enabled. It only worked if the code action had `refactoring` kind exactly and not if it had more specific one like `refactoring.move`. This is fixed by the new `kind_includes_other_kind` function.
  - Allow passing `is_refactoring` to `Session.execute_command` to allow for all edits triggered within this request to be treated as refactoring and trigger the `refactoring_auto_save` logic.  (see https://github.com/sublimelsp/LSP-typescript/pull/278 to see the code that uses that)