### PR TITLE
Fix another case of outdated diagnostics

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -631,10 +631,6 @@ class SessionBufferProtocol(Protocol):
     def last_synced_version(self) -> int:
         ...
 
-    @property
-    def version(self) -> int | None:
-        ...
-
     def get_uri(self) -> str | None:
         ...
 
@@ -1398,7 +1394,7 @@ class Session(TransportCallbacks):
         for data in self._registrations.values():
             data.check_applicable(sb)
         uri = sb.get_uri()
-        version = sb.version
+        version = sb.last_synced_version
         if uri and version is not None:
             diagnostics = self.diagnostics.diagnostics_by_document_uri(uri)
             if diagnostics:
@@ -2022,7 +2018,7 @@ class Session(TransportCallbacks):
             # results are expected to be streamed by the server.
             if isinstance(version, int):
                 sb = self.get_session_buffer_for_uri_async(uri)
-                if sb and sb.version != version:
+                if sb and sb.last_synced_version != version:
                     continue
             self.diagnostics_result_ids[uri] = diagnostic_report.get('resultId')
             if is_workspace_full_document_diagnostic_report(diagnostic_report):

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1394,11 +1394,10 @@ class Session(TransportCallbacks):
         for data in self._registrations.values():
             data.check_applicable(sb)
         uri = sb.get_uri()
-        version = sb.last_synced_version
-        if uri and version is not None:
+        if uri:
             diagnostics = self.diagnostics.diagnostics_by_document_uri(uri)
             if diagnostics:
-                self._publish_diagnostics_to_session_buffer_async(sb, diagnostics, version)
+                self._publish_diagnostics_to_session_buffer_async(sb, diagnostics, sb.last_synced_version)
 
     def _publish_diagnostics_to_session_buffer_async(
         self, sb: SessionBufferProtocol, diagnostics: list[Diagnostic], version: int

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -160,11 +160,6 @@ class SessionBuffer:
     def last_synced_version(self) -> int:
         return self._last_synced_version
 
-    @property
-    def version(self) -> int | None:
-        view = self.some_view()
-        return view.change_count() if view else None
-
     def _check_did_open(self, view: sublime.View) -> None:
         if not self.opened and self.should_notify_did_open():
             language_id = self.get_language_id()

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -532,7 +532,6 @@ class SessionBuffer:
     def _on_document_diagnostic_error_async(self, version: int, error: ResponseError) -> None:
         self._document_diagnostic_pending_request = None
         if error['code'] == LSPErrorCodes.ServerCancelled:
-            self._diagnostics_version = -1
             data = error.get('data')
             if is_diagnostic_server_cancellation_data(data) and data['retriggerRequest']:
                 # Retrigger the request after a short delay, but only if there were no additional changes to the buffer

--- a/tests/test_server_notifications.py
+++ b/tests/test_server_notifications.py
@@ -12,6 +12,7 @@ class ServerNotifications(TextDocumentTestCase):
 
     def test_publish_diagnostics(self) -> Generator:
         self.insert_characters("a b c\n")
+        yield from self.await_message('textDocument/didChange')
         params: PublishDiagnosticsParams = {
             'uri': filename_to_uri(self.view.file_name() or ''),
             'diagnostics': [

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -84,7 +84,7 @@ class MockSessionBuffer:
         self.mock_language_id = mock_language_id
 
     @property
-    def version(self) -> int | None:
+    def last_synced_version(self) -> int:
         return 0
 
     def get_uri(self) -> DocumentUri | None:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -106,7 +106,7 @@ class MockSessionBuffer:
     ) -> None:
         pass
 
-    def on_diagnostics_async(self, raw_diagnostics: list[Diagnostic], version: int | None) -> None:
+    def on_diagnostics_async(self, raw_diagnostics: list[Diagnostic], version: int) -> None:
         pass
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -83,6 +83,10 @@ class MockSessionBuffer:
         self.mock_uri = mock_uri
         self.mock_language_id = mock_language_id
 
+    @property
+    def version(self) -> int | None:
+        return 0
+
     def get_uri(self) -> DocumentUri | None:
         return self.mock_uri
 


### PR DESCRIPTION
Somehow I still keep running into outdated diagnostics ;) I've identified one more problem.

When the response for pull diagnostic comes back, in `SessionBuffer._on_document_diagnostic_async` the `version` can be 5 (for example) but by the time the code gets to `SessionBuffer.on_diagnostics_async` the `view.change_count()` can increase. Since we didn't pass the actual diagnostics `version` to `SessionBuffer.on_diagnostics_async`, we assumed that those diagnostics are for the latest version of the view (6 in this example) and then never requested the more recent diagnostics (actual version 6 diagnostics) later. Fix by passing the actual version of the diagnostics around so that we never show outdated diagnostics due to not getting latest diagnostics.

Also reset `_diagnostics_version` on diagnostics request getting canceled. This might not make any difference in practice since if we did cancel the request then it likely means that the view version has changed and we wouldn't ignore next request anyway but in any case, this change feels right.