### PR TITLE
Add support to open unsaved buffers with VSCode-specific `untitled` scheme

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1752,6 +1752,18 @@ class Session(TransportCallbacks):
             if r:
                 center_selection(view, r)
             return Promise.resolve(view)
+        if uri.startswith('untitled:'):  # VSCode specific URI scheme for unsaved buffers
+            if name := uri[len('untitled:'):]:
+                # Check if there is a pre-existing unsaved buffer with the given name
+                for view in self.window.views():
+                    if view.file_name() is None and view.name() == name:
+                        self.window.focus_view(view)
+                        return Promise.resolve(view)
+                view = self.window.new_file()
+                view.set_name(name)
+                return Promise.resolve(view)
+            view = self.window.new_file()
+            return Promise.resolve(view)
         # There is no pre-existing session-buffer, so we have to go through AbstractPlugin.on_open_uri_async.
         if self._plugin:
             return self._open_uri_with_plugin_async(self._plugin, uri, r, flags, group)


### PR DESCRIPTION
This adds support to open URIs with the `untitled` scheme, which is used by VS Code for unsaved buffers. This may be used by language servers in `window/showDocument` and `workspace/applyEdit` requests. For example the https://github.com/aviatesk/JETLS.jl language server uses such URIs to open and populate a new unsaved tab with a result log for a test run.

I tried to implement it in a plugin (AbstractPlugin subclass) first, via `on_open_uri_async`, but it does not work for pre-existing views, because in that case the view is not passed on further from `_open_uri_with_plugin_async`:
https://github.com/sublimelsp/LSP/blob/5ff516ca9d869f93f52e84afcaa9652a5ef91742/plugin/core/sessions.py#L1817-L1818

If there ever will be an AbstractPluginV2, I'd say that the `on_open_uri_async` should be rewritten to return `sublime.Sheet | None` directly, where `None` means that the URI cannot be opened by the plugin. Then the plugin should handle to open or focus a new or existing sheet. And then in LSP it can be further checked if the returned sheet is a regular view (or otherwise an image, etc.), if edits for that URI are supposed to be made from a WorkspaceEdit.

But since the `untitled:` scheme is not really plugin-specific, I think it is better to handle it directly in LSP anyway.