### PR TITLE
chore(ci): fix test server crashing in new python version

### DIFF
--- a/tests/server.py
+++ b/tests/server.py
@@ -35,10 +35,7 @@ __package__ = "server"
 __version__ = "1.0.0"
 
 
-if sys.version_info[0] < 3:
-    print("only works for python3.6 and higher")
-    exit(1)
-if sys.version_info[1] < 6:
+if sys.version_info[:2] < (3, 6):
     print("only works for python3.6 and higher")
     exit(1)
 
@@ -515,7 +512,8 @@ if __name__ == '__main__':
     if args.version:
         print(__package__, __version__)
         exit(0)
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     shutdown_received = False
     try:
         shutdown_received = loop.run_until_complete(main(args.tcp_port))

--- a/unittesting.json
+++ b/unittesting.json
@@ -4,8 +4,6 @@
     "capture_console": true,
     "failfast": false,
     "reload_package_on_testing": false,
-    "start_coverage_after_reload": false,
-    "show_reload_progress": false,
     "output": null,
     "generate_html_report": true
 }


### PR DESCRIPTION
Test server was crashing in new Python version (since 3.14 perhaps?) due to breaking changes in asyncio handling.

The Unitesting was being blocked by a dialog message saying that the server has crashed.

Fixes #2671