### PR TITLE
Set scratch property for new view with untitled scheme

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1786,9 +1786,11 @@ class Session(TransportCallbacks):
                         self.window.focus_view(view)
                         return Promise.resolve(view)
                 view = self.window.new_file()
+                view.set_scratch(True)
                 view.set_name(name)
                 return Promise.resolve(view)
             view = self.window.new_file()
+            view.set_scratch(True)
             return Promise.resolve(view)
         # There is no pre-existing session-buffer, so we have to go through AbstractPlugin.on_open_uri_async.
         if self._plugin:


### PR DESCRIPTION
This is a small tweak for the changes from #2667

If a new view gets created via `window/showDocument` with `untitled` scheme, it is likely used to display some temporary data and not intended to be saved as a file on disk, so I think it's useful to set the scratch property to not bother with the save dialog when the view gets closed.