### PR TITLE
Add support for relative patterns in didChangeWatchedFiles

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -24,7 +24,6 @@ from ...protocol import FileEvent
 from ...protocol import FileSystemWatcher
 from ...protocol import FoldingRangeKind
 from ...protocol import GeneralClientCapabilities
-from ...protocol import GlobPattern
 from ...protocol import InitializeError
 from ...protocol import InitializeParams
 from ...protocol import InitializeResult


### PR DESCRIPTION
Add support for [`RelativePattern`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#relativePattern) for use during didChangeWatchedFiles capability registration.

This doesn't address the https://github.com/sublimelsp/LSP/issues/2684 issue - that's specific to the non-relativePattern case which is unchanged here.

One behavior change that I've sneaked in here is automatic unregistration of `workspace/didChangeWatchedFiles` capability when trying to register the already registered ID. This is to avoid duplicate notifications in case of [buggy biome server](https://github.com/biomejs/biome/issues/8094). One could argue that we shouldn't cater for that but it's IMO fine.