### PR TITLE
Fix diagnostics request after refresh

### DIFF
--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -540,7 +540,9 @@ class SessionBuffer:
             return
         if mgr.should_ignore_diagnostics(self._last_known_uri, self.session.config):
             return
-        if version < view.change_count() or version == self._diagnostics_version:
+        if version < view.change_count():
+            return
+        if version == self._diagnostics_version and not forced_update:
             return
         if self._document_diagnostic_pending_request:
             if self._document_diagnostic_pending_request.version == version and not forced_update:


### PR DESCRIPTION
This fixes a regression from https://github.com/sublimelsp/LSP/commit/7bbfa9e0a36dcbcd7dd35257c4964a00aec19109, which accidentally prevented requesting diagnostics even if forced by a refresh request from the server.

Maybe we should add some regression tests for this some time...