### PR TITLE
Make sure to await session.apply_workspace_edit_async

### DIFF
--- a/plugin/rename_file.py
+++ b/plugin/rename_file.py
@@ -7,7 +7,7 @@ from .core.types import match_file_operation_filters
 from .core.url import filename_to_uri
 from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 import sublime
 import sublime_plugin
 import weakref
@@ -99,10 +99,10 @@ class LspRenamePathCommand(LspWindowCommand):
                 yield session.send_request_task(Request.willRenameFiles({'files': [file_rename]})) \
                     .then(partial(lambda weak_session, response: (response, weak_session), weakref.ref(session)))
 
-    def handle_rename_async(self, responses: list[tuple[WorkspaceEdit | None, weakref.ref[Session]]]) -> Promise[Any]:
+    def handle_rename_async(self, responses: list[tuple[WorkspaceEdit | None, weakref.ref[Session]]]) -> Promise[None]:
         for response, weak_session in responses:
             if (session := weak_session()) and response:
-                return session.apply_workspace_edit_async(response, is_refactoring=True)
+                return session.apply_workspace_edit_async(response, is_refactoring=True).then(lambda _: None)
         return Promise.resolve(None)
 
     def rename_path(self, old: str, new: str) -> Promise[bool]:


### PR DESCRIPTION
This PR addresses the comment from Rafal https://github.com/sublimelsp/LSP/pull/2498#discussion_r2687601832

I used Promise[Any] instead of Promise[None | WorkspaceEditSummary] to avoid the line too long flake error.

Note, Promise[Any] is a temporary type until https://github.com/sublimelsp/LSP/pull/2716 is merged