### PR TITLE
Restrict package.json parser to http/https schemes

### DIFF
--- a/plugin/tooling.py
+++ b/plugin/tooling.py
@@ -127,10 +127,9 @@ class LspParseVscodePackageJson(sublime_plugin.ApplicationCommand):
     def run(self, base_package_name: str) -> None:
         # Download the contents of the URL pointing to the package.json file.
         base_url = sublime.get_clipboard()
-        try:
-            urllib.parse.urlparse(base_url)
-        except Exception:
-            sublime.error_message("The clipboard content must be a URL to a package.json file.")
+        parsed_url = urllib.parse.urlparse(base_url)
+        if parsed_url.scheme not in ("http", "https"):
+            sublime.error_message("URL must use http or https scheme.")
             return
         if not base_url.endswith("package.json"):
             sublime.error_message("URL must end with 'package.json'")


### PR DESCRIPTION
I noticed that the `LspParseVscodePackageJson` command uses `urllib.request.urlopen` on a URL taken directly from the clipboard without validating the scheme. 

Since `urlopen` supports `file://`, this could allow unintended local file reads if a user is tricked into copying a malicious path (e.g., `file:///etc/passwd#package.json`). I've added a check to ensure only `http` and `https` schemes are allowed, which should be sufficient for the intended use case of fetching `package.json` from a remote source.