### PR TITLE
Remove unnecessary version check on diagnostics response

### DIFF
--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -587,13 +587,7 @@ class SessionBuffer:
         self, identifier: DiagnosticsIdentifier, version: int, response: DocumentDiagnosticReport
     ) -> None:
         self._diagnostics_versions[identifier] = version
-        if version == self.last_synced_version:
-            # Only reset the pending request if the synced version wasn't incremented in the meanwhile, to prevent to
-            # accidentally overwrite the request number of a new request that might already been sent after this one.
-            # Note that the diagnostic response still needs to be handled even if the buffer content has changed,
-            # because the response of the next request might be an UnchangedDocumentDiagnosticReport, signalizing that
-            # the diagnostics with the present resultId are still valid.
-            self._document_diagnostic_pending_requests[identifier] = None
+        self._document_diagnostic_pending_requests[identifier] = None
         self.session.diagnostics_result_ids[(self._last_known_uri, identifier)] = response.get('resultId')
         if is_related_full_document_diagnostic_report(response):
             self.session.handle_diagnostics_async(self._last_known_uri, identifier, version, response['items'])
@@ -607,10 +601,6 @@ class SessionBuffer:
     def _on_document_diagnostic_error_async(
         self, view: sublime.View, identifier: DiagnosticsIdentifier, version: int, error: ResponseError
     ) -> None:
-        if version != view.change_count():
-            # It is not necessary to check whether to retrigger the request, because a new request is sent automatically
-            # after the didChange notification.
-            return
         self._document_diagnostic_pending_requests[identifier] = None
         if error['code'] == LSPErrorCodes.ServerCancelled:
             data = error.get('data')
@@ -618,6 +608,8 @@ class SessionBuffer:
                 # Retrigger the request after a short delay, but only if there are no additional changes to the buffer
                 # in the meanwhile, because in that case a new request will be sent automatically after the didChange
                 # notification.
+                if version != view.change_count():
+                    return
                 sublime.set_timeout_async(
                     lambda: self._if_view_unchanged(self._do_document_diagnostic_async, version)(identifier, version),
                     DOCUMENT_DIAGNOSTICS_RETRIGGER_DELAY


### PR DESCRIPTION
I've realized that the situation described in the comment actually cannot happen, because if there is still an open diagnostics request, it is cancelled on sending the new request, in which case the response handler for the previous request doesn't run anyway (provided that both the response handling and triggering the new request happens on the same (async) thread).

And the case of [UnchangedDocumentDiagnosticReport](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#unchangedDocumentDiagnosticReport) shouldn't be any problem, because that is only allowed if a `resultId` is provided, and in that case the `previousResultId` in the request still always corresponds to the stored diagnostics.

---

Also relocated the version check in the error handler, which should prevent a rare case where a cancel notification could be sent even though the server already responded with an error response just right before that.