### PR TITLE
Add more caching for color scheme rules

### DIFF
--- a/plugin/core/constants.py
+++ b/plugin/core/constants.py
@@ -228,6 +228,9 @@ DOCUMENT_HIGHLIGHT_KIND_SCOPES: dict[DocumentHighlightKind, str] = {
     DocumentHighlightKind.Write: "region.yellowish markup.highlight.write.lsp"
 }
 
+CODE_ACTION_ANNOTATION_SCOPE = 'region.bluish markup.accent.codeaction.lsp'
+CODE_LENS_ANNOTATION_SCOPE = 'region.greenish markup.accent.codelens.lsp'
+
 # These are the "exceptional" base scopes. If a base scope is not in this map, nor the first two components or more
 # match any of the entries here, then the rule is that we split the base scope on the ".", and take the second
 # component. The resulting string is assumed to be the language ID. The official list is maintained at

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -732,7 +732,7 @@ class SessionBufferProtocol(Protocol):
     def get_semantic_tokens(self) -> list[SemanticToken]:
         ...
 
-    def evaluate_semantic_tokens_color_scheme_support(self, view: sublime.View) -> None:
+    def on_color_scheme_changed(self, view: sublime.View) -> None:
         ...
 
     def do_inlay_hints_async(self, view: sublime.View) -> None:

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -323,8 +323,8 @@ class SessionView:
             non_tag_regions = data.regions
             for tag, regions in data.regions_with_tag.items():
                 tag_scope = DIAGNOSTIC_TAG_SCOPES[tag]
-                # Trick to only add tag regions if there is a corresponding color scheme scope defined.
-                if 'background' in self.view.style_for_scope(tag_scope):
+                # Only add tag regions if there is a corresponding color scheme scope defined
+                if tag in self.session_buffer.supported_diagnostic_tags:
                     tags[tag].regions = regions
                     tags[tag].scope = tag_scope
                 else:
@@ -400,7 +400,7 @@ class SessionView:
             regions = [self._code_lens_region(code_lens) for code_lens in self._code_lenses]
             flags = sublime.RegionFlags.NO_UNDO
             annotations = [self._code_lens_annotation(code_lens) for code_lens in self._code_lenses]
-            annotation_color = self.view.style_for_scope('region.greenish markup.accent.codelens.lsp')['foreground']
+            annotation_color = self.session_buffer.code_lens_annotation_color
             self.view.add_regions(key, regions, flags=flags, annotations=annotations, annotation_color=annotation_color)
         elif userprefs().show_code_lens == 'phantom':
             # Workaround for https://github.com/sublimehq/sublime_text/issues/6188


### PR DESCRIPTION
This adds caching for the color scheme rules of diagnostic tags, code action annotations and code lens annotations. Not yet handled (cached) are the rules for the signature help popup and diagnostic annotations. Colors are automatically updated on next feature redraw after the color scheme changes.

Also fixed a minor bug (I think) for when the syntax changes and there is a different syntax-specific color scheme defined, by moving the `DocumentSyncListener._current_color_scheme` assignment from `__init__` to `_setup`.

Most of the `_update_color_scheme_rules` method could actually moved from `SessionBuffer` into `DocumentSyncListener`, because the color scheme rules are specific to views, and not to sessions. There is a bit code related to session-specific semantic token types that would still need proper handling though. But I decided not to do that for now, because it is a bit awkward to access the `listener` (which is a weakref) from the SessionBuffer and SessionView classes.