### PR TITLE
Disable project specific lsp server when it is disabled for the current session

### DIFF
--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -80,7 +80,6 @@ class WindowConfigManager:
             else:
                 overrides = {}
             if name in self._disabled_for_session:
-                printf(f"current session has '{name}' disabled")
                 overrides["enabled"] = False
             updated_config = ClientConfig.from_config(config, overrides)
             self.all[name] = updated_config
@@ -90,7 +89,6 @@ class WindowConfigManager:
                 continue
             debug("loading project-only configuration", name)
             if name in self._disabled_for_session:
-                printf(f"current session has '{name}' disabled")
                 config["enabled"] = False
             try:
                 updated_config = ClientConfig.from_dict(name, config)


### PR DESCRIPTION
This PR fixes an issue where the "LSP server has crashed" dialog pops up forever when I have a sublime project with "project only" LSP servers, even when I press cancel. 

Example configuration:

```json
{
 	"folders":
	[
		{
			"path": "."
		}
	],
	"settings":
	{
		"LSP": {
			"ruff": {
				"enabled": true,
				"command": ["docker/bin/lsp", ".venv/bin/ruff", "server"],
				"selector": "source.python"
			},
			"zuban": {
				"enabled": true,
				"command": ["docker/bin/lsp", ".venv/bin/zuban", "server"],
				"selector": "source.python"
			}
		}
	}
}
```

In this case I run the LSP servers inside a docker container, so it's easy to let them "crash" by stopping the container. The "LSP server has crashed" dialog pops up:

<img width="3076" height="1974" alt="image" src="https://github.com/user-attachments/assets/aae79c03-1d8f-495f-82bc-0ffb8f7dbc63" />

When pressing cancel, the dialog will reappear **forever** because for project settings, the `_disabled_for_session` method is not consulted:

https://github.com/sublimelsp/LSP/blob/8c77738df6cdff50bf60784f29a271f8e84b033b/plugin/core/configurations.py#L74-L94

With the proposed changes, `_disabled_for_session` will be taken into account so "project only" LSP servers will also be disabled during the session when pressing "Cancel". ~~An informational message will be printed to the console~~ (has been rejected):
<img width="3076" height="1974" alt="image" src="https://github.com/user-attachments/assets/1a06a305-3143-45e9-bfdd-f8fb1e4cad36" />

It is then possible to fire up your container (or do other stuff like installing dependencies, nodejs etc, whatever is needed to start up the LSP server) and then start the LSP via `Tools` -> `LSP` -> `Enable Language Server ...` without restarting Sublime Text.