### PR TITLE
Don't replace builtin rename_path command

### DIFF
--- a/Side Bar.sublime-menu
+++ b/Side Bar.sublime-menu
@@ -1,0 +1,4 @@
+[
+    { "caption": "-", "id": "lsp" },
+    { "caption": "LSP: Rename…", "command": "lsp_rename_path", "args": {"paths": []} }
+]

--- a/boot.py
+++ b/boot.py
@@ -274,13 +274,6 @@ class Listener(sublime_plugin.EventListener):
                     tup[1](None)
                     break
 
-    def on_window_command(
-        self, window: sublime.Window, command_name: str, args: dict[str, Any]
-    ) -> tuple[str, dict[str, Any]] | None:
-        if command_name == "rename_path":
-            return ('lsp_rename_path', args)
-        return None
-
     def on_post_window_command(self, window: sublime.Window, command_name: str, args: dict[str, Any] | None) -> None:
         if command_name == "show_panel":
             wm = windows.lookup(window)

--- a/plugin/rename_file.py
+++ b/plugin/rename_file.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
 
 class RenamePathInputHandler(sublime_plugin.TextInputHandler):
+
     def __init__(self, path: str) -> None:
         self.path = Path(path)
 
@@ -55,14 +56,15 @@ class LspRenamePathInputArgs(TypedDict):
 
 
 class LspRenamePathCommand(LspWindowCommand):
+
     capability = 'workspace.fileOperations.willRename'
 
     @staticmethod
     def is_case_change(path_a: str, path_b: str) -> bool:
         return path_a.lower() == path_b.lower() and Path(path_a).stat().st_ino == Path(path_b).stat().st_ino
 
-    def is_enabled(self) -> bool:
-        return True
+    def is_visible(self, **kwargs: dict[str, Any]) -> bool:
+        return self.is_enabled()
 
     def want_event(self) -> bool:
         return False


### PR DESCRIPTION
It seems like people are not happy about LSP replacing the builtin `rename_path` command when using "Rename…" from the sidebar context menu.

Instead, let's add a separate "LSP: Rename…" entry for now, which is only visible when there is a server with that capability.