### PR TITLE
Fixup modifying regions key for DocumentHighlight

### DIFF
--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -18,6 +18,7 @@ from ...protocol import DidOpenTextDocumentParams
 from ...protocol import DidSaveTextDocumentParams
 from ...protocol import DocumentColorParams
 from ...protocol import DocumentFormattingParams
+from ...protocol import DocumentHighlightKind
 from ...protocol import DocumentRangeFormattingParams
 from ...protocol import DocumentRangesFormattingParams
 from ...protocol import DocumentUri
@@ -878,3 +879,7 @@ def kind_contains_other_kind(kind: str, other_kind: str) -> bool:
         return True
     kind_len = len(kind)
     return len(other_kind) > kind_len and other_kind.startswith(kind + '.')
+
+
+def document_highlight_key(kind: DocumentHighlightKind, *, multiline: bool) -> str:
+    return "lsp_highlight_{}{}".format(kind, "m" if multiline else "s")

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -47,6 +47,7 @@ from .core.types import SettingsRegistration
 from .core.url import parse_uri
 from .core.url import view_to_uri
 from .core.views import diagnostic_severity
+from .core.views import document_highlight_key
 from .core.views import first_selection_region
 from .core.views import format_code_actions_for_quick_panel
 from .core.views import format_diagnostic_for_html
@@ -844,19 +845,16 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
 
     # --- textDocument/documentHighlight -------------------------------------------------------------------------------
 
-    def _highlights_key(self, kind: DocumentHighlightKind, *, multiline: bool) -> str:
-        return "lsp_highlight_{}{}".format(kind.name, "m" if multiline else "s")
-
     def _clear_highlight_regions(self) -> None:
         for kind in DocumentHighlightKind:
-            self.view.erase_regions(self._highlights_key(kind, multiline=False))
-            self.view.erase_regions(self._highlights_key(kind, multiline=True))
+            self.view.erase_regions(document_highlight_key(kind, multiline=False))
+            self.view.erase_regions(document_highlight_key(kind, multiline=True))
 
     def _is_in_higlighted_region(self, point: int) -> bool:
         for kind in DocumentHighlightKind:
             regions: Iterable[sublime.Region] = itertools.chain(
-                self.view.get_regions(self._highlights_key(kind, multiline=False)),
-                self.view.get_regions(self._highlights_key(kind, multiline=True))
+                self.view.get_regions(document_highlight_key(kind, multiline=False)),
+                self.view.get_regions(document_highlight_key(kind, multiline=True))
             )
             if any(region.contains(point) for region in regions):
                 return True
@@ -892,7 +890,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
                 if not regions:
                     continue
                 kind, multiline = tup
-                key = self._highlights_key(kind, multiline=multiline)
+                key = document_highlight_key(kind, multiline=multiline)
                 flags = flags_multi if multiline else flags_single
                 self.view.add_regions(key, regions, scope=DOCUMENT_HIGHLIGHT_KIND_SCOPES[kind], flags=flags)
 

--- a/plugin/session_view.py
+++ b/plugin/session_view.py
@@ -16,6 +16,7 @@ from .core.sessions import AbstractViewListener
 from .core.sessions import Session
 from .core.settings import userprefs
 from .core.views import DIAGNOSTIC_SEVERITY
+from .core.views import document_highlight_key
 from .core.views import make_command_link
 from .core.views import range_to_region
 from .diagnostics import DiagnosticsAnnotationsView
@@ -149,8 +150,8 @@ class SessionView:
             keys.append(f"lsp_semantic_{session_name}_{key}")
         if document_highlight_style in ("background", "fill"):
             for kind in DocumentHighlightKind:
-                for mode in line_modes:
-                    keys.append(f"lsp_highlight_{kind.name}{mode}")
+                keys.append(document_highlight_key(kind, multiline=True))
+                keys.append(document_highlight_key(kind, multiline=False))
         if hover_highlight_style in ("background", "fill"):
             keys.append(RegionKey.HOVER_HIGHLIGHT)
         for severity in range(1, 5):
@@ -166,8 +167,8 @@ class SessionView:
                 keys.append(f"lsp{session_name}d{mode}{severity}_underline")
         if document_highlight_style in ("underline", "stippled"):
             for kind in DocumentHighlightKind:
-                for mode in line_modes:
-                    keys.append(f"lsp_highlight_{kind.name}{mode}")
+                keys.append(document_highlight_key(kind, multiline=True))
+                keys.append(document_highlight_key(kind, multiline=False))
         if hover_highlight_style in ("underline", "stippled"):
             keys.append(RegionKey.HOVER_HIGHLIGHT)
         for key in keys:


### PR DESCRIPTION
I made a mistake in https://github.com/sublimelsp/LSP/commit/73463dcff37106a3f43c577fcfb3df707c88249d where we can't actually use `kind.name`, because when we read that `kind` at https://github.com/sublimelsp/LSP/blob/73463dcff37106a3f43c577fcfb3df707c88249d/plugin/documents.py#L884
it is just transported as an `int` via JSONRPC, and not actually a member of the `DocumentHighlightKind` enum.

Fixed it now by using the value in the region key directly, instead of the kind name.
Also made a small refactoring into a standalone function, so that we don't need to use the string literal for the region key in multiple places.