### PR TITLE
Fix lsp_check_applicable starting disabled config

### DIFF
--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -240,6 +240,8 @@ class LspCheckApplicableCommand(sublime_plugin.TextCommand):
             if not config:
                 debug(f'Configuration with name {session_name} does not exist')
                 return
+            if not config.enabled:
+                return
             listener = windows.listener_for_view(self.view)
             if not listener:
                 debug(f'No listener for view {self.view}')


### PR DESCRIPTION
Don't start session if config is disabled.

ref: https://github.com/sublimelsp/LSP-copilot/pull/269#issuecomment-3969303357