### PR TITLE
Fix pull diagnostics after reload/revert

### DIFF
--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -414,8 +414,6 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         session_views = self.session_views_async()
         if not session_views:
             return
-        if userprefs().show_code_actions and self._code_actions_for_selection_needs_refresh:
-            self._do_code_actions_for_selection_async()
         for sb in self.session_buffers_async():
             if sb.code_lenses_needs_refresh:
                 sb.do_code_lenses_async(self.view)
@@ -429,6 +427,8 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
                     and (session_view := sb.session.session_view_for_view_async(self.view)) \
                     and session_view.get_request_flags() & RequestFlags.INLAY_HINT:
                 sb.do_inlay_hints_async(self.view)
+        if userprefs().show_code_actions and self._code_actions_for_selection_needs_refresh:
+            self._do_code_actions_for_selection_async()
 
     @requires_session
     def on_selection_modified_async(self) -> None:


### PR DESCRIPTION
Fixed the bug reported initially in https://github.com/sublimelsp/LSP/pull/2743#issuecomment-3959101654

When file is changed externally and either ST window is not active or that file is not the active one then on activating the window/file, we often didn't request updated diagnostics.

Depending on timing, sometimes (often) diagnostic request triggered from activation event before reload event and then when reload came later we ignored diagnostic request as version was already updated when initial diagnostics request triggered.

Took a bit of a hammer approach and just forced diagnostic request from reload/revert handler. That case should not happen frequently so I don't think we need to optimize this.