### PR TITLE
Include view settings in project files schema

### DIFF
--- a/sublime-package.json
+++ b/sublime-package.json
@@ -875,18 +875,20 @@
           "/Preferences.sublime-settings"
         ],
         "schema": {
-          "lsp_format_on_paste": {
-            "$ref": "sublime://settings/LSP#/definitions/lsp_format_on_paste"
+          "properties": {
+            "lsp_format_on_paste": {
+              "$ref": "sublime://settings/LSP#/definitions/lsp_format_on_paste"
+            },
+            "lsp_format_on_save": {
+              "$ref": "sublime://settings/LSP#/definitions/lsp_format_on_save"
+            },
+            "lsp_code_actions_on_format": {
+              "$ref": "sublime://settings/LSP#/definitions/lsp_code_actions_on_format"
+            },
+            "lsp_code_actions_on_save": {
+              "$ref": "sublime://settings/LSP#/definitions/lsp_code_actions_on_save"
+            }
           },
-          "lsp_format_on_save": {
-            "$ref": "sublime://settings/LSP#/definitions/lsp_format_on_save"
-          },
-          "lsp_code_actions_on_format": {
-            "$ref": "sublime://settings/LSP#/definitions/lsp_code_actions_on_format"
-          },
-          "lsp_code_actions_on_save": {
-            "$ref": "sublime://settings/LSP#/definitions/lsp_code_actions_on_save"
-          }
         }
       },
       {


### PR DESCRIPTION
Make it so that LSP-json recognizes `lsp_*` settings in project files.

Also updated `Preferences.json` schema to include `lsp_code_actions_on_format` as it was forgotten.