### PR TITLE
Add setting to disable signature help popup

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -176,6 +176,9 @@
   // Show symbol references in Sublime's quick panel instead of the output panel.
   "show_references_in_quick_panel": true,
 
+  // Show the signature help popup when typing the arguments of a function call.
+  "show_signature_help": true,
+
   // Show code lenses:
   // "annotation" - show code lenses as annotations on the right.
   // "phantom" - show code lenses as phantoms between lines.

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -276,6 +276,7 @@ class Settings:
     show_multiline_diagnostics_highlights = cast(bool, None)
     show_multiline_document_highlights = cast(bool, None)
     show_references_in_quick_panel = cast(bool, None)
+    show_signature_help = cast(bool, None)
     show_symbol_action_links = cast(bool, None)
     show_view_status = cast(bool, None)
 
@@ -324,6 +325,7 @@ class Settings:
         r("show_multiline_diagnostics_highlights", True)
         r("show_multiline_document_highlights", True)
         r("show_references_in_quick_panel", True)
+        r("show_signature_help", True)
         r("show_symbol_action_links", False)
         r("show_view_status", True)
 

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -1028,7 +1028,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         if userprefs().document_highlight_style:
             self._when_selection_remains_stable_async(
                 self._do_highlights_async, first_region, after_ms=self.debounce_time)
-        if selection := self._stored_selection:
+        if userprefs().show_signature_help and (selection := self._stored_selection):
             if self._sighelp:
                 self.do_signature_help_async(SignatureHelpTriggerKind.ContentChange)
             else:

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -634,6 +634,11 @@
               "default": false,
               "markdownDescription": "Enable semantic highlighting in addition to standard syntax highlighting."
             },
+            "show_signature_help": {
+              "type": "boolean",
+              "default": true,
+              "markdownDescription": "Show the signature help popup when typing the arguments of a function call."
+            },
             "show_code_actions": {
               "enum": [
                 "annotation",


### PR DESCRIPTION
Some people prefer to disable the signature help popup and occasionally there are questions about that in the forum.
So I think it would be good to have a setting for that, which should make it easier than via `disabled_capabilities` in the individual server configs.