### PR TITLE
Fix false-positive PackageDev linter warnings

### DIFF
--- a/Preferences.sublime-settings-hints
+++ b/Preferences.sublime-settings-hints
@@ -41,6 +41,6 @@
   // existing configurations. The keys of this dictionary are free-form. They
   // give a humany-friendly name to the server configuration. They are shown
   // in the bottom-left corner in the status bar once attached to a view
-  // (unless you have `"show_view_status"` set to `false`).
+  // (unless you have "show_view_status" set to `false`).
   "LSP": {}
 }


### PR DESCRIPTION
This commit adds a settings hints file for user and project-specific settings to tell PackageDev about their existence and validity.

Without this setting PackageDev marks all of them invalid by underlining them, in Preferences and project-specific `"settings"` keys.

_Despite LSP-json proving superior code intelligence features, numerous packages still lack proper subliem-package.json files to provide required information. In such cases PackageDev still helps to fill the gaps._

