### PR TITLE
Clear all progress reports when session ends

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -2111,6 +2111,7 @@ class Session(APIHandler, TransportCallbacks['dict[str, Any]']):
         session_view.shutdown_async()
 
     def _handle_shutdown_result(self, _: Any) -> None:
+        self._progress.clear()
         self.exit()
 
     def on_transport_close(self, exit_code: int, exception: Exception | None) -> None:


### PR DESCRIPTION
Fixes #2798

Who had the idea to make erasing the status messages for progress reports to rely on the garbage collector, lol.

On the other hand this resulted in this fix being a single-line change :-)