### PR TITLE
Update capabilities for pull diagnostics

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -493,7 +493,13 @@ def get_initialize_params(variables: dict[str, str], workspace_folders: list[Wor
         },
         "diagnostic": {
             "dynamicRegistration": True,
-            "relatedDocumentSupport": True
+            "relatedDocumentSupport": True,
+            "relatedInformation": True,
+            "tagSupport": {
+                "valueSet": diagnostic_tag_value_set
+            },
+            "codeDescriptionSupport": True,
+            "dataSupport": True
         },
         "selectionRange": {
             "dynamicRegistration": True


### PR DESCRIPTION
Diagnostics from publishDiagnostics and from pull diagnostics are handled/rendered through the same functions, so we can enable all supported options for pull diagnostics as well (apparently some servers like Pyright don't even check the client capabilities for that and use these fields in the diagnostics regardless).

I have not yet activated `markupMessageSupport` from the 3.18 specs, because that is not included in the type definitions yet and I think support for that would also require a few small changes to the `format_diagnostic_for_html` and related functions.