### PR TITLE
Add caching for mdpopups.tint

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -806,6 +806,7 @@ class AbstractViewListener(metaclass=ABCMeta):
 
     view = cast(sublime.View, None)
     hover_provider_count = 0
+    lightbulb_color: str = ''
 
     @abstractmethod
     def session_async(self, capability: str, point: int | None = None) -> Session | None:
@@ -889,11 +890,6 @@ class AbstractViewListener(metaclass=ABCMeta):
 
     @abstractmethod
     def get_request_flags(self, session: Session) -> RequestFlags:
-        raise NotImplementedError()
-
-    @property
-    @abstractmethod
-    def lightbulb_html(self) -> str:
         raise NotImplementedError()
 
 

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -82,7 +82,6 @@ from typing_extensions import ParamSpec
 from weakref import WeakSet
 from weakref import WeakValueDictionary
 import itertools
-import mdpopups
 import sublime
 import sublime_plugin
 import weakref
@@ -262,10 +261,6 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         sublime.set_timeout_async(self.on_activated_async)
 
     # --- Implements AbstractViewListener ------------------------------------------------------------------------------
-
-    @property
-    def lightbulb_html(self) -> str:
-        return self._lightbulb_html
 
     def on_post_move_window_async(self) -> None:
         if self._registered and self._manager:
@@ -1147,6 +1142,4 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
     def _update_styles(self) -> None:
         self._code_action_annotation_color = self.view.style_for_scope(CODE_ACTION_ANNOTATION_SCOPE)['foreground']
         self._signature_help_style = self._get_signature_help_style()
-        lightbulb_img = mdpopups.tint(
-            'Packages/LSP/icons/lightbulb_cropped.png', self.view.style_for_scope(LIGHTBULB_SCOPE)['foreground'])
-        self._lightbulb_html = f'<span class="lightbulb">{lightbulb_img}</span>'
+        self.lightbulb_color = self.view.style_for_scope(LIGHTBULB_SCOPE)['foreground']

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -40,6 +40,7 @@ from .core.views import show_lsp_popup
 from .core.views import text_document_position_params
 from .core.views import unpack_href_location
 from .core.views import update_lsp_popup
+from functools import lru_cache
 from functools import partial
 from typing import Sequence
 from typing import Union
@@ -85,7 +86,12 @@ link_kinds = [
 ]
 
 
-def code_actions_content(actions_by_config: list[CodeActionsByConfigName], icon_html: str = '') -> str:
+@lru_cache
+def lightbulb_html(color: str) -> str:
+    return f'<span class="lightbulb">{mdpopups.tint("Packages/LSP/icons/lightbulb_cropped.png", color)}</span> '
+
+
+def code_actions_content(actions_by_config: list[CodeActionsByConfigName], lightbulb_color: str | None = None) -> str:
     formatted = []
     for config_name, actions in actions_by_config:
         action_count = len(actions)
@@ -97,7 +103,8 @@ def code_actions_content(actions_by_config: list[CodeActionsByConfigName], icon_
             text = actions[0].get('title', 'code action')
         href = "{}:{}".format('code-actions', config_name)
         link = make_link(href, text)
-        formatted.append(html_wrapper(f'{icon_html} {link} <span class="color-muted">{config_name}</span>',
+        icon_html = lightbulb_html(lightbulb_color) if lightbulb_color else ''
+        formatted.append(html_wrapper(f'{icon_html}{link} <span class="color-muted">{config_name}</span>',
                                       class_name='code-actions'))
     return "".join(formatted)
 
@@ -284,7 +291,7 @@ class LspHoverCommand(LspTextCommand):
         prefs = userprefs()
         diagnostics_content = self.diagnostics_content() if only_diagnostics or prefs.show_diagnostics_in_hover else ""
         contents = diagnostics_content + hover_content + \
-            code_actions_content(self._actions_by_config, listener.lightbulb_html)
+            code_actions_content(self._actions_by_config, listener.lightbulb_color)
         link_content, link_range = self.link_content_and_range()
         only_link_content = not bool(contents) and link_range is not None
         if prefs.show_symbol_action_links and contents and not only_diagnostics and hover_content:


### PR DESCRIPTION
Fix #2812 

Actually let's do it now, because it was just a few lines change. The lightbulb icon used in the popup may be removed in another PR later.