### PR TITLE
Fix on-type-formatting running when duplicating line

### DIFF
--- a/plugin/core/constants.py
+++ b/plugin/core/constants.py
@@ -253,7 +253,7 @@ LIGHTBULB_SCOPE = 'region.yellowish lightbulb.lsp'
 
 COMMAND_TO_CHANGE_EVENT_ACTION: dict[str, ChangeEventAction] = {
     'cut': 'cut',
-    'duplicate_line': 'duplicate_line',
+    'duplicate_line': 'other',
     'paste': 'paste',
     'paste_and_indent': 'paste',
     'redo': 'redo',

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -71,7 +71,7 @@ import sublime
 import sublime_plugin
 import tempfile
 
-ChangeEventAction = Literal['cut', 'duplicate_line', 'paste', 'redo', 'undo', 'type']
+ChangeEventAction = Literal['cut', 'other', 'paste', 'redo', 'undo', 'type']
 MarkdownLangMap = Dict[str, Tuple[Tuple[str, ...], Tuple[str, ...]]]
 
 _baseflags = sublime.RegionFlags.DRAW_NO_FILL | sublime.RegionFlags.DRAW_NO_OUTLINE | sublime.RegionFlags.DRAW_EMPTY_AS_OVERWRITE | sublime.RegionFlags.NO_UNDO  # noqa: E501


### PR DESCRIPTION
Recognize edits triggered by `duplicate_line` so that those don't trigger on-type-formatting.

Fixes #2815