### PR TITLE
Allow SettingsRegistration to be GCed

### DIFF
--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -168,7 +168,7 @@ def debounced(f: Callable[[], Any], timeout_ms: int = 0, condition: Callable[[],
 
 
 class SettingsRegistration:
-    __slots__ = ("settings", "settings_path", "__weakref__")
+    __slots__ = ("settings", "settings_path", "__weakref__")  # pyright: ignore[reportUninitializedInstanceVariable]
 
     def __init__(
         self, settings: sublime.Settings, settings_path: str, on_change: Callable[[SettingsRegistration], None]


### PR DESCRIPTION
Despite what I've said about `weakref`, it seems acceptable here. Otherwise I would probably use explicit listener registration/unregistration but I don't want to complicate things.

Fixes #2811