### PR TITLE
Test both TCP modes

### DIFF
--- a/tests/server.py
+++ b/tests/server.py
@@ -21,18 +21,16 @@ resumes (since response to request will arrive after requested notification).
 from __future__ import annotations
 
 from argparse import ArgumentParser
-import argparse
-from enum import IntEnum
-import enum
 from typing import Any
 from typing import Awaitable
 from typing import Callable
 from typing import Dict
 from typing import Iterable
 from typing import List
-from typing import Literal
 from typing import Union
+import argparse
 import asyncio
+import enum
 import json
 import os
 import sys
@@ -48,7 +46,7 @@ PayloadLike = Union[List[StringDict], StringDict, None]
 ENCODING = "utf-8"
 
 
-class ErrorCode(IntEnum):
+class ErrorCode(enum.IntEnum):
     # Defined by JSON RPC
     ParseError = -32700
     InvalidRequest = -32600
@@ -480,12 +478,9 @@ def _win32_stdio(loop: asyncio.AbstractEventLoop) -> tuple[asyncio.StreamReader,
 # END: https://stackoverflow.com/a/52702646/990142
 
 
-class Mode(enum.Enum):
+class Mode(enum.StrEnum):
     server = "server"
     client = "client"
-
-    def __str__(self) -> str:
-        return self.value
 
 
 async def main(tcp_port: int | None = None, mode: Mode = Mode.server) -> bool:
@@ -530,7 +525,7 @@ if __name__ == '__main__':
     parser.add_argument("-v", "--version", action="store_true", help="print version and exit")
     parser.add_argument("-p", "--tcp-port", type=int)
     parser.add_argument("--mode", type=Mode, default=Mode.server)
-    args: CmdLineArgs = parser.parse_args(namespace=CmdLineArgs())
+    args = parser.parse_args(namespace=CmdLineArgs())
     if args.version:
         print(__package__, __version__)
         sys.exit(0)

--- a/tests/server.py
+++ b/tests/server.py
@@ -1,8 +1,7 @@
 """
 A simple test server for integration tests.
 
-Only understands stdio.
-Uses the asyncio module and mypy types, so you'll need a modern Python.
+Can do JSON-RPC with stdio or TCP sockets as the transport.
 
 To make this server reply to requests, send the $test/setResponse notification.
 
@@ -18,7 +17,6 @@ with expected notification method in params['method'] and params in params['para
 Tests can await this request to make sure that they receive notification before code
 resumes (since response to request will arrive after requested notification).
 
-TODO: Untested on Windows.
 """
 from __future__ import annotations
 
@@ -38,7 +36,7 @@ import sys
 import uuid
 
 __package__ = "server"
-__version__ = "1.0.0"
+__version__ = "2.0.0"
 
 
 StringDict = Dict[str, Any]
@@ -479,24 +477,36 @@ def _win32_stdio(loop: asyncio.AbstractEventLoop) -> tuple[asyncio.StreamReader,
 # END: https://stackoverflow.com/a/52702646/990142
 
 
-async def main(tcp_port: int | None = None) -> bool:
+async def main(tcp_port: int | None = None, mode: str | None = None) -> bool:
     if tcp_port is not None:
 
-        class ClientConnectedCallback:
+        if mode is None or mode == "server":
+            print("running in TCP server mode", file=sys.stderr)
 
-            def __init__(self) -> None:
-                self.received_shutdown = False
+            class ClientConnectedCallback:
 
-            async def __call__(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
-                session = Session(reader, writer)
-                self.received_shutdown = await session.run_forever()
+                def __init__(self) -> None:
+                    self.received_shutdown = False
 
-        callback = ClientConnectedCallback()
-        server = await asyncio.start_server(callback, port=tcp_port)
-        # NOTE: This is deliberately wrong -- we should stop serving once the exit notification is received.
-        # But, it's good to have this botched logic here to make sure that servers shutdown in the integration tests.
-        await server.serve_forever()
-        return callback.received_shutdown
+                async def __call__(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+                    session = Session(reader, writer)
+                    self.received_shutdown = await session.run_forever()
+
+            callback = ClientConnectedCallback()
+            server = await asyncio.start_server(callback, port=tcp_port)
+            # NOTE: This is deliberately wrong -- we should stop serving once the exit notification is received. But,
+            # it's good to have this botched logic here to make sure that servers shutdown in the integration tests.
+            await server.serve_forever()
+            return callback.received_shutdown
+
+        if mode is not None and mode == "client":
+            print("running in TCP client mode", file=sys.stderr)
+            reader, writer = await asyncio.open_connection(host=None, port=tcp_port)
+            session = Session(reader, writer)
+            return await session.run_forever()
+
+        return False
+
     reader, writer = await stdio()
     session = Session(reader, writer)
     return await session.run_forever()
@@ -506,6 +516,7 @@ if __name__ == '__main__':
     parser = ArgumentParser(prog=__package__, description=__doc__)
     parser.add_argument("-v", "--version", action="store_true", help="print version and exit")
     parser.add_argument("-p", "--tcp-port", type=int)
+    parser.add_argument("--mode", help="one of 'client' or 'server'", default="server")
     args = parser.parse_args()
     if args.version:
         print(__package__, __version__)
@@ -514,7 +525,7 @@ if __name__ == '__main__':
     asyncio.set_event_loop(loop)
     shutdown_received = False
     try:
-        shutdown_received = loop.run_until_complete(main(args.tcp_port))
+        shutdown_received = loop.run_until_complete(main(args.tcp_port, args.mode))
     except KeyboardInterrupt:
         pass
     loop.run_until_complete(loop.shutdown_asyncgens())

--- a/tests/server.py
+++ b/tests/server.py
@@ -21,13 +21,16 @@ resumes (since response to request will arrive after requested notification).
 from __future__ import annotations
 
 from argparse import ArgumentParser
+import argparse
 from enum import IntEnum
+import enum
 from typing import Any
 from typing import Awaitable
 from typing import Callable
 from typing import Dict
 from typing import Iterable
 from typing import List
+from typing import Literal
 from typing import Union
 import asyncio
 import json
@@ -477,47 +480,57 @@ def _win32_stdio(loop: asyncio.AbstractEventLoop) -> tuple[asyncio.StreamReader,
 # END: https://stackoverflow.com/a/52702646/990142
 
 
-async def main(tcp_port: int | None = None, mode: str | None = None) -> bool:
-    if tcp_port is not None:
+class Mode(enum.Enum):
+    server = "server"
+    client = "client"
 
-        if mode is None or mode == "server":
-            print("running in TCP server mode", file=sys.stderr)
+    def __str__(self) -> str:
+        return self.value
 
-            class ClientConnectedCallback:
 
-                def __init__(self) -> None:
-                    self.received_shutdown = False
+async def main(tcp_port: int | None = None, mode: Mode = Mode.server) -> bool:
+    if tcp_port is None:
+        reader, writer = await stdio()
+        session = Session(reader, writer)
+        return await session.run_forever()
 
-                async def __call__(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
-                    session = Session(reader, writer)
-                    self.received_shutdown = await session.run_forever()
+    if mode == Mode.server:
+        print("running in TCP server mode", file=sys.stderr)
 
-            callback = ClientConnectedCallback()
-            server = await asyncio.start_server(callback, port=tcp_port)
-            # NOTE: This is deliberately wrong -- we should stop serving once the exit notification is received. But,
-            # it's good to have this botched logic here to make sure that servers shutdown in the integration tests.
-            await server.serve_forever()
-            return callback.received_shutdown
+        class ClientConnectedCallback:
 
-        if mode is not None and mode == "client":
-            print("running in TCP client mode", file=sys.stderr)
-            reader, writer = await asyncio.open_connection(host=None, port=tcp_port)
-            session = Session(reader, writer)
-            return await session.run_forever()
+            def __init__(self) -> None:
+                self.received_shutdown = False
 
-        return False
+            async def __call__(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+                session = Session(reader, writer)
+                self.received_shutdown = await session.run_forever()
 
-    reader, writer = await stdio()
+        callback = ClientConnectedCallback()
+        server = await asyncio.start_server(callback, port=tcp_port)
+        # NOTE: This is deliberately wrong -- we should stop serving once the exit notification is received. But,
+        # it's good to have this botched logic here to make sure that servers shutdown in the integration tests.
+        await server.serve_forever()
+        return callback.received_shutdown
+
+    print("running in TCP client mode", file=sys.stderr)
+    reader, writer = await asyncio.open_connection(host=None, port=tcp_port)
     session = Session(reader, writer)
     return await session.run_forever()
 
 
 if __name__ == '__main__':
+
+    class CmdLineArgs(argparse.Namespace):
+        version: bool = False
+        tcp_port: int | None = None
+        mode: Mode = Mode.server
+
     parser = ArgumentParser(prog=__package__, description=__doc__)
     parser.add_argument("-v", "--version", action="store_true", help="print version and exit")
     parser.add_argument("-p", "--tcp-port", type=int)
-    parser.add_argument("--mode", help="one of 'client' or 'server'", default="server")
-    args = parser.parse_args()
+    parser.add_argument("--mode", type=Mode, default=Mode.server)
+    args: CmdLineArgs = parser.parse_args(namespace=CmdLineArgs())
     if args.version:
         print(__package__, __version__)
         sys.exit(0)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -44,23 +44,42 @@ class YieldPromise:
         return self.__result
 
 
-def make_stdio_test_config() -> ClientConfig:
-    return ClientConfig(
-        name="TEST",
+def make_stdio_test_config(name: str, init_options: dict[str, Any]) -> ClientConfig:
+    """Start the fake language server in STDIO mode."""
+    config = ClientConfig(
+        name=name,
         command=["python3", join("$packages", "LSP", "tests", "server.py")],
         selector="text.plain",
         enabled=True,
     )
+    config.initialization_options.assign(init_options)
+    return config
 
 
-def make_tcp_test_config() -> ClientConfig:
-    return ClientConfig(
-        name="TEST",
-        command=["python3", join("$packages", "LSP", "tests", "server.py"), "--tcp-port", "$port"],
+def make_tcp_server_test_config(name: str, init_options: dict[str, Any]) -> ClientConfig:
+    """Start the fake server in TCP mode, and make it act as the TCP server, awaiting a single client connection."""
+    config = ClientConfig(
+        name=name,
+        command=["python3", join("$packages", "LSP", "tests", "server.py"), "--tcp-port", "$port", "--mode=server"],
         selector="text.plain",
         tcp_port=0,  # select a free one for me
         enabled=True,
     )
+    config.initialization_options.assign(init_options)
+    return config
+
+
+def make_tcp_client_test_config(name: str, init_options: dict[str, Any]) -> ClientConfig:
+    """Start the fake server in TCP mode, and make it act as the TCP client, where it connects to the LSP plugin."""
+    config = ClientConfig(
+        name=name,
+        command=["python3", join("$packages", "LSP", "tests", "server.py"), "--tcp-port", "$port", "--mode=client"],
+        selector="text.plain",
+        tcp_port=-1,  # select a free one for me
+        enabled=True,
+    )
+    config.initialization_options.assign(init_options)
+    return config
 
 
 def add_config(config: ClientConfig) -> None:
@@ -85,7 +104,7 @@ def expand(s: str, w: sublime.Window) -> str:
 class TextDocumentTestCase(DeferrableTestCase):
     @classmethod
     def get_stdio_test_config(cls) -> ClientConfig:
-        return make_stdio_test_config()
+        return make_stdio_test_config("TEST", {})
 
     @classmethod
     def setUpClass(cls) -> Generator:

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -47,7 +47,7 @@ class YieldPromise:
         return self.__result
 
 
-def make_stdio_test_config(name: str, init_options: dict[str, Any]) -> ClientConfig:
+def make_stdio_test_config(name: str, init_options: dict[str, Any] | None = None) -> ClientConfig:
     """Create a config for starting the fake language server in STDIO mode."""
     return ClientConfig(
         name=name,
@@ -58,7 +58,7 @@ def make_stdio_test_config(name: str, init_options: dict[str, Any]) -> ClientCon
     )
 
 
-def make_tcp_server_test_config(name: str, init_options: dict[str, Any]) -> ClientConfig:
+def make_tcp_server_test_config(name: str, init_options: dict[str, Any] | None = None) -> ClientConfig:
     """
     Create a config for starting the fake server in TCP mode, and make it act as the TCP server, awaiting a single
     client connection.
@@ -73,7 +73,7 @@ def make_tcp_server_test_config(name: str, init_options: dict[str, Any]) -> Clie
     )
 
 
-def make_tcp_client_test_config(name: str, init_options: dict[str, Any]) -> ClientConfig:
+def make_tcp_client_test_config(name: str, init_options: dict[str, Any] | None = None) -> ClientConfig:
     """
     Create a config for starting the fake server in TCP mode, and make it act as the TCP client, where it connects to
     the LSP plugin.
@@ -110,7 +110,7 @@ def expand(s: str, w: sublime.Window) -> str:
 class TextDocumentTestCase(DeferrableTestCase):
     @classmethod
     def get_stdio_test_config(cls) -> ClientConfig:
-        return make_stdio_test_config("TEST", {})
+        return make_stdio_test_config("TEST")
 
     @classmethod
     def setUpClass(cls) -> Generator:

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from .test_mocks import basic_responses
+from collections.abc import Generator
+from LSP.plugin.core.collections import DottedDict
+from LSP.plugin.core.promise import Promise
 from LSP.plugin.core.protocol import Notification
 from LSP.plugin.core.protocol import Request
 from LSP.plugin.core.registry import windows
@@ -45,41 +48,44 @@ class YieldPromise:
 
 
 def make_stdio_test_config(name: str, init_options: dict[str, Any]) -> ClientConfig:
-    """Start the fake language server in STDIO mode."""
-    config = ClientConfig(
+    """Create a config for starting the fake language server in STDIO mode."""
+    return ClientConfig(
         name=name,
         command=["python3", join("$packages", "LSP", "tests", "server.py")],
         selector="text.plain",
+        initialization_options=DottedDict(init_options),
         enabled=True,
     )
-    config.initialization_options.assign(init_options)
-    return config
 
 
 def make_tcp_server_test_config(name: str, init_options: dict[str, Any]) -> ClientConfig:
-    """Start the fake server in TCP mode, and make it act as the TCP server, awaiting a single client connection."""
-    config = ClientConfig(
+    """
+    Create a config for starting the fake server in TCP mode, and make it act as the TCP server, awaiting a single
+    client connection.
+    """
+    return ClientConfig(
         name=name,
         command=["python3", join("$packages", "LSP", "tests", "server.py"), "--tcp-port", "$port", "--mode=server"],
         selector="text.plain",
+        initialization_options=DottedDict(init_options),
         tcp_port=0,  # select a free one for me
         enabled=True,
     )
-    config.initialization_options.assign(init_options)
-    return config
 
 
 def make_tcp_client_test_config(name: str, init_options: dict[str, Any]) -> ClientConfig:
-    """Start the fake server in TCP mode, and make it act as the TCP client, where it connects to the LSP plugin."""
-    config = ClientConfig(
+    """
+    Create a config for starting the fake server in TCP mode, and make it act as the TCP client, where it connects to
+    the LSP plugin.
+    """
+    return ClientConfig(
         name=name,
         command=["python3", join("$packages", "LSP", "tests", "server.py"), "--tcp-port", "$port", "--mode=client"],
         selector="text.plain",
+        initialization_options=DottedDict(init_options),
         tcp_port=-1,  # select a free one for me
         enabled=True,
     )
-    config.initialization_options.assign(init_options)
-    return config
 
 
 def add_config(config: ClientConfig) -> None:

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -4,6 +4,8 @@ from .setup import add_config
 from .setup import close_test_view
 from .setup import expand
 from .setup import make_stdio_test_config
+from .setup import make_tcp_client_test_config
+from .setup import make_tcp_server_test_config
 from .setup import remove_config
 from .setup import TIMEOUT_TIME
 from .setup import YieldPromise
@@ -50,16 +52,17 @@ class WindowDocumentHandlerTests(DeferrableTestCase):
         self.assertTrue(self.window)
         self.session1 = None
         self.session2 = None
-        self.config1 = make_stdio_test_config()
-        self.config1.initialization_options.assign(initialization_options)
-        self.config2 = make_stdio_test_config()
-        self.config2.initialization_options.assign(initialization_options)
-        self.config2.name = "TEST-2"
+        self.session3 = None
+        self.config1 = make_stdio_test_config("TEST-1", initialization_options)
+        self.config2 = make_tcp_client_test_config("TEST-2", initialization_options)
+        self.config3 = make_tcp_server_test_config("TEST-3", initialization_options)
         self.wm = windows.lookup(self.window)
         add_config(self.config1)
         add_config(self.config2)
+        add_config(self.config3)
         self.wm.get_config_manager().all[self.config1.name] = self.config1
         self.wm.get_config_manager().all[self.config2.name] = self.config2
+        self.wm.get_config_manager().all[self.config3.name] = self.config3
 
     def test_sends_did_open_to_multiple_sessions(self) -> Generator:
         filename = expand(join("$packages", "LSP", "tests", "testfile.txt"), self.window)
@@ -76,14 +79,21 @@ class WindowDocumentHandlerTests(DeferrableTestCase):
         yield {
             "condition": lambda: self.wm.get_session(self.config2.name, self.view.file_name()) is not None,
             "timeout": TIMEOUT_TIME}
+        yield {
+            "condition": lambda: self.wm.get_session(self.config3.name, self.view.file_name()) is not None,
+            "timeout": TIMEOUT_TIME}
         self.session1 = self.wm.get_session(self.config1.name, self.view.file_name())
         self.session2 = self.wm.get_session(self.config2.name, self.view.file_name())
+        self.session3 = self.wm.get_session(self.config3.name, self.view.file_name())
         self.assertIsNotNone(self.session1)
         self.assertIsNotNone(self.session2)
+        self.assertIsNotNone(self.session3)
         self.assertEqual(self.session1.config.name, self.config1.name)
         self.assertEqual(self.session2.config.name, self.config2.name)
+        self.assertEqual(self.session3.config.name, self.config3.name)
         yield {"condition": lambda: self.session1.state == ClientStates.READY, "timeout": TIMEOUT_TIME}
         yield {"condition": lambda: self.session2.state == ClientStates.READY, "timeout": TIMEOUT_TIME}
+        yield {"condition": lambda: self.session3.state == ClientStates.READY, "timeout": TIMEOUT_TIME}
         yield from self.await_message("initialize")
         yield from self.await_message("initialized")
         yield from self.await_message("textDocument/didOpen")
@@ -103,6 +113,13 @@ class WindowDocumentHandlerTests(DeferrableTestCase):
         if self.session2:
             sublime.set_timeout_async(self.session2.end_async)
             yield lambda: self.session2.state == ClientStates.STOPPING
+        if self.session3:
+            sublime.set_timeout_async(self.session3.end_async)
+            yield lambda: self.session3.state == ClientStates.STOPPING
+        try:
+            remove_config(self.config3)
+        except ValueError:
+            pass
         try:
             remove_config(self.config2)
         except ValueError:
@@ -111,6 +128,7 @@ class WindowDocumentHandlerTests(DeferrableTestCase):
             remove_config(self.config1)
         except ValueError:
             pass
+        self.wm.get_config_manager().all.pop(self.config3.name, None)
         self.wm.get_config_manager().all.pop(self.config2.name, None)
         self.wm.get_config_manager().all.pop(self.config1.name, None)
         yield from super().doCleanups()
@@ -118,6 +136,7 @@ class WindowDocumentHandlerTests(DeferrableTestCase):
     def await_message(self, method: str) -> Generator:
         promise1 = YieldPromise()
         promise2 = YieldPromise()
+        promise3 = YieldPromise()
 
         def handler1(params: Any) -> None:
             promise1.fulfill(params)
@@ -125,10 +144,15 @@ class WindowDocumentHandlerTests(DeferrableTestCase):
         def handler2(params: Any) -> None:
             promise2.fulfill(params)
 
+        def handler3(params: Any) -> None:
+            promise3.fulfill(params)
+
         def error_handler(params: Any) -> None:
             debug("Got error:", params, "awaiting timeout :(")
 
         self.session1.send_request(Request("$test/getReceived", {"method": method}), handler1, error_handler)
         self.session2.send_request(Request("$test/getReceived", {"method": method}), handler2, error_handler)
+        self.session3.send_request(Request("$test/getReceived", {"method": method}), handler3, error_handler)
         yield {"condition": promise1, "timeout": TIMEOUT_TIME}
         yield {"condition": promise2, "timeout": TIMEOUT_TIME}
+        yield {"condition": promise3, "timeout": TIMEOUT_TIME}

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -395,7 +395,7 @@ class ViewsTest(DeferrableTestCase):
         diagnostic2.pop("relatedInformation")
         self.assertIn("relatedInformation", diagnostic1)
         self.assertNotIn("relatedInformation", diagnostic2)
-        client_config = make_stdio_test_config("TEST", {})
+        client_config = make_stdio_test_config("TEST")
         # They should result in the same minihtml.
         self.assertEqual(
             format_diagnostic_for_html(self.view, client_config, diagnostic1, [], '#ffffff', "/foo/bar"),

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -395,7 +395,7 @@ class ViewsTest(DeferrableTestCase):
         diagnostic2.pop("relatedInformation")
         self.assertIn("relatedInformation", diagnostic1)
         self.assertNotIn("relatedInformation", diagnostic2)
-        client_config = make_stdio_test_config()
+        client_config = make_stdio_test_config("TEST", {})
         # They should result in the same minihtml.
         self.assertEqual(
             format_diagnostic_for_html(self.view, client_config, diagnostic1, [], '#ffffff', "/foo/bar"),


### PR DESCRIPTION
Add a test that checks that "tcp server mode" works. Server meaning that this plugin acts as the TCP server and the langserver connects as TCP client.