### PR TITLE
Add an opt-in pre-commit hook for development

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 .github/ export-ignore
+.pre-commit-config.yaml export-ignore
 .style.yapf export-ignore
 codecov.yml export-ignore
 docs/ export-ignore
@@ -10,6 +11,7 @@ stubs/ export-ignore
 tests/ export-ignore
 tox.ini export-ignore
 unittesting.json export-ignore
+uv.lock  export-ignore
 
 # Release script
 .release.json export-ignore

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: local
+    hooks:
+      - id: tox
+        name: tox
+        language: python
+        entry: tox
+        pass_filenames: false
+        always_run: true
+        additional_dependencies: [tox]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Sublime Text bundles Python 3.8, please be sure to set up your environment to ma
 LSP uses [Pyright](https://microsoft.github.io/pyright) and [Ruff](https://docs.astral.sh/ruff/) to provide some code quality assurances.
 Run `tox` to check your work.
 Consider using [LSP-pyright](https://packages.sublimetext.io/packages/LSP-pyright) and/or [LSP-ruff](https://packages.sublimetext.io/packages/LSP-ruff) as a language server.
-Enable `"basedpyright.dev_environment": "sublime_text_38"` in `LPS-pyright` settings to make all types correct.
+Enable `"pyright.dev_environment": "sublime_text_38"` in `LSP-pyright` settings to ensure that types for Sublime Text modules are known.
 Changes in the code only apply after restarting Sublime Text.
 
 ## Pre-commit hooks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,11 +18,11 @@ The issues also allow you to gather some feedback and help from other contributo
 ## Coding
 
 Sublime Text bundles Python 3.8, please be sure to set up your environment to match.
-LSP uses [Pyright](https://microsoft.github.io/pyright), [Ruff](https://docs.astral.sh/ruff/) and [mypy](https://mypy-lang.org/) to provide some code quality assurances.
+LSP uses [Pyright](https://microsoft.github.io/pyright) and [Ruff](https://docs.astral.sh/ruff/) to provide some code quality assurances.
 Run `tox` to check your work.
 Consider using [LSP-pyright](https://packages.sublimetext.io/packages/LSP-pyright) and/or [LSP-ruff](https://packages.sublimetext.io/packages/LSP-ruff) as a language server.
-To reload the plugin, save the file `boot.py`.
-Saving any other file does not reload the plugin.
+Enable `"basedpyright.dev_environment": "sublime_text_38"` in `LPS-pyright` settings to make all types correct.
+Changes in the code only apply after restarting Sublime Text.
 
 ## Pre-commit hooks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,28 @@ Consider using [LSP-pyright](https://packages.sublimetext.io/packages/LSP-pyrigh
 To reload the plugin, save the file `boot.py`.
 Saving any other file does not reload the plugin.
 
+## Pre-commit hooks
+
+The repository ships a [pre-commit](https://pre-commit.com) configuration that runs linting and type-checking before every commit, matching the checks that run in CI via `tox`.
+
+The hook delegates to `tox`, which manages the exact tool versions itself. pre-commit installs `tox` into its own isolated environment, so the checks work regardless of your shell environment or Git client.
+
+**One-time setup:**
+
+```sh
+# Install pre-commit (uv, pipx, or pip)
+uv tool install pre-commit
+
+# Install the git hook
+pre-commit install
+```
+
+To run the checks manually:
+
+```sh
+pre-commit run --all-files
+```
+
 ## Testing
 
 Please consider testing your work with other language servers, even if you do not use them.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,14 +11,11 @@ skipsdist = true
 
 [tool.tox.env_run_base]
 deps = [
-    "mypy==1.18.2",
     "pyright==1.1.408",
     "ruff==0.15.10",
     "orjson==3.11.4",
 ]
 commands = [
-    # mypy disabled for main code as it doesn't currently support cyclic definitions - https://github.com/python/mypy/issues/731
-    ["mypy", "stubs"],
     ["pyright", "plugin", "stubs"],
     ["ruff", "check"],
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,22 +148,3 @@ ignore = [
     "TRY003",  # https://docs.astral.sh/ruff/rules/raise-vanilla-args/
     "TRY301",  # https://docs.astral.sh/ruff/rules/raise-within-try/
 ]
-
-[tool.mypy]
-python_version = "3.9"
-
-# ignore_missing_imports = True
-# check_untyped_defs = True
-disallow_untyped_defs = true
-strict_optional = true
-mypy_path = ["stubs"]
-
-[[tool.mypy.overrides]]
-module = 'tests.*'
-check_untyped_defs = true
-disallow_untyped_defs = false
-
-[[tool.mypy.overrides]]
-module = 'third_party.*'
-ignore_errors = true
-ignore_missing_imports = true

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -170,7 +170,7 @@ class TextDocumentTestCase(DeferrableTestCase):
         :returns:   A generator with resolved value.
         """
         # cls.assertIsNotNone(cls.session)
-        assert cls.session  # mypy
+        assert cls.session
         if promise is None:
             promise = YieldPromise()
 
@@ -218,12 +218,12 @@ class TextDocumentTestCase(DeferrableTestCase):
 
     def set_response(self, method: str, response: Any) -> None:
         self.assertIsNotNone(self.session)
-        assert self.session  # mypy
+        assert self.session
         self.session.send_notification(Notification("$test/setResponse", {"method": method, "response": response}))
 
     def set_responses(self, responses: list[tuple[str, Any]]) -> Generator:
         self.assertIsNotNone(self.session)
-        assert self.session  # mypy
+        assert self.session
         promise = YieldPromise()
 
         def handler(params: Any) -> None:
@@ -238,7 +238,7 @@ class TextDocumentTestCase(DeferrableTestCase):
 
     def await_client_notification(self, method: str, params: Any = None) -> Generator:
         self.assertIsNotNone(self.session)
-        assert self.session  # mypy
+        assert self.session
         promise = YieldPromise()
 
         def handler(params: Any) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.8"


### PR DESCRIPTION
- Document how to enable optional pre-commit hook for the repository.
- Don't run mypy since it didn't prove useful in a long time and pyright also runs on stubs.
