### PR TITLE
Add support for VSCode-specific editor.action.showReferences command

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -78,6 +78,7 @@ from ..api import request_handler
 from ..diagnostics import DiagnosticsIdentifier
 from ..diagnostics import DiagnosticsStorage
 from ..diagnostics import WORKSPACE_DIAGNOSTICS_RETRIGGER_DELAY
+from ..locationpicker import LocationPicker
 from .constants import ChangeEventAction
 from .constants import MARKO_MD_PARSER_VERSION
 from .constants import RequestFlags
@@ -1352,6 +1353,15 @@ class Session(APIHandler, TransportCallbacks):
                 listener.do_signature_help_async(SignatureHelpTriggerKind.Invoked)
 
             sublime.set_timeout_async(run_async)
+            return Promise.resolve(None)
+        # Handle VSCode-specific command which is often used for "References" code lenses
+        if command_name == "editor.action.showReferences" and view:
+            if (arguments := command.get('arguments')) and len(arguments) == 3:
+                if references := cast('list[Location]', arguments[2]):
+                    if len(references) == 1:
+                        sublime.set_timeout_async(lambda: self.open_location_async(references[0]))
+                    else:
+                        LocationPicker(view, self, references, side_by_side=False)
             return Promise.resolve(None)
         request = Request[ExecuteCommandParams, Union[R, None]].executeCommand(command, progress=progress)
         execute_command_promise = self.send_request_task(request)

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1359,7 +1359,7 @@ class Session(APIHandler, TransportCallbacks):
             if (arguments := command.get('arguments')) and len(arguments) == 3:
                 if references := cast('list[Location]', arguments[2]):
                     if len(references) == 1:
-                        sublime.set_timeout_async(lambda: self.open_location_async(references[0]))
+                        self.open_location_async(references[0])
                     else:
                         LocationPicker(view, self, references, side_by_side=False)
             return Promise.resolve(None)

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -549,7 +549,9 @@ class SessionBuffer:
                 self._supported_custom_tokens.add(token_type)
 
     def _update_supported_commands(self) -> None:
-        self._supported_commands = set(self.session.get_capability('executeCommandProvider.commands') or [])
+        self._supported_commands = set(['editor.action.showReferences'])
+        if commands := self.session.get_capability('executeCommandProvider.commands'):
+            self._supported_commands.update(commands)
         self._supported_commands.update(itertools.chain.from_iterable(self._dynamically_registered_commands.values()))
 
     def _get_request_flags(self, view: sublime.View) -> RequestFlags:

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -549,7 +549,7 @@ class SessionBuffer:
                 self._supported_custom_tokens.add(token_type)
 
     def _update_supported_commands(self) -> None:
-        self._supported_commands = {'editor.action.showReferences'}
+        self._supported_commands = {'editor.action.showReferences'}  # Handled on client side in Session.execute_command
         if commands := self.session.get_capability('executeCommandProvider.commands'):
             self._supported_commands.update(commands)
         self._supported_commands.update(itertools.chain.from_iterable(self._dynamically_registered_commands.values()))

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -549,7 +549,7 @@ class SessionBuffer:
                 self._supported_custom_tokens.add(token_type)
 
     def _update_supported_commands(self) -> None:
-        self._supported_commands = set(['editor.action.showReferences'])
+        self._supported_commands = {'editor.action.showReferences'}
         if commands := self.session.get_capability('executeCommandProvider.commands'):
             self._supported_commands.update(commands)
         self._supported_commands.update(itertools.chain.from_iterable(self._dynamically_registered_commands.values()))


### PR DESCRIPTION
The `editor.action.showReferences` command is technically not part of the protocol (see https://github.com/microsoft/language-server-protocol/issues/788 - the last comment therein from 2024 suggests that they are open to standardize relevant commands, but it seems there was no follow up to that, so I'd say we shouldn't wait for that - or we would possibly wait indefinitely).

This command is used by various servers for "References" code lenses. There are a few custom implementations to handle it on the plugin side in LSP-typescript, LSP-elm, LSP-volar, LSP-vue and LSP-PowerShellEditorServices, which look all identical: https://github.com/search?q=org%3Asublimelsp%20editor.action.showReferences&type=code

A similar middleware is also required in VSCode extensions to translate the JSON arguments into `vscode.Uri`, `vscode.Position` and `vscode.Location` objects, that are accepted by the built-in VSCode command. But since these objects have a direct correspondence to the JSON types from the LSP specs, we can probably assume that the `arguments` from the server always match those types, when the command name is `editor.action.showReferences`.

The advantage of having this implementation directly in LSP is that such code lenses would work automatically and even for manual server configs that don't have a helper package. If there is a custom implementation in a plugin, that still takes precedence, because we ask the plugin first:
https://github.com/sublimelsp/LSP/blob/d9cf1f7d02b0e0c5233c59efb2b5377483f12cca/plugin/core/sessions.py#L1332-L1336

This even allows to override the implementation from LSP in case a server would decide to use different command args for the same command name. But for the plugins which are mentioned above, the custom implementation basically becomes obsolete.

---

By the way, I'm considering to maybe refresh the `LocationPicker` a bit (because currently it just puts the server name as annotation on the righthand side of each entry - maybe we could use that space in a better way for this application), but it should be good for now and that can wait.