### PR TITLE
Include diagnostic code when copying diagnostic text

### DIFF
--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -917,12 +917,12 @@ def format_diagnostic_for_html(
     content = _format_diagnostic_message(view, message)
     code = diagnostic.get("code")
     source = diagnostic.get("source")
-    copy_text = raw_message.replace(' ', ' ')
+    copy_text = f'{raw_message} '.replace(' ', ' ')
     if source or code is not None:
         meta_info = ""
         if source:
             meta_info += text2html(source)
-            copy_text += f' ({source})' if code is None else f' {source}'
+            copy_text += f'({source})' if code is None else source
         if code is not None:
             if code_description := diagnostic.get("codeDescription"):
                 href = code_description["href"]
@@ -933,7 +933,7 @@ def format_diagnostic_for_html(
                 copy_text += f'({code})'
         content += " " + _html_element("span", meta_info, class_name="color-muted", escape=False)
     content += f"""<a class='copy-icon' title='Copy to clipboard' href='{sublime.command_url(
-        'lsp_copy_text', {'text': copy_text}
+        'lsp_copy_text', {'text': copy_text.strip()}
     )}'>⧉</a>"""
     if related_infos := diagnostic.get("relatedInformation"):
         info = "<br>".join(_format_diagnostic_related_info(config, info, base_dir) for info in related_infos)

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -609,7 +609,7 @@ def minihtml(
             }
         ]
         # Workaround CommonMark deficiency: two spaces followed by a newline should result in a new paragraph.
-        result = re.sub('(\\S)  \n', '\\1\n\n', result)
+        result = re.sub('(\\S)  \n', '\\1\n\n', result)  # noqa: RUF039
     if isinstance(language_id_map, dict):
         frontmatter["language_map"] = language_id_map
     return mdpopups.md2html(view, mdpopups.format_frontmatter(frontmatter) + result)

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -609,7 +609,7 @@ def minihtml(
             }
         ]
         # Workaround CommonMark deficiency: two spaces followed by a newline should result in a new paragraph.
-        result = re.sub('(\\S)  \n', '\\1\n\n', result)  # noqa: RUF039
+        result = re.sub('(\\S)  \n', '\\1\n\n', result)
     if isinstance(language_id_map, dict):
         frontmatter["language_map"] = language_id_map
     return mdpopups.md2html(view, mdpopups.format_frontmatter(frontmatter) + result)
@@ -917,7 +917,7 @@ def format_diagnostic_for_html(
     content = _format_diagnostic_message(view, message)
     code = diagnostic.get("code")
     source = diagnostic.get("source")
-    copy_text = f'{raw_message}'.replace(' ', ' ')
+    copy_text = raw_message.replace(' ', ' ')
     if source or code is not None:
         meta_info = ""
         if source:

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -917,18 +917,21 @@ def format_diagnostic_for_html(
     content = _format_diagnostic_message(view, message)
     code = diagnostic.get("code")
     source = diagnostic.get("source")
+    copy_text = raw_message.replace(' ', ' ')
     if source or code is not None:
         meta_info = ""
         if source:
+            copy_text += f' ({source})'
             meta_info += text2html(source)
         if code is not None:
             if code_description := diagnostic.get("codeDescription"):
                 href = code_description["href"]
                 meta_info += f'({make_link(href, str(code), tooltip=html.escape(href))})'
+                copy_text += f' [{code} - {href}]'
             else:
                 meta_info += f'({text2html(str(code))})'
+                copy_text += f' [{code}]'
         content += " " + _html_element("span", meta_info, class_name="color-muted", escape=False)
-    copy_text = f"{raw_message} {f'({source})' if source else ''}".strip().replace(' ', ' ')
     content += f"""<a class='copy-icon' title='Copy to clipboard' href='{sublime.command_url(
         'lsp_copy_text', {'text': copy_text}
     )}'>⧉</a>"""

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -917,12 +917,12 @@ def format_diagnostic_for_html(
     content = _format_diagnostic_message(view, message)
     code = diagnostic.get("code")
     source = diagnostic.get("source")
-    copy_text = f'{raw_message} '.replace(' ', ' ')
+    copy_text = f'{raw_message}'.replace(' ', ' ')
     if source or code is not None:
         meta_info = ""
         if source:
             meta_info += text2html(source)
-            copy_text += f'({source})' if code is None else f'({source}[{code}])'
+            copy_text += f' ({source})' if code is None else f' ({source}[{code}])'
         if code is not None:
             if code_description := diagnostic.get("codeDescription"):
                 href = code_description["href"]
@@ -931,7 +931,7 @@ def format_diagnostic_for_html(
                 meta_info += f'({text2html(str(code))})'
         content += " " + _html_element("span", meta_info, class_name="color-muted", escape=False)
     content += f"""<a class='copy-icon' title='Copy to clipboard' href='{sublime.command_url(
-        'lsp_copy_text', {'text': copy_text.strip()}
+        'lsp_copy_text', {'text': copy_text}
     )}'>⧉</a>"""
     if related_infos := diagnostic.get("relatedInformation"):
         info = "<br>".join(_format_diagnostic_related_info(config, info, base_dir) for info in related_infos)

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -921,8 +921,8 @@ def format_diagnostic_for_html(
     if source or code is not None:
         meta_info = ""
         if source:
-            copy_text += f' ({source})'
             meta_info += text2html(source)
+            copy_text += f' ({source})'
         if code is not None:
             if code_description := diagnostic.get("codeDescription"):
                 href = code_description["href"]

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -922,15 +922,13 @@ def format_diagnostic_for_html(
         meta_info = ""
         if source:
             meta_info += text2html(source)
-            copy_text += f'({source})' if code is None else source
+            copy_text += f'({source})' if code is None else f'({source}[{code}])'
         if code is not None:
             if code_description := diagnostic.get("codeDescription"):
                 href = code_description["href"]
                 meta_info += f'({make_link(href, str(code), tooltip=html.escape(href))})'
-                copy_text += f'({code} - {href})'
             else:
                 meta_info += f'({text2html(str(code))})'
-                copy_text += f'({code})'
         content += " " + _html_element("span", meta_info, class_name="color-muted", escape=False)
     content += f"""<a class='copy-icon' title='Copy to clipboard' href='{sublime.command_url(
         'lsp_copy_text', {'text': copy_text.strip()}

--- a/plugin/core/views.py
+++ b/plugin/core/views.py
@@ -922,15 +922,15 @@ def format_diagnostic_for_html(
         meta_info = ""
         if source:
             meta_info += text2html(source)
-            copy_text += f' ({source})'
+            copy_text += f' ({source})' if code is None else f' {source}'
         if code is not None:
             if code_description := diagnostic.get("codeDescription"):
                 href = code_description["href"]
                 meta_info += f'({make_link(href, str(code), tooltip=html.escape(href))})'
-                copy_text += f' [{code} - {href}]'
+                copy_text += f'({code} - {href})'
             else:
                 meta_info += f'({text2html(str(code))})'
-                copy_text += f' [{code}]'
+                copy_text += f'({code})'
         content += " " + _html_element("span", meta_info, class_name="color-muted", escape=False)
     content += f"""<a class='copy-icon' title='Copy to clipboard' href='{sublime.command_url(
         'lsp_copy_text', {'text': copy_text}


### PR DESCRIPTION
We have not been copying diagnostic code when copying diagnostic text to clipboard which was inconsistent with text in hover popup and also annoying if one wants to lookup the code.

Before:

```
Could not assign item in TypedDict
  "Literal['jsonc']" is not assignable to "LanguageKind" (basedpyright)
```

After:

```
Could not assign item in TypedDict
  "Literal['jsonc']" is not assignable to "LanguageKind" (basedpyright[reportGeneralTypeIssues])
```

The formatting doesn't exactly match style in the hover popup but it's because we don't have colors in plain text so we can't just include `source` without parenthesis.