### PR TITLE
Fix initializationOptions being ignored

### DIFF
--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -945,7 +945,7 @@ class ClientConfig:
             auto_complete_selector=deepcopy(d.get("auto_complete_selector")),
             enabled=deepcopy(d.get("enabled", False)),
             initialization_options=DottedDict(
-                deepcopy(d.get("initialization_options"), d.get("initializationOptions"))),
+                deepcopy(d.get("initialization_options", d.get("initializationOptions")))),
             settings=DottedDict(deepcopy(d.get("settings"))),
             env=deepcopy(d.get("env", {})),
             experimental_capabilities=deepcopy(d.get("experimental_capabilities")),


### PR DESCRIPTION
So #2779 got merged a while back and that was fine, but since e31ee1e933d6, initializationOptions in the global config seems to be ignored and has to be updated to the new spelling, initialization_options. This somehow doesn't affect the per-project config, and I didn't look deep enough into the code to figure out why, since I managed to cook up a change that fixed the problem for me, so that's a potentially interesting open question.

Commit message verbatim:

Fix initializationOptions being ignored

initialization_options still works in global config though. Also both initialization_options and initializationOptions seem to work in per-project config. Broken by e31ee1e933d6, which wrapped a lot of stuff in deepcopy(...). This was done wrong in the case of initializationOptions, which used to be derived with

	DottedDict(d.get("initialization_options", d.get("initializationOptions")))

which got updated to

	DottedDict(deepcopy(d.get("initialization_options"), d.get("initializationOptions")))

Note how the first d.get doesn't get the result of the second d.get as a second parameter, which deepcopy gets instead (which presumably ignores it).