### PR TITLE
Emit spec-compliant file:/// URIs for filename_to_uri

### DIFF
--- a/plugin/core/url.py
+++ b/plugin/core/url.py
@@ -15,6 +15,7 @@ from urllib.request import url2pathname
 import json
 import os
 import re
+import sys
 
 if TYPE_CHECKING:
     from ...protocol import CodeAction
@@ -38,8 +39,12 @@ def filename_to_uri(file_name: str) -> str:
     prefix = ST_PACKAGES_PATH
     if file_name.startswith(prefix) and not os.path.exists(file_name):
         return _to_resource_uri(file_name, prefix)
-    path = pathname2url(file_name)
-    return urljoin("file:", path)
+    # CI only exercises the CPython version bundled with Sublime Text (3.8
+    # today), so the >= 3.14 branch is not covered by the test suite until ST
+    # ships a public 3.14 build.
+    if sys.version_info >= (3, 14):
+        return pathname2url(file_name, add_scheme=True)
+    return urljoin('file:', pathname2url(file_name))
 
 
 def view_to_uri(view: sublime.View) -> str:


### PR DESCRIPTION
## Summary

On CPython 3.14, `filename_to_uri` produces a non-spec-compliant `file:/path` URI
(one slash) instead of `file:///path` (three slashes). Strict LSP servers —
notably **gopls v0.15+** — reject it with a JSON-RPC parse error and crash-loop
on `initialize`:

```
--> gopls initialize: {'rootUri': 'file:/Users/sean/src/.../elysium', ...}
<~~ gopls (1): {'code': -32700, 'message': "JSON RPC parse error:
    DocumentURI scheme is not 'file': file:/Users/sean/src/.../elysium"}
```

On CPython 3.8 (current public Sublime Text builds) the old code produces
correct `file:///path` URIs — this bug is specific to CPython 3.14 (current ST
private beta).

## Who is affected

- **ST private beta (build 4204+)** — ships CPython 3.14 → **broken**, every
  file URI is malformed.
- **ST public builds (≤ 4200)** — ship CPython 3.8 → **not affected**, URIs are
  well-formed today.

Only private-beta users hit this today, but the beta will eventually become the
public release. Landing this fix now means LSP keeps working when ST ships a
CPython 3.14 build to everyone.

## Root cause

```python
path = pathname2url(file_name)
return urljoin("file:", path)
```

Two independent things changed in CPython 3.14 and their combination breaks
this pattern:

1. **`pathname2url` became RFC 8089 compliant** and now emits an empty
   authority prefix, so `/etc/hosts` encodes as `///etc/hosts` instead of
   `/etc/hosts`.
2. **`urljoin` stopped synthesizing the authority separator** when the base is
   the scheme-only string `"file:"`. On 3.8, `urljoin("file:", "/etc/hosts")`
   returned `"file:///etc/hosts"` — it effectively treated `"file:"` as
   `"file:///"`. On 3.14, it returns `"file:/etc/hosts"` (plain
   concatenation).

Either change alone would still produce a valid URI. Together they collapse
every POSIX and Windows-drive path to the malformed single-slash form.

RFC 8089 §2 requires `file://<authority>/<path>`, where the authority may be
empty (`file:///path` for a local file) or a hostname
(`file://server/share/path` for a Windows UNC path).

## How each Python version behaves with the old code

| Path | `pathname2url` output | `urljoin("file:", …)` result |
| --- | --- | --- |
| `/etc/hosts` (POSIX, 3.8) | `/etc/hosts` | `file:///etc/hosts` ✅ |
| `/etc/hosts` (POSIX, 3.14) | `///etc/hosts` | `file:/etc/hosts` ❌ |
| `C:\foo` (Win, 3.8) | `/C:/foo` | `file:///C:/foo` ✅ |
| `C:\foo` (Win, 3.14) | `///C:/foo` | `file:/C:/foo` ❌ |
| `\\server\share\f` (Win UNC, 3.8) | `//server/share/f` | `file://server/share/f` ✅ |
| `\\server\share\f` (Win UNC, 3.14) | `////server/share/f` | `file:////server/share/f` ❌ |

## Fix

Gate on Python version. On 3.14+, delegate to `pathname2url(..., add_scheme=True)`,
which was added in 3.14 alongside the RFC 8089 changes and produces correct
URIs for POSIX, Windows drive, and Windows UNC paths. On < 3.14, keep the
existing `urljoin` path, which already produces well-formed URIs on 3.8.

```python
if sys.version_info >= (3, 14):
    return pathname2url(file_name, add_scheme=True)
return urljoin('file:', pathname2url(file_name))
```

Verified `add_scheme=True` handles every input shape correctly by tracing the
CPython 3.14 source of `pathname2url` — on Windows, `splitroot` separates UNC
authority from the path *before* slashes are prepended, so UNC becomes
`file://server/share/...` and drive paths become `file:///C:/...` naturally.

| Path | `pathname2url(..., add_scheme=True)` (3.14) |
| --- | --- |
| `/etc/hosts` (POSIX) | `file:///etc/hosts` |
| `C:\foo\bar` (Win drive) | `file:///C:/foo/bar` |
| `\\server\share\file` (Win UNC) | `file://server/share/file` |
| `\\wsl$\Ubuntu\home` (WSL UNC) | `file://wsl%24/Ubuntu/home` |

## Tests

No new test code. The existing platform-specific tests in `tests/test_url.py`
cover `filename_to_uri` end-to-end on each CI runner. Both branches of the
version gate are trivial delegations to stdlib — the 3.14 branch to
`pathname2url(add_scheme=True)`, the < 3.14 branch to the pre-existing
`urljoin`-based call path that has been correct on 3.8 all along.

### CI coverage note

`SublimeText/UnitTesting` runs the test suite inside a real Sublime Text build,
so tests execute under whatever CPython that build bundles (3.8 today). That
means the `< 3.14` branch of the version gate is exercised on every CI row,
but the `>= 3.14` branch is **not covered by CI** until ST ships a public 3.14
build. Correctness of the 3.14 branch has been confirmed manually by (a) fixing
gopls initialization on ST build 4204 end-to-end, and (b) tracing the CPython
3.14 `pathname2url` source for all relevant path shapes. The inline comment in
`url.py` flags this gap for future readers.

## Reproduction

I hit it on the current Sublime Text private beta (build 4204), which bundles
CPython 3.14 — every file URI LSP emits is the malformed `file:/...` form, and
gopls crash-loops immediately:

1. Use Sublime Text build 4204 (or any build bundling CPython ≥ 3.14).
2. Open a Go project folder.
3. Enable LSP-gopls (gopls ≥ v0.15.0).
4. `View → Show Console` and watch the `initialize` request — `rootUri` is
   `file:/path` instead of `file:///path`, and gopls responds with
   `DocumentURI scheme is not 'file'` and crashes. After 5 crashes in 180
   seconds the UI shows the "gopls server has crashed 5 times" dialog.

With this patch, the `initialize` request emits `file:///path` and gopls
initializes cleanly.

## Test plan

- [x] `tox` passes locally (pyright 1.1.408 + ruff 0.15.10 on Python 3.14)
- [x] `pre-commit run --all-files` passes
- [x] Verified gopls starts cleanly on macOS with the patched `url.py`
- [x] Traced CPython 3.14 `pathname2url` source to confirm `add_scheme=True`
      handles Windows UNC correctly
- [x] CI passes on Linux, macOS, Windows (all on CPython 3.8)
