### PR TITLE
Fix some cases in ST pattern to glob conversion

### DIFF
--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -143,14 +143,14 @@ def sublime_pattern_to_glob(pattern: str, *, is_directory_pattern: bool, root_pa
         # name and any contained files or subdirectories.
         if glob.endswith('/'):
             glob += '**'
-        # If pattern begins with '//', it will be compared as a relative path from the project root.
-        if glob.startswith('//') and root_path:
-            glob = posixpath.join(root_path, glob[2:])
         # If a pattern begins with a single /, it will be treated as an absolute path.
         if not glob.startswith('/') and not glob.startswith('**/'):
             glob = f'**/{glob}'
         if is_directory_pattern and not glob.endswith('/**'):
             glob += '/**'
+        # If pattern begins with '//', it will be compared as a relative path from the project root.
+        if glob.startswith('//') and root_path:
+            glob = posixpath.join(root_path.replace('\\', '/'), glob[2:])
         # Question mark also matches slashes.
         glob = glob.replace('?', '{?,/}')
         # Compact pattern to remove redundant repeated globs

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -44,6 +44,7 @@ import contextlib
 import fnmatch
 import os
 import posixpath
+import re
 import sublime
 import time
 import weakref
@@ -124,7 +125,7 @@ def matches_pattern(path: str, patterns: Any) -> bool:
     return False
 
 
-def sublime_pattern_to_glob(pattern: str, is_directory_pattern: bool, root_path: str | None = None) -> str:
+def sublime_pattern_to_glob(pattern: str, *, is_directory_pattern: bool, root_path: str | None = None) -> str:
     """
     Convert a Sublime Text pattern (http://www.sublimetext.com/docs/file_patterns.html)
     to a glob pattern that utilizes globstar extension.
@@ -135,11 +136,9 @@ def sublime_pattern_to_glob(pattern: str, is_directory_pattern: bool, root_path:
         if is_directory_pattern:
             glob += '/**'
     else:  # complex pattern
-        # With '*/' prefix or '/*' suffix, the '*' matches '/' characters.
-        if glob.startswith('*/'):
-            glob = f'*{glob}'
-        if glob.endswith('/*'):
-            glob += '*'
+        # With '*/' or '/*' sequence, the '*' matches '/' characters.
+        glob = re.sub(r'(?<!\*)\*/', '*/**/', glob)
+        glob = re.sub(r'/\*(?!\*)', '/**/*', glob)
         # If a pattern ends in '/' it will be treated as a directory pattern, and will match both a directory with that
         # name and any contained files or subdirectories.
         if glob.endswith('/'):
@@ -152,6 +151,11 @@ def sublime_pattern_to_glob(pattern: str, is_directory_pattern: bool, root_path:
             glob = f'**/{glob}'
         if is_directory_pattern and not glob.endswith('/**'):
             glob += '/**'
+        # Question mark also matches slashes.
+        glob = glob.replace('?', '{?,/}')
+        # Compact pattern to remove redundant repeated globs
+        glob = re.sub(r'\*\*/(\*\*?/)+', '**/', glob)
+        glob = re.sub(r'(/\*\*?)+/\*\*', '/**', glob)
     return glob
 
 

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -395,7 +395,10 @@ class WindowManager(Manager, WindowConfigChangeListener, ViewStatusHandler):
             return "matches a pattern in binary_file_patterns"
         if matches_pattern(path, settings.get("file_exclude_patterns")):
             return "matches a pattern in file_exclude_patterns"
-        patterns = [sublime_pattern_to_glob(pattern, True) for pattern in settings.get("folder_exclude_patterns") or []]
+        patterns = [
+            sublime_pattern_to_glob(pattern, is_directory_pattern=True)
+            for pattern in settings.get("folder_exclude_patterns") or []
+        ]
         if matches_pattern(path, patterns):
             return "matches a pattern in folder_exclude_patterns"
         if self._workspace.includes_excluded_path(path):

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -397,7 +397,7 @@ class WindowManager(Manager, WindowConfigChangeListener, ViewStatusHandler):
             return "matches a pattern in file_exclude_patterns"
         patterns = [
             sublime_pattern_to_glob(pattern, is_directory_pattern=True)
-            for pattern in settings.get("folder_exclude_patterns") or []
+            for pattern in settings.get("folder_exclude_patterns")
         ]
         if matches_pattern(path, patterns):
             return "matches a pattern in folder_exclude_patterns"

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -78,12 +78,14 @@ class ProjectFolders:
             path = folders[i]
             for pattern in folder.get('folder_exclude_patterns', []):
                 if pattern.startswith('//'):
-                    exclude_patterns.append(sublime_pattern_to_glob(pattern, True, path))
+                    exclude_patterns.append(sublime_pattern_to_glob(pattern, is_directory_pattern=True, root_path=path))
                 elif pattern.startswith('/'):
-                    exclude_patterns.append(sublime_pattern_to_glob(pattern, True))
+                    exclude_patterns.append(sublime_pattern_to_glob(pattern, is_directory_pattern=True))
                 else:
-                    exclude_patterns.extend((sublime_pattern_to_glob('//' + pattern, True, path),
-                                             sublime_pattern_to_glob('//**/' + pattern, True, path)))
+                    exclude_patterns.extend((
+                        sublime_pattern_to_glob('//' + pattern, is_directory_pattern=True, root_path=path),
+                        sublime_pattern_to_glob('//**/' + pattern, is_directory_pattern=True, root_path=path)
+                    ))
             self._folders_exclude_patterns[i] = exclude_patterns
 
     def update(self) -> bool:

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -11,13 +11,11 @@ from LSP.plugin import parse_uri
 from LSP.plugin.core.file_watcher import file_watcher_event_type_to_lsp_file_change_type
 from LSP.plugin.core.file_watcher import register_file_watcher_implementation
 from LSP.plugin.core.types import ClientConfig
-from LSP.plugin.core.types import sublime_pattern_to_glob
 from LSP.protocol import WatchKind
 from os.path import join
 from typing import Generator
 from typing import TYPE_CHECKING
 import sublime
-import unittest
 
 if TYPE_CHECKING:
     from LSP.protocol import DidChangeWatchedFilesRegistrationOptions
@@ -284,81 +282,3 @@ class FileWatcherDynamicTests(FileWatcherDocumentTestCase):
         self.assertEqual(watcher.events, ['create', 'change', 'delete'])
         _, base_path_2 = parse_uri(base_uri_2)
         self.assertEqual(watcher.root_path, base_path_2)
-
-
-class PatternToGlobTests(unittest.TestCase):
-
-    def test_basic_directory_patterns(self) -> None:
-        patterns = [
-            '.git',
-            'CVS',
-            '.Trash-*',
-        ]
-        self._verify_patterns(
-            patterns,
-            [
-                '**/.git/**',
-                '**/CVS/**',
-                '**/.Trash-*/**',
-            ],
-            is_directory_pattern=True)
-
-    def test_complex_directory_patterns(self) -> None:
-        patterns = [
-            '*/foo',
-            'foo/bar',
-            'foo/bar/',
-            '/foo',
-        ]
-        self._verify_patterns(
-            patterns,
-            [
-                '**/foo/**',
-                '**/foo/bar/**',
-                '**/foo/bar/**',
-                '/foo/**',
-            ],
-            is_directory_pattern=True)
-
-    def test_basic_file_patterns(self) -> None:
-        self._verify_patterns(
-            [
-                '*.pyc',
-                ".DS_Store",
-
-            ],
-            [
-                '**/*.pyc',
-                '**/.DS_Store',
-            ],
-            is_directory_pattern=False)
-
-    def test_complex_file_patterns(self) -> None:
-        self._verify_patterns(
-            [
-                "/*.pyo",
-            ],
-            [
-                '/*.pyo',
-            ],
-            is_directory_pattern=False)
-
-    def test_project_relative_patterns(self) -> None:
-        self._verify_patterns(['//foo'], ['/Users/me/foo/**'], is_directory_pattern=True, root_path='/Users/me')
-        self._verify_patterns(['//*.pyo'], ['/Users/me/*.pyo'], is_directory_pattern=False, root_path='/Users/me')
-        # Without root_path those will be treated as absolute paths even when starting with multiple slashes.
-        self._verify_patterns(['//foo'], ['//foo/**'], is_directory_pattern=True)
-        self._verify_patterns(['//*.pyo'], ['//*.pyo'], is_directory_pattern=False)
-
-    def _verify_patterns(
-        self,
-        patterns: list[str],
-        expected: list[str],
-        is_directory_pattern: bool,
-        root_path: str | None = None
-    ) -> None:
-        glob_patterns = [
-            sublime_pattern_to_glob(pattern, is_directory_pattern=is_directory_pattern, root_path=root_path)
-            for pattern in patterns
-        ]
-        self.assertEqual(glob_patterns, expected)

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from LSP.plugin.core.types import sublime_pattern_to_glob
+import sys
 import unittest
 
 
@@ -42,5 +43,38 @@ class PatternToGlobTests(unittest.TestCase):
         self.assertEqual(
             sublime_pattern_to_glob('//*.pyo', is_directory_pattern=False, root_path='/Users/me'), '/Users/me/**/*.pyo')
         # Without root_path those will be treated as absolute paths even when starting with multiple slashes.
+        self.assertEqual(sublime_pattern_to_glob('//foo', is_directory_pattern=True), '//foo/**')
+        self.assertEqual(sublime_pattern_to_glob('//*.pyo', is_directory_pattern=False), '//**/*.pyo')
+
+
+@unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
+class PatternToGlobWindowsTests(unittest.TestCase):
+
+    def test_project_relative_directory_pattern_forward_slash_root(self) -> None:
+        self.assertEqual(
+            sublime_pattern_to_glob('//foo', is_directory_pattern=True, root_path='C:/project'),
+            'C:/project/foo/**')
+
+    def test_project_relative_file_pattern_forward_slash_root(self) -> None:
+        self.assertEqual(
+            sublime_pattern_to_glob('//*.pyo', is_directory_pattern=False, root_path='C:/project'),
+            'C:/project/**/*.pyo')
+
+    def test_project_relative_nested_pattern_forward_slash_root(self) -> None:
+        self.assertEqual(
+            sublime_pattern_to_glob('//foo/bar', is_directory_pattern=True, root_path='C:/project'),
+            'C:/project/foo/bar/**')
+
+    def test_project_relative_directory_pattern_backslash_root(self) -> None:
+        self.assertEqual(
+            sublime_pattern_to_glob('//foo', is_directory_pattern=True, root_path=r'C:\project'),
+            'C:/project/foo/**')
+
+    def test_project_relative_file_pattern_backslash_root(self) -> None:
+        self.assertEqual(
+            sublime_pattern_to_glob('//*.pyo', is_directory_pattern=False, root_path=r'C:\project'),
+            'C:/project/**/*.pyo')
+
+    def test_project_relative_without_root_path(self) -> None:
         self.assertEqual(sublime_pattern_to_glob('//foo', is_directory_pattern=True), '//foo/**')
         self.assertEqual(sublime_pattern_to_glob('//*.pyo', is_directory_pattern=False), '//**/*.pyo')

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from LSP.plugin.core.types import sublime_pattern_to_glob
+import unittest
+
+
+class PatternToGlobTests(unittest.TestCase):
+
+    def test_basic_directory_patterns(self) -> None:
+        self.assertEqual(sublime_pattern_to_glob('.git', is_directory_pattern=True), '**/.git/**')
+        self.assertEqual(sublime_pattern_to_glob('CVS', is_directory_pattern=True), '**/CVS/**')
+        self.assertEqual(sublime_pattern_to_glob('.Trash-*', is_directory_pattern=True), '**/.Trash-*/**')
+
+    def test_complex_directory_patterns(self) -> None:
+        self.assertEqual(sublime_pattern_to_glob('*/foo', is_directory_pattern=True), '**/foo/**')
+        self.assertEqual(sublime_pattern_to_glob('foo/bar', is_directory_pattern=True), '**/foo/bar/**')
+        self.assertEqual(sublime_pattern_to_glob('foo/bar/', is_directory_pattern=True), '**/foo/bar/**')
+        self.assertEqual(sublime_pattern_to_glob('/foo', is_directory_pattern=True), '/foo/**')
+
+    def test_basic_file_patterns(self) -> None:
+        self.assertEqual(sublime_pattern_to_glob('*.pyc', is_directory_pattern=False), '**/*.pyc')
+        self.assertEqual(sublime_pattern_to_glob('.DS_Store', is_directory_pattern=False), '**/.DS_Store')
+
+    def test_complex_file_patterns(self) -> None:
+        self.assertEqual(sublime_pattern_to_glob('*/foo.py', is_directory_pattern=False), '**/foo.py')
+        self.assertEqual(sublime_pattern_to_glob('/*.pyo', is_directory_pattern=False), '/**/*.pyo')
+
+    def test_slash_star_or_star_slash_matches_any_directory(self) -> None:
+        self.assertEqual(sublime_pattern_to_glob('foo/*', is_directory_pattern=True), '**/foo/**')
+        self.assertEqual(sublime_pattern_to_glob('foo/*/', is_directory_pattern=True), '**/foo/**')
+        self.assertEqual(sublime_pattern_to_glob('foo/*.py', is_directory_pattern=False), '**/foo/**/*.py')
+
+    def test_question_mark_not_matches_slash_in_basic_pattern(self) -> None:
+        self.assertEqual(sublime_pattern_to_glob('foo?bar', is_directory_pattern=True), '**/foo?bar/**')
+
+    def test_question_mark_matches_slash_in_complex_pattern(self) -> None:
+        self.assertEqual(sublime_pattern_to_glob('/foo?bar', is_directory_pattern=True), '/foo{?,/}bar/**')
+
+    def test_project_relative_patterns(self) -> None:
+        self.assertEqual(
+            sublime_pattern_to_glob('//foo', is_directory_pattern=True, root_path='/Users/me'), '/Users/me/foo/**')
+        self.assertEqual(
+            sublime_pattern_to_glob('//*.pyo', is_directory_pattern=False, root_path='/Users/me'), '/Users/me/**/*.pyo')
+        # Without root_path those will be treated as absolute paths even when starting with multiple slashes.
+        self.assertEqual(sublime_pattern_to_glob('//foo', is_directory_pattern=True), '//foo/**')
+        self.assertEqual(sublime_pattern_to_glob('//*.pyo', is_directory_pattern=False), '//**/*.pyo')


### PR DESCRIPTION
Align `sublime_pattern_to_glob` to match the behavior of ST implementation. In https://github.com/sublimehq/sublime_text/issues/6906 I've raised some inconsistencies in ST documentation so I'm aligning with those findings. I'm assuming that the documentation will be clarified rather than implementation updated.

Resolves #2112