### PR TITLE
fix lsp_check_applicable starting extra server instance

### DIFF
--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from .logging import debug
-from .url import parse_uri
 from .views import first_selection_region
 from .views import get_uri_and_position_from_location
 from .views import MissingUriError
@@ -252,26 +250,7 @@ class LspCheckApplicableCommand(sublime_plugin.TextCommand):
 
     def _run_async(self, session_name: str) -> None:
         if wm := windows.lookup(self.view.window()):
-            config = wm.get_config_manager().get_config(session_name)
-            if not config:
-                debug(f'Configuration with name {session_name} does not exist')
-                return
-            if not config.enabled:
-                return
-            listener = windows.listener_for_view(self.view)
-            if not listener:
-                debug(f'No listener for view {self.view}')
-                return
-            scheme, _ = parse_uri(uri_from_view(self.view))
-            is_applicable = config.match_view(self.view, scheme, wm.window, wm.workspace_folders)
-            if session := wm.get_session(session_name, self.view.file_name() or ''):
-                session_view = session.session_view_for_view_async(self.view)
-                if is_applicable and not session_view:
-                    listener.on_session_initialized_async(session)
-                elif not is_applicable and session_view:
-                    session.shutdown_session_view_async(session_view)
-            elif is_applicable:
-                wm.register_listener_async(listener)
+            wm.recheck_is_applicable_async(self.view)
 
 
 def navigate_diagnostics(view: sublime.View, point: int | None, forward: bool = True) -> None:

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -271,11 +271,7 @@ class LspCheckApplicableCommand(sublime_plugin.TextCommand):
                 elif not is_applicable and session_view:
                     session.shutdown_session_view_async(session_view)
             elif is_applicable:
-                wm.start_async(config, self.view)
-                if wm._new_session:
-                    wm._sessions.add(wm._new_session)
-                    listener.on_session_initialized_async(wm._new_session)
-                    wm._new_session = None
+                wm.register_listener_async(listener)
 
 
 def navigate_diagnostics(view: sublime.View, point: int | None, forward: bool = True) -> None:

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -250,7 +250,7 @@ class LspCheckApplicableCommand(sublime_plugin.TextCommand):
 
     def _run_async(self, session_name: str) -> None:
         if wm := windows.lookup(self.view.window()):
-            wm.recheck_is_applicable_async(self.view)
+            wm.recheck_is_applicable_async(self.view, session_name)
 
 
 def navigate_diagnostics(view: sublime.View, point: int | None, forward: bool = True) -> None:

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -178,7 +178,7 @@ class WindowManager(Manager, WindowConfigChangeListener, ViewStatusHandler):
         else:
             try:
                 listener = self._pending_listeners.pop()
-                if not listener.view.is_valid():
+                if not listener.view.is_valid() or listener in self._listeners:
                     # debug("listener", listener, "is no longer valid")
                     self._dequeue_listener_async()
                     return

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -169,7 +169,7 @@ class WindowManager(Manager, WindowConfigChangeListener, ViewStatusHandler):
                 return listener
         return None
 
-    def recheck_is_applicable_async(self, view: sublime.View) -> None:
+    def recheck_is_applicable_async(self, view: sublime.View, config_name: str) -> None:
         if not (listener := self.listener_for_view(view)):
             debug(f'No listener for view {view}')
             return
@@ -177,9 +177,7 @@ class WindowManager(Manager, WindowConfigChangeListener, ViewStatusHandler):
             debug(f'Already starting relevant sessions for view {view}.')
             return
         scheme = parse_uri(listener.get_uri())[0]
-        for config in self._config_manager.get_configs():
-            if not config.enabled:
-                continue
+        if (config := self._config_manager.get_config(config_name)) and config.enabled:
             is_applicable = config.match_view(view, scheme, self.window, self.workspace_folders)
             if session := self.get_session(config.name, view.file_name()):
                 session_view = session.session_view_for_view_async(view)

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -169,6 +169,31 @@ class WindowManager(Manager, WindowConfigChangeListener, ViewStatusHandler):
                 return listener
         return None
 
+    def recheck_is_applicable_async(self, view: sublime.View) -> None:
+        if not (listener := self.listener_for_view(view)):
+            debug(f'No listener for view {view}')
+            return
+        if listener == self._new_listener:
+            debug(f'Already starting relevant sessions for view {view}.')
+            return
+        scheme = parse_uri(listener.get_uri())[0]
+        for config in self._config_manager.get_configs():
+            if not config.enabled:
+                continue
+            is_applicable = config.match_view(view, scheme, self.window, self.workspace_folders)
+            if session := self.get_session(config.name, view.file_name()):
+                session_view = session.session_view_for_view_async(view)
+                if is_applicable and not session_view:
+                    listener.on_session_initialized_async(session)
+                elif not is_applicable and session_view:
+                    session.shutdown_session_view_async(session_view)
+            elif is_applicable:
+                self.start_async(config, view)
+                if self._new_session:
+                    self._sessions.add(self._new_session)
+                    listener.on_session_initialized_async(self._new_session)
+                    self._new_session = None
+
     def _dequeue_listener_async(self) -> None:
         listener: AbstractViewListener | None = None
         if self._new_listener is not None:

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -203,7 +203,7 @@ class WindowManager(Manager, WindowConfigChangeListener, ViewStatusHandler):
         else:
             try:
                 listener = self._pending_listeners.pop()
-                if not listener.view.is_valid() or listener in self._listeners:
+                if not listener.view.is_valid():
                     # debug("listener", listener, "is no longer valid")
                     self._dequeue_listener_async()
                     return


### PR DESCRIPTION
Fix issue noticed in https://github.com/sublimelsp/LSP-copilot/issues/279

The `LspCheckApplicableCommand` was triggering `wm.start_async` while there was session being started already, causing it to be started twice. It requires certain timing that for me only seemed to trigger on linux.

Use the existing session-starting machinery instead of short-cutting some of its internal logic that historically caused us issues.