### PR TITLE
Return correct result for workspace/applyEdit request

### DIFF
--- a/plugin/core/edit.py
+++ b/plugin/core/edit.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 from ...protocol import AnnotatedTextEdit
+from ...protocol import CreateFile
+from ...protocol import DeleteFile
 from ...protocol import Position
+from ...protocol import RenameFile
 from ...protocol import SnippetTextEdit
+from ...protocol import TextDocumentEdit
 from ...protocol import TextEdit
 from ...protocol import WorkspaceEdit
 from .logging import debug
@@ -30,7 +34,24 @@ class WorkspaceEditSummary(TypedDict):
     deleted_files: NotRequired[int]
 
 
-# TODO: change return type to TypeIs[SnippetTextEdit] when properly supported by Pyright
+def is_text_document_edit(
+    document_change: TextDocumentEdit | CreateFile | RenameFile | DeleteFile
+) -> TypeGuard[TextDocumentEdit]:
+    return 'edits' in document_change
+
+
+def is_create_file(document_change: TextDocumentEdit | CreateFile | RenameFile | DeleteFile) -> TypeGuard[CreateFile]:
+    return document_change.get('kind') == 'create'
+
+
+def is_rename_file(document_change: TextDocumentEdit | CreateFile | RenameFile | DeleteFile) -> TypeGuard[RenameFile]:
+    return document_change.get('kind') == 'rename'
+
+
+def is_delete_file(document_change: TextDocumentEdit | CreateFile | RenameFile | DeleteFile) -> TypeGuard[DeleteFile]:
+    return document_change.get('kind') == 'rename'
+
+
 def is_snippet_text_edit(edit: TextEdit | AnnotatedTextEdit | SnippetTextEdit) -> TypeGuard[SnippetTextEdit]:
     return 'snippet' in edit
 
@@ -92,11 +113,8 @@ def apply_text_edits(
                 'required_view_version': required_view_version,
             }
         )
-    else:
-        view.run_command(
-            'lsp_apply_text_document_edit',
-            {'edits': edits, 'version': required_view_version, 'label': label}
-        )
+    elif required_view_version is None or required_view_version == view.change_count():
+        view.run_command('lsp_apply_text_document_edit', {'edits': edits, 'label': label})
     # Resolving from the next message loop iteration guarantees that the edits have already been applied in the main
     # thread, and that we've received view changes in the asynchronous thread.
     return Promise(lambda resolve: sublime.set_timeout_async(lambda: resolve(view if view.is_valid() else None)))

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from ...protocol import AnnotatedTextEdit
 from ...protocol import ApplyWorkspaceEditParams
 from ...protocol import ApplyWorkspaceEditResult
+from ...protocol import ChangeAnnotation
+from ...protocol import ChangeAnnotationIdentifier
 from ...protocol import ClientCapabilities
 from ...protocol import CodeAction
 from ...protocol import CodeActionKind
@@ -11,6 +13,8 @@ from ...protocol import Command
 from ...protocol import CompletionItemKind
 from ...protocol import CompletionItemTag
 from ...protocol import ConfigurationParams
+from ...protocol import CreateFile
+from ...protocol import DeleteFile
 from ...protocol import Diagnostic
 from ...protocol import DiagnosticOptions
 from ...protocol import DiagnosticServerCancellationData
@@ -48,6 +52,7 @@ from ...protocol import ProgressToken
 from ...protocol import PublishDiagnosticsParams
 from ...protocol import Range
 from ...protocol import RegistrationParams
+from ...protocol import RenameFile
 from ...protocol import SemanticTokenModifiers
 from ...protocol import SemanticTokenTypes
 from ...protocol import ShowDocumentParams
@@ -59,6 +64,7 @@ from ...protocol import SnippetTextEdit
 from ...protocol import SymbolKind
 from ...protocol import SymbolTag
 from ...protocol import TextDocumentClientCapabilities
+from ...protocol import TextDocumentEdit
 from ...protocol import TextDocumentSyncKind
 from ...protocol import TextEdit
 from ...protocol import TokenFormat
@@ -92,6 +98,10 @@ from .constants import RequestFlags
 from .constants import SEMANTIC_TOKENS_MAP
 from .constants import SUPPORTED_DIAGNOSTIC_TAGS
 from .edit import apply_text_edits
+from .edit import is_create_file
+from .edit import is_delete_file
+from .edit import is_rename_file
+from .edit import is_text_document_edit
 from .edit import parse_workspace_edit
 from .edit import WorkspaceChanges
 from .edit import WorkspaceEditSummary
@@ -1635,6 +1645,109 @@ class Session(APIHandler, TransportCallbacks):
                 .then(lambda _: None)
         return promise
 
+    def apply_document_changes_async(
+        self,
+        document_changes: list[TextDocumentEdit | CreateFile | RenameFile | DeleteFile],
+        change_annotations: dict[ChangeAnnotationIdentifier, ChangeAnnotation],
+        *,
+        label: str | None = None,
+        is_refactoring: bool = False
+    ) -> Promise[ApplyWorkspaceEditResult]:
+        active_sheet = self.window.active_sheet()
+        selected_sheets = self.window.selected_sheets()
+        auto_save = userprefs().refactoring_auto_save if is_refactoring else 'never'
+        index = 0  # Assuming 0-based indexing for the ApplyWorkspaceEditResult.faildedChange value
+        promise = self._apply_document_changes_recursive_async(
+            document_changes, change_annotations, index, label, auto_save)
+        promise \
+            .then(lambda _: self._set_selected_sheets(selected_sheets)) \
+            .then(lambda _: self._set_focused_sheet(active_sheet))
+        return promise
+
+    def _apply_document_changes_recursive_async(
+        self,
+        document_changes: list[TextDocumentEdit | CreateFile | RenameFile | DeleteFile],
+        change_annotations: dict[ChangeAnnotationIdentifier, ChangeAnnotation],
+        index: int,
+        label: str | None,
+        auto_save: str
+    ) -> Promise[ApplyWorkspaceEditResult]:
+
+        def apply_text_document_edit(
+            view: sublime.View | None,
+            uri: DocumentUri,
+            edits: list[TextEdit | AnnotatedTextEdit | SnippetTextEdit],
+            version: int | None,
+            view_state_actions: ViewStateActions
+        ) -> Promise[str | None]:
+            if not view:
+                return Promise.resolve(f'Failed to open URI {uri}')
+            if version is not None and version != (change_count := view.change_count()):
+                return Promise.resolve(f'Document version for URI {uri} is {change_count}, but required {version}')
+            for edit in edits:
+                # Use more specific label for this particular TextDocumentEdit if available
+                if annotation_id := edit.get('annotationId'):
+                    edit_label = change_annotations[annotation_id]['label']
+                    break
+            else:
+                edit_label = label
+            view.run_command('lsp_apply_text_document_edit', {'edits': edits, 'label': edit_label})
+            promise = Promise(lambda resolve: sublime.set_timeout_async(lambda: resolve(None)))
+            if view and view_state_actions:
+                return promise.then(lambda _: self._set_view_state(view_state_actions, view))  # pyright: ignore[reportReturnType]
+            return promise
+
+        def _continue(failure_reason: str | None) -> Promise[ApplyWorkspaceEditResult]:
+            if failure_reason:
+                return Promise.resolve({
+                    'applied': False,
+                    'failureReason': failure_reason,
+                    'failedChange': index
+                })
+            return self._apply_document_changes_recursive_async(
+                document_changes, change_annotations, index + 1, label, auto_save)
+
+        try:
+            document_change = document_changes.pop(0)
+        except IndexError:
+            # All document changes were handled
+            return Promise.resolve({'applied': True})
+        if is_text_document_edit(document_change):
+            text_document = document_change['textDocument']
+            uri = text_document['uri']
+            version = text_document['version']
+            view_state_actions = self._get_view_state_actions(uri, auto_save)
+            return self.open_uri_async(uri).then(
+                lambda view: apply_text_document_edit(view, uri, document_change['edits'], version, view_state_actions)
+            ).then(_continue)
+        if is_create_file(document_change):
+            # TODO: add support for ResourceOperationKind.Create
+            return Promise.resolve({
+                'applied': False,
+                'failureReason': 'CreateFile not yet supported by client',
+                'failedChange': index
+            })
+        if is_rename_file(document_change):
+            # TODO: add support for ResourceOperationKind.Rename
+            return Promise.resolve({
+                'applied': False,
+                'failureReason': 'RenameFile not yet supported by client',
+                'failedChange': index
+            })
+        if is_delete_file(document_change):
+            # TODO: add support for ResourceOperationKind.Delete
+            return Promise.resolve({
+                'applied': False,
+                'failureReason': 'DeleteFile not yet supported by client',
+                'failedChange': index
+            })
+        # Should be unreachable, but must return value on all code paths to satisfy type checker
+        return Promise.resolve({
+            'applied': False,
+            'failureReason': 'Unknown document change type',
+            'failedChange': index
+        })
+
     def apply_workspace_edit_async(
         self, edit: WorkspaceEdit, *, label: str | None = None, is_refactoring: bool = False
     ) -> Promise[WorkspaceEditSummary]:
@@ -1877,10 +1990,15 @@ class Session(APIHandler, TransportCallbacks):
 
     @request_handler('workspace/applyEdit')
     def on_workspace_apply_edit(self, params: ApplyWorkspaceEditParams) -> Promise[ApplyWorkspaceEditResult]:
-        is_refactoring = params.get('metadata', {}).get('isRefactoring', False)
-        return self.apply_workspace_edit_async(
-            params['edit'], label=params.get('label'), is_refactoring=is_refactoring
-        ).then(lambda _: {'applied': True})
+        edit = params['edit']
+        label = params.get('label')
+        is_refactoring = metadata.get('isRefactoring', False) if (metadata := params.get('metadata')) else False
+        if document_changes := edit.get('documentChanges'):
+            change_annotations = edit.get('changeAnnotations', {})
+            return self.apply_document_changes_async(
+                document_changes, change_annotations, label=label, is_refactoring=is_refactoring)
+        return self.apply_workspace_edit_async(edit, label=label, is_refactoring=is_refactoring).then(
+            lambda _: {'applied': True})
 
     @request_handler('workspace/codeLens/refresh')
     def on_workspace_code_lens_refresh(self, _: None) -> Promise[None]:

--- a/plugin/edit.py
+++ b/plugin/edit.py
@@ -109,13 +109,9 @@ class LspApplyTextDocumentEditCommand(sublime_plugin.TextCommand):
         self,
         edit: sublime.Edit,
         edits: list[TextEdit | AnnotatedTextEdit | SnippetTextEdit],
-        version: int | None = None,
         label: str | None = None
     ) -> None:
         if not edits:
-            return
-        if version is not None and version != self.view.change_count():
-            debug('ignoring edit due to non-matching document version')
             return
         if listener := windows.listener_for_view(self.view):
             listener.set_change_event_action(ChangeEventAction.OTHER)

--- a/tests/test_server_requests.py
+++ b/tests/test_server_requests.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING
 import os
 import sublime
 import tempfile
-import unittest
 
 if TYPE_CHECKING:
     from LSP.plugin.core.sessions import SessionBufferProtocol
@@ -118,7 +117,6 @@ class ServerRequests(TextDocumentTestCase):
                 self.assertEqual(view.substr(sublime.Region(0, view.size())), expected[i])
                 view.close()
 
-    @unittest.skip("TODO: fix to not automatically create a new view for nonexistent file URI")
     def test_m_workspace_applyEdit_with_wrong_uri(self) -> Generator:
         uri = "file:///C:/wrong/uri.txt"
         yield from verify(

--- a/tests/test_server_requests.py
+++ b/tests/test_server_requests.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 import os
 import sublime
 import tempfile
+import unittest
 
 if TYPE_CHECKING:
     from LSP.plugin.core.sessions import SessionBufferProtocol
@@ -116,6 +117,91 @@ class ServerRequests(TextDocumentTestCase):
                 self.assertFalse(view.is_loading())
                 self.assertEqual(view.substr(sublime.Region(0, view.size())), expected[i])
                 view.close()
+
+    @unittest.skip("TODO: fix to not automatically create a new view for nonexistent file URI")
+    def test_m_workspace_applyEdit_with_wrong_uri(self) -> Generator:
+        uri = "file:///C:/wrong/uri.txt"
+        yield from verify(
+            self,
+            "workspace/applyEdit",
+            {
+                "edit": {
+                    "documentChanges": [
+                        {
+                            "textDocument": {
+                                "uri": uri,
+                                "version": None
+                            },
+                            "edits": [
+                                {
+                                    "range": {
+                                        "start": {"line": 0, "character": 0},
+                                        "end": {"line": 0, "character": 1}
+                                    },
+                                    "newText": "hello"
+                                },
+                                {
+                                    "range": {
+                                        "start": {"line": 0, "character": 2},
+                                        "end": {"line": 0, "character": 3}
+                                    },
+                                    "newText": "there"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "applied": False,
+                "failureReason": f"Failed to open URI {uri}",
+                "failedChange": 0
+            }
+        )
+
+    def test_m_workspace_applyEdit_with_wrong_document_version(self) -> Generator:
+        with tempfile.TemporaryDirectory() as dirpath:
+            file_name = os.path.join(dirpath, "file3.txt")
+            uri = filename_to_uri(file_name)
+            version = 123
+            Path(file_name).write_text("a b", encoding="utf-8")
+            yield from verify(
+                self,
+                "workspace/applyEdit",
+                {
+                    "edit": {
+                        "documentChanges": [
+                            {
+                                "textDocument": {
+                                    "uri": uri,
+                                    "version": version
+                                },
+                                "edits": [
+                                    {
+                                        "range": {
+                                            "start": {"line": 0, "character": 0},
+                                            "end": {"line": 0, "character": 1}
+                                        },
+                                        "newText": "hello"
+                                    },
+                                    {
+                                        "range": {
+                                            "start": {"line": 0, "character": 2},
+                                            "end": {"line": 0, "character": 3}
+                                        },
+                                        "newText": "there"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                {
+                    "applied": False,
+                    "failureReason": f"Document version for URI {uri} is 0, but required {version}",
+                    "failedChange": 0
+                }
+            )
 
     def test_m_client_registerCapability(self) -> Generator:
         yield from verify(


### PR DESCRIPTION
When handling a `workspace/applyEdit` request from the server, the client must return a [ApplyWorkspaceEditResult](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#applyWorkspaceEditResult).

Currently, we unconditionally return `"applied": true`, even when the WorkspaceEdit cannot be applied correctly (e.g. due to failed to open view for URI, or view version doesn't match a given version in the WorkspaceEdit):
https://github.com/sublimelsp/LSP/blob/ced62c991cd4bc28cd633b26414eae1f3cd6ca43/plugin/core/sessions.py#L1883

Apart from that, we declare
https://github.com/sublimelsp/LSP/blob/ced62c991cd4bc28cd633b26414eae1f3cd6ca43/plugin/core/sessions.py#L540
for handling WorkspaceEdits, which means that (https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#failureHandlingKind)
```ts
	/**
	 * Applying the workspace change is simply aborted if one of the changes
	 * provided fails. All operations executed before the failing operation
	 * stay executed.
	 */
	export const Abort: FailureHandlingKind = 'abort';
```

But in reality, we simply continue with further changes even if one of the change failed:
https://github.com/sublimelsp/LSP/blob/ced62c991cd4bc28cd633b26414eae1f3cd6ca43/plugin/core/sessions.py#L1674-L1680

So the actual behavior isn't what we declared in the client capabilities as our failure handling strategy. Also I think this async implementation (via `Promise.all`) cannot work if support for resource operations (`create` / `rename`) should be implemented later at some point (#2706), because we cannot run a TextDocumentEdit before a file for the corresponding URI has been created or renamed. This means that if the [WorkspaceEdit](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspaceEdit) contains `documentChanges`, we have to apply them sequentially.

This PR should fix that, but only for WorkspaceEdits from the `workspace/applyEdit` request. Other WorkspaceEdits, for example from code actions or from a `textDocument/rename` request still use the previous (current) implementation. For those it would require some more refactorings, because they currently return a custom WorkspaceEditSummary which is used to display the number of changes and affected files in the UI (in case of rename).

---

Also this PR still ignores the `needsConfirmation` flag from the [ChangeAnnotation](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#changeAnnotation) of [AnnotatedTextEdit](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#annotatedTextEdit):
```ts
	/**
	 * A flag which indicates that user confirmation is needed
	 * before applying the change.
	 */
	needsConfirmation?: boolean;
```
If we want to support that, for example with a [`sublime.ok_cancel_dialog`](https://www.sublimetext.com/docs/api_reference.html#sublime.ok_cancel_dialog), then probably more considerations will be required to make the code wait for the user choice.