### PR TITLE
Fix new view on open file URI with path not existing on disk

### DIFF
--- a/plugin/core/open.py
+++ b/plugin/core/open.py
@@ -101,6 +101,11 @@ def open_file(
         return Promise.resolve(view)
 
     was_already_open = view is not None
+    if not was_already_open and not os.path.isfile(file):
+        # window.open_file creates a new view with empty content if the path from the given URI doesn't exist as a file
+        # on disk, but we don't want that here. If the language server wants to create a new file for a given URI, it
+        # must use the CreateFile resource operation in a WorkspaceEdit.
+        return Promise.resolve(None)
     view = window.open_file(file, flags, group)
     if not view.is_loading():
         if was_already_open and (flags & sublime.NewFileFlags.SEMI_TRANSIENT):


### PR DESCRIPTION
When opening a file URI for a document change in a WorkspaceEdit or from a link in the hover popup, but the file path doesn't exist as an actual file on disk, we should not silently open a new empty view.

If the server wants to create a new file in a WorkspaceEdit, it needs to use the CreateFile resource operation: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#resourceChanges
