### PR TITLE
Add support for resource operations in WorkspaceEdit

### DIFF
--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -366,8 +366,16 @@ class Notification(Generic[P]):
         return Notification("textDocument/didClose", params)
 
     @classmethod
+    def didCreateFiles(cls, params: CreateFilesParams) -> Notification[CreateFilesParams]:
+        return Notification("workspace/didCreateFiles", params)
+
+    @classmethod
     def didRenameFiles(cls, params: RenameFilesParams) -> Notification[RenameFilesParams]:
         return Notification("workspace/didRenameFiles", params)
+
+    @classmethod
+    def didDeleteFiles(cls, params: DeleteFilesParams) -> Notification[DeleteFilesParams]:
+        return Notification("workspace/didDeleteFiles", params)
 
     @classmethod
     def didChangeConfiguration(cls, params: DidChangeConfigurationParams) -> Notification[DidChangeConfigurationParams]:

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -76,7 +76,7 @@ class LspWindowCommand(sublime_plugin.WindowCommand):
         return self.session() is not None
 
     def session(self) -> Session | None:
-        wm = windows.lookup(self.window)
+        wm = self.manager()
         if not wm:
             return None
         for session in wm.get_sessions():
@@ -88,7 +88,7 @@ class LspWindowCommand(sublime_plugin.WindowCommand):
         return None
 
     def sessions(self) -> Generator[Session]:
-        wm = windows.lookup(self.window)
+        wm = self.manager()
         if not wm:
             return
         for session in wm.get_sessions():
@@ -99,7 +99,7 @@ class LspWindowCommand(sublime_plugin.WindowCommand):
             yield session
 
     def session_by_name(self, session_name: str) -> Session | None:
-        wm = windows.lookup(self.window)
+        wm = self.manager()
         if not wm:
             return None
         for session in wm.get_sessions():
@@ -108,6 +108,9 @@ class LspWindowCommand(sublime_plugin.WindowCommand):
             if session.config.name == session_name:
                 return session
         return None
+
+    def manager(self) -> WindowManager | None:
+        return windows.lookup(self.window)
 
 
 class LspTextCommand(sublime_plugin.TextCommand):

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -53,6 +53,7 @@ from ...protocol import PublishDiagnosticsParams
 from ...protocol import Range
 from ...protocol import RegistrationParams
 from ...protocol import RenameFile
+from ...protocol import ResourceOperationKind
 from ...protocol import SemanticTokenModifiers
 from ...protocol import SemanticTokenTypes
 from ...protocol import ShowDocumentParams
@@ -546,6 +547,11 @@ def get_initialize_params(
         "applyEdit": True,
         "workspaceEdit": {
             "documentChanges": True,
+            "resourceOperations": [
+                ResourceOperationKind.Create,
+                ResourceOperationKind.Rename,
+                ResourceOperationKind.Delete
+            ],
             "failureHandling": FailureHandlingKind.Abort,
             "normalizesLineEndings": True,
             "changeAnnotationSupport": {
@@ -1695,6 +1701,43 @@ class Session(APIHandler, TransportCallbacks):
                 return promise.then(lambda _: self._set_view_state(view_state_actions, view))  # pyright: ignore[reportReturnType]
             return promise
 
+        def create_file(path: str) -> Promise[str | None]:
+            # TODO: We cannot really distinguish whether the target path should be a file or a folder, because files
+            # don't necessarily have a file extension. Should we create a folder instead, if there is no file extension?
+            try:
+                open(path, 'x').close()
+            except FileExistsError as ex:
+                return Promise.resolve(str(ex))
+            except OSError as ex:
+                return Promise.resolve(str(ex))
+            return Promise.resolve(None)
+
+        def rename_file(old_path: str, new_path: str) -> Promise[str | None]:
+            view = self.window.find_open_file(old_path) if os.path.isfile(old_path) else None
+            try:
+                os.rename(old_path, new_path)
+            except FileExistsError as ex:
+                return Promise.resolve(str(ex))
+            except IsADirectoryError as ex:
+                return Promise.resolve(str(ex))
+            except NotADirectoryError as ex:
+                return Promise.resolve(str(ex))
+            except OSError as ex:
+                return Promise.resolve(str(ex))
+            if view:
+                view.retarget(new_path)
+            return Promise.resolve(None)
+
+        def delete_file(path: str) -> Promise[None]:
+            # The delete_file command moves the given files into the recycle bin
+            self.window.run_command('delete_file', {'files': [path], 'prompt': False})
+            return Promise(lambda resolve: sublime.set_timeout_async(lambda: resolve(None)))
+
+        def delete_folder(path: str) -> Promise[None]:
+            # The delete_folder command moves the given folders into the recycle bin
+            self.window.run_command('delete_folder', {'dirs': [path], 'prompt': False})
+            return Promise(lambda resolve: sublime.set_timeout_async(lambda: resolve(None)))
+
         def _continue(failure_reason: str | None) -> Promise[ApplyWorkspaceEditResult]:
             if failure_reason:
                 printf(f'Error while applying WorkspaceEdit: {failure_reason}')
@@ -1720,32 +1763,62 @@ class Session(APIHandler, TransportCallbacks):
                 lambda view: apply_text_document_edit(view, uri, document_change['edits'], version, view_state_actions)
             ).then(_continue)
         if is_create_file(document_change):
-            # TODO: add support for ResourceOperationKind.Create
-            return Promise.resolve({
-                'applied': False,
-                'failureReason': 'CreateFile not yet supported by client',
-                'failedChange': index
-            })
+            uri = document_change['uri']
+            options = document_change.get('options', {})
+            scheme, path = parse_uri(uri)
+            if scheme != 'file':
+                return _continue(f'CreateFile not supported for URI {uri}')
+            if os.path.isfile(path):
+                if options.get('overwrite'):
+                    return delete_file(path).then(lambda _: create_file(path)).then(_continue)
+                elif options.get('ignoreIfExists'):
+                    return _continue(None)
+                else:
+                    return _continue(f'CreateFile failed because a file already exists at target {uri}')
+            elif os.path.isdir(path):
+                # Don't allow to overwrite entire folders, even if the CreateFileOptions.overwrite flag is set
+                return _continue(f'CreateFile failed because a folder already exists at target {uri}')
+            return create_file(path).then(_continue)
         if is_rename_file(document_change):
-            # TODO: add support for ResourceOperationKind.Rename
-            return Promise.resolve({
-                'applied': False,
-                'failureReason': 'RenameFile not yet supported by client',
-                'failedChange': index
-            })
+            old_uri = document_change['oldUri']
+            new_uri = document_change['newUri']
+            options = document_change.get('options', {})
+            old_scheme, old_path = parse_uri(old_uri)
+            if old_scheme != 'file':
+                return _continue(f'RenameFile not supported for URI {old_uri}')
+            if not os.path.exists(old_path):
+                return _continue(f'RenameFile failed because {old_uri} does not exist')
+            new_scheme, new_path = parse_uri(new_uri)
+            if new_scheme != 'file':
+                return _continue(f'RenameFile not supported for URI {new_uri}')
+            if os.path.isfile(new_path):
+                if options.get('overwrite') and os.path.isfile(old_path):
+                    return delete_file(new_path).then(lambda _: rename_file(old_path, new_path)).then(_continue)
+                elif options.get('ignoreIfExists'):
+                    return _continue(None)
+                else:
+                    return _continue(f'RenameFile failed because target {new_uri} already exists')
+            elif os.path.isdir(new_path):
+                # Don't allow to overwrite entire folders, even if the CreateFileOptions.overwrite flag is set
+                return _continue(f'RenameFile failed because target {new_uri} already exists')
+            return rename_file(old_path, new_path).then(_continue)
         if is_delete_file(document_change):
-            # TODO: add support for ResourceOperationKind.Delete
-            return Promise.resolve({
-                'applied': False,
-                'failureReason': 'DeleteFile not yet supported by client',
-                'failedChange': index
-            })
+            uri = document_change['uri']
+            options = document_change.get('options', {})
+            scheme, path = parse_uri(uri)
+            if scheme != 'file':
+                return _continue(f'DeleteFile not supported for URI {uri}')
+            if os.path.isfile(path):
+                return delete_file(path).then(_continue)
+            if os.path.isdir(path):
+                if os.listdir() and not options.get('recursive'):
+                    return _continue(f'DeleteFile failed because folder {uri} is not empty')
+                return delete_folder(path).then(_continue)
+            if options.get('ignoreIfNotExists'):
+                return _continue(None)
+            return _continue(f'DeleteFile failed because {uri} does not exist')
         # Should be unreachable, but must return value on all code paths to satisfy type checker
-        return Promise.resolve({
-            'applied': False,
-            'failureReason': 'Unknown document change type',
-            'failedChange': index
-        })
+        return _continue('Unknown document change type')
 
     def apply_workspace_edit_async(
         self, edit: WorkspaceEdit, *, label: str | None = None, is_refactoring: bool = False

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -14,9 +14,7 @@ from ...protocol import CompletionItemKind
 from ...protocol import CompletionItemTag
 from ...protocol import ConfigurationParams
 from ...protocol import CreateFile
-from ...protocol import CreateFilesParams
 from ...protocol import DeleteFile
-from ...protocol import DeleteFilesParams
 from ...protocol import Diagnostic
 from ...protocol import DiagnosticOptions
 from ...protocol import DiagnosticServerCancellationData
@@ -58,7 +56,6 @@ from ...protocol import PublishDiagnosticsParams
 from ...protocol import Range
 from ...protocol import RegistrationParams
 from ...protocol import RenameFile
-from ...protocol import RenameFilesParams
 from ...protocol import ResourceOperationKind
 from ...protocol import SemanticTokenModifiers
 from ...protocol import SemanticTokenTypes
@@ -332,15 +329,15 @@ class Manager(ABC):
         ...
 
     @abstractmethod
-    def notify_did_create_files(self, params: CreateFilesParams) -> None:
+    def notify_did_create_files(self, created_files: list[FileCreate]) -> None:
         ...
 
     @abstractmethod
-    def notify_did_rename_files(self, params: RenameFilesParams) -> None:
+    def notify_did_rename_files(self, renamed_files: list[FileRename]) -> None:
         ...
 
     @abstractmethod
-    def notify_did_delete_files(self, params: DeleteFilesParams) -> None:
+    def notify_did_delete_files(self, deleted_files: list[FileDelete]) -> None:
         ...
 
 
@@ -1982,11 +1979,11 @@ class Session(APIHandler, TransportCallbacks):
     ) -> None:
         if mgr := self.manager():
             if created_files:
-                mgr.notify_did_create_files({'files': created_files})
+                mgr.notify_did_create_files(created_files)
             if renamed_files:
-                mgr.notify_did_rename_files({'files': renamed_files})
+                mgr.notify_did_rename_files(renamed_files)
             if deleted_files:
-                mgr.notify_did_delete_files({'files': deleted_files})
+                mgr.notify_did_delete_files(deleted_files)
 
     def decode_semantic_token(
         self,

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -14,7 +14,9 @@ from ...protocol import CompletionItemKind
 from ...protocol import CompletionItemTag
 from ...protocol import ConfigurationParams
 from ...protocol import CreateFile
+from ...protocol import CreateFilesParams
 from ...protocol import DeleteFile
+from ...protocol import DeleteFilesParams
 from ...protocol import Diagnostic
 from ...protocol import DiagnosticOptions
 from ...protocol import DiagnosticServerCancellationData
@@ -28,7 +30,10 @@ from ...protocol import DocumentUri
 from ...protocol import ErrorCodes
 from ...protocol import ExecuteCommandParams
 from ...protocol import FailureHandlingKind
+from ...protocol import FileCreate
+from ...protocol import FileDelete
 from ...protocol import FileEvent
+from ...protocol import FileRename
 from ...protocol import FileSystemWatcher
 from ...protocol import FoldingRangeKind
 from ...protocol import GeneralClientCapabilities
@@ -53,6 +58,7 @@ from ...protocol import PublishDiagnosticsParams
 from ...protocol import Range
 from ...protocol import RegistrationParams
 from ...protocol import RenameFile
+from ...protocol import RenameFilesParams
 from ...protocol import ResourceOperationKind
 from ...protocol import SemanticTokenModifiers
 from ...protocol import SemanticTokenTypes
@@ -323,6 +329,18 @@ class Manager(ABC):
 
     @abstractmethod
     def handle_stderr_log(self, config_name: str, message: str) -> None:
+        ...
+
+    @abstractmethod
+    def notify_did_create_files(self, params: CreateFilesParams) -> None:
+        ...
+
+    @abstractmethod
+    def notify_did_rename_files(self, params: RenameFilesParams) -> None:
+        ...
+
+    @abstractmethod
+    def notify_did_delete_files(self, params: DeleteFilesParams) -> None:
         ...
 
 
@@ -1690,21 +1708,28 @@ class Session(APIHandler, TransportCallbacks):
         label: str | None = None,
         is_refactoring: bool = False
     ) -> Promise[ApplyWorkspaceEditResult]:
+        created_files: list[FileCreate] = []
+        renamed_files: list[FileRename] = []
+        deleted_files: list[FileDelete] = []
         active_sheet = self.window.active_sheet()
         selected_sheets = self.window.selected_sheets()
         auto_save = userprefs().refactoring_auto_save if is_refactoring else 'never'
         index = 0  # Assuming 0-based indexing for the ApplyWorkspaceEditResult.faildedChange value
         promise = self._apply_document_changes_recursive_async(
-            document_changes, change_annotations, index, label, auto_save)
+            document_changes, change_annotations, created_files, renamed_files, deleted_files, index, label, auto_save)
         promise \
             .then(lambda _: self._set_selected_sheets(selected_sheets)) \
-            .then(lambda _: self._set_focused_sheet(active_sheet))
+            .then(lambda _: self._set_focused_sheet(active_sheet)) \
+            .then(lambda _: self._notify_after_resource_operations(created_files, renamed_files, deleted_files))
         return promise
 
     def _apply_document_changes_recursive_async(
         self,
         document_changes: list[TextDocumentEdit | CreateFile | RenameFile | DeleteFile],
         change_annotations: dict[ChangeAnnotationIdentifier, ChangeAnnotation],
+        created_files: list[FileCreate],
+        renamed_files: list[FileRename],
+        deleted_files: list[FileDelete],
         index: int,
         label: str | None,
         auto_save: str
@@ -1739,6 +1764,7 @@ class Session(APIHandler, TransportCallbacks):
                 Path(path).open('x', encoding='utf-8').close()
             except (FileExistsError, OSError) as ex:
                 return Promise.resolve(str(ex))
+            created_files.append({'uri': filename_to_uri(path)})
             return Promise.resolve(None)
 
         def rename_file(old_path: str, new_path: str) -> Promise[str | None]:
@@ -1747,9 +1773,12 @@ class Session(APIHandler, TransportCallbacks):
                 Path(old_path).rename(new_path)
             except (FileExistsError, IsADirectoryError, NotADirectoryError, OSError) as ex:
                 return Promise.resolve(str(ex))
+            old_uri = filename_to_uri(old_path)
+            new_uri = filename_to_uri(new_path)
             if view:
                 view.retarget(new_path)
-                view.settings().set('lsp_uri', filename_to_uri(new_path))
+                view.settings().set('lsp_uri', new_uri)
+            renamed_files.append({'oldUri': old_uri, 'newUri': new_uri})
             return Promise.resolve(None)
 
         def delete_file(path: str) -> Promise[None]:
@@ -1771,7 +1800,15 @@ class Session(APIHandler, TransportCallbacks):
                     'failedChange': index
                 })
             return self._apply_document_changes_recursive_async(
-                document_changes, change_annotations, index + 1, label, auto_save)
+                document_changes,
+                change_annotations,
+                created_files,
+                renamed_files,
+                deleted_files,
+                index + 1,
+                label,
+                auto_save
+            )
 
         try:
             document_change = document_changes.pop(0)
@@ -1831,10 +1868,12 @@ class Session(APIHandler, TransportCallbacks):
             if scheme != 'file':
                 return _continue(f'DeleteFile not supported for URI {uri}')
             if os.path.isfile(path):
+                deleted_files.append({'uri': uri})
                 return delete_file(path).then(_continue)
             if os.path.isdir(path):
                 if os.listdir() and not options.get('recursive'):
                     return _continue(f'DeleteFile failed because folder {uri} is not empty')
+                deleted_files.append({'uri': uri})
                 return delete_folder(path).then(_continue)
             if options.get('ignoreIfNotExists'):
                 return _continue(None)
@@ -1937,6 +1976,17 @@ class Session(APIHandler, TransportCallbacks):
     def _set_focused_sheet(self, sheet: sublime.Sheet | None) -> None:
         if sheet and sheet != self.window.active_sheet():
             self.window.focus_sheet(sheet)
+
+    def _notify_after_resource_operations(
+        self, created_files: list[FileCreate], renamed_files: list[FileRename], deleted_files: list[FileDelete]
+    ) -> None:
+        if mgr := self.manager():
+            if created_files:
+                mgr.notify_did_create_files({'files': created_files})
+            if renamed_files:
+                mgr.notify_did_rename_files({'files': renamed_files})
+            if deleted_files:
+                mgr.notify_did_delete_files({'files': deleted_files})
 
     def decode_semantic_token(
         self,

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1688,9 +1688,7 @@ class Session(APIHandler, TransportCallbacks):
         def create_file(path: str) -> Promise[str | None]:
             try:
                 Path(path).open('x', encoding='utf-8').close()
-            except FileExistsError as ex:
-                return Promise.resolve(str(ex))
-            except OSError as ex:
+            except (FileExistsError, OSError) as ex:
                 return Promise.resolve(str(ex))
             return Promise.resolve(None)
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1698,13 +1698,7 @@ class Session(APIHandler, TransportCallbacks):
             view = self.window.find_open_file(old_path) if os.path.isfile(old_path) else None
             try:
                 Path(old_path).rename(new_path)
-            except FileExistsError as ex:
-                return Promise.resolve(str(ex))
-            except IsADirectoryError as ex:
-                return Promise.resolve(str(ex))
-            except NotADirectoryError as ex:
-                return Promise.resolve(str(ex))
-            except OSError as ex:
+            except (FileExistsError, IsADirectoryError, NotADirectoryError, OSError) as ex:
                 return Promise.resolve(str(ex))
             if view:
                 view.retarget(new_path)

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1730,7 +1730,7 @@ class Session(APIHandler, TransportCallbacks):
         def delete_file(path: str) -> Promise[None]:
             # The delete_file command moves the given files into the recycle bin
             self.window.run_command('delete_file', {'files': [path], 'prompt': False})
-            return Promise(lambda resolve: sublime.set_timeout_async(lambda: resolve(None)))
+            return Promise(lambda resolve: sublime.set_timeout_async(lambda: resolve(None), 100))
 
         def delete_folder(path: str) -> Promise[None]:
             # The delete_folder command moves the given folders into the recycle bin

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -161,6 +161,7 @@ from enum import IntFlag
 from functools import lru_cache
 from functools import partial
 from operator import itemgetter
+from pathlib import Path
 from typing import Any
 from typing import Callable
 from typing import cast
@@ -1705,7 +1706,7 @@ class Session(APIHandler, TransportCallbacks):
             # TODO: We cannot really distinguish whether the target path should be a file or a folder, because files
             # don't necessarily have a file extension. Should we create a folder instead, if there is no file extension?
             try:
-                open(path, 'x').close()
+                Path(path).open('x', encoding='utf-8').close()
             except FileExistsError as ex:
                 return Promise.resolve(str(ex))
             except OSError as ex:
@@ -1715,7 +1716,7 @@ class Session(APIHandler, TransportCallbacks):
         def rename_file(old_path: str, new_path: str) -> Promise[str | None]:
             view = self.window.find_open_file(old_path) if os.path.isfile(old_path) else None
             try:
-                os.rename(old_path, new_path)
+                Path(old_path).rename(new_path)
             except FileExistsError as ex:
                 return Promise.resolve(str(ex))
             except IsADirectoryError as ex:
@@ -1771,11 +1772,10 @@ class Session(APIHandler, TransportCallbacks):
             if os.path.isfile(path):
                 if options.get('overwrite'):
                     return delete_file(path).then(lambda _: create_file(path)).then(_continue)
-                elif options.get('ignoreIfExists'):
+                if options.get('ignoreIfExists'):
                     return _continue(None)
-                else:
-                    return _continue(f'CreateFile failed because a file already exists at target {uri}')
-            elif os.path.isdir(path):
+                return _continue(f'CreateFile failed because a file already exists at target {uri}')
+            if os.path.isdir(path):
                 # Don't allow to overwrite entire folders, even if the CreateFileOptions.overwrite flag is set
                 return _continue(f'CreateFile failed because a folder already exists at target {uri}')
             return create_file(path).then(_continue)
@@ -1794,11 +1794,10 @@ class Session(APIHandler, TransportCallbacks):
             if os.path.isfile(new_path):
                 if options.get('overwrite') and os.path.isfile(old_path):
                     return delete_file(new_path).then(lambda _: rename_file(old_path, new_path)).then(_continue)
-                elif options.get('ignoreIfExists'):
+                if options.get('ignoreIfExists'):
                     return _continue(None)
-                else:
-                    return _continue(f'RenameFile failed because target {new_uri} already exists')
-            elif os.path.isdir(new_path):
+                return _continue(f'RenameFile failed because target {new_uri} already exists')
+            if os.path.isdir(new_path):
                 # Don't allow to overwrite entire folders, even if the CreateFileOptions.overwrite flag is set
                 return _continue(f'RenameFile failed because target {new_uri} already exists')
             return rename_file(old_path, new_path).then(_continue)

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1730,12 +1730,12 @@ class Session(APIHandler, TransportCallbacks):
         def delete_file(path: str) -> Promise[None]:
             # The delete_file command moves the given files into the recycle bin
             self.window.run_command('delete_file', {'files': [path], 'prompt': False})
-            return Promise(lambda resolve: sublime.set_timeout_async(lambda: resolve(None), 100))
+            return Promise(lambda resolve: sublime.set_timeout_async(lambda: resolve(None), 1))
 
         def delete_folder(path: str) -> Promise[None]:
             # The delete_folder command moves the given folders into the recycle bin
             self.window.run_command('delete_folder', {'dirs': [path], 'prompt': False})
-            return Promise(lambda resolve: sublime.set_timeout_async(lambda: resolve(None)))
+            return Promise(lambda resolve: sublime.set_timeout_async(lambda: resolve(None), 1))
 
         def _continue(failure_reason: str | None) -> Promise[ApplyWorkspaceEditResult]:
             if failure_reason:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1711,6 +1711,7 @@ class Session(APIHandler, TransportCallbacks):
                 return Promise.resolve(str(ex))
             if view:
                 view.retarget(new_path)
+                view.settings().set('lsp_uri', filename_to_uri(new_path))
             return Promise.resolve(None)
 
         def delete_file(path: str) -> Promise[None]:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1703,8 +1703,6 @@ class Session(APIHandler, TransportCallbacks):
             return promise
 
         def create_file(path: str) -> Promise[str | None]:
-            # TODO: We cannot really distinguish whether the target path should be a file or a folder, because files
-            # don't necessarily have a file extension. Should we create a folder instead, if there is no file extension?
             try:
                 Path(path).open('x', encoding='utf-8').close()
             except FileExistsError as ex:

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from ...protocol import CreateFilesParams
-from ...protocol import DeleteFilesParams
 from ...protocol import Diagnostic
 from ...protocol import DocumentUri
+from ...protocol import FileCreate
+from ...protocol import FileDelete
+from ...protocol import FileRename
 from ...protocol import LogMessageParams
 from ...protocol import MessageActionItem
 from ...protocol import MessageType
-from ...protocol import RenameFilesParams
 from ...protocol import ShowMessageParams
 from ...protocol import ShowMessageRequestParams
 from ...third_party import WebsocketServer  # type: ignore
@@ -559,29 +559,29 @@ class WindowManager(Manager, WindowConfigChangeListener, ViewStatusHandler):
             phantoms.append(sublime.Phantom(region, f"({make_link(href, code)})", sublime.PhantomLayout.INLINE))
         self._panel_code_phantoms.update(phantoms)
 
-    def notify_did_create_files(self, params: CreateFilesParams) -> None:
+    def notify_did_create_files(self, created_files: list[FileCreate]) -> None:
         for session in self.get_sessions():
             if filters := session.get_capability('workspace.fileOperations.didCreate.filters', []):
                 if files := [
-                    file_create for file_create in params['files']
+                    file_create for file_create in created_files
                     if match_file_operation_filters(filters, file_create['uri'])
                 ]:
                     session.send_notification(Notification.didCreateFiles({'files': files}))
 
-    def notify_did_rename_files(self, params: RenameFilesParams) -> None:
+    def notify_did_rename_files(self, renamed_files: list[FileRename]) -> None:
         for session in self.get_sessions():
             if filters := session.get_capability('workspace.fileOperations.didRename.filters', []):
                 if files := [
-                    file_rename for file_rename in params['files']
+                    file_rename for file_rename in renamed_files
                     if match_file_operation_filters(filters, file_rename['oldUri'])
                 ]:
                     session.send_notification(Notification.didRenameFiles({'files': files}))
 
-    def notify_did_delete_files(self, params: DeleteFilesParams) -> None:
+    def notify_did_delete_files(self, deleted_files: list[FileDelete]) -> None:
         for session in self.get_sessions():
             if filters := session.get_capability('workspace.fileOperations.didDelete.filters', []):
                 if files := [
-                    file_delete for file_delete in params['files']
+                    file_delete for file_delete in deleted_files
                     if match_file_operation_filters(filters, file_delete['uri'])
                 ]:
                     session.send_notification(Notification.didDeleteFiles({'files': files}))

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+from ...protocol import CreateFilesParams
+from ...protocol import DeleteFilesParams
 from ...protocol import Diagnostic
 from ...protocol import DocumentUri
 from ...protocol import LogMessageParams
 from ...protocol import MessageActionItem
 from ...protocol import MessageType
+from ...protocol import RenameFilesParams
 from ...protocol import ShowMessageParams
 from ...protocol import ShowMessageRequestParams
 from ...third_party import WebsocketServer  # type: ignore
@@ -29,6 +32,7 @@ from .panels import PanelManager
 from .panels import PanelName
 from .promise import Promise
 from .protocol import Error
+from .protocol import Notification
 from .protocol import Point
 from .sessions import AbstractViewListener
 from .sessions import Logger
@@ -38,6 +42,7 @@ from .settings import client_configs
 from .settings import LspSettingsChangeListener
 from .settings import userprefs
 from .types import ClientConfig
+from .types import match_file_operation_filters
 from .types import matches_pattern
 from .types import sublime_pattern_to_glob
 from .types import ViewStatusHandler
@@ -553,6 +558,33 @@ class WindowManager(Manager, WindowConfigChangeListener, ViewStatusHandler):
             region = sublime.Region(point, point)
             phantoms.append(sublime.Phantom(region, f"({make_link(href, code)})", sublime.PhantomLayout.INLINE))
         self._panel_code_phantoms.update(phantoms)
+
+    def notify_did_create_files(self, params: CreateFilesParams) -> None:
+        for session in self.get_sessions():
+            if filters := session.get_capability('workspace.fileOperations.didCreate.filters', []):
+                if files := [
+                    file_create for file_create in params['files']
+                    if match_file_operation_filters(filters, file_create['uri'])
+                ]:
+                    session.send_notification(Notification.didCreateFiles({'files': files}))
+
+    def notify_did_rename_files(self, params: RenameFilesParams) -> None:
+        for session in self.get_sessions():
+            if filters := session.get_capability('workspace.fileOperations.didRename.filters', []):
+                if files := [
+                    file_rename for file_rename in params['files']
+                    if match_file_operation_filters(filters, file_rename['oldUri'])
+                ]:
+                    session.send_notification(Notification.didRenameFiles({'files': files}))
+
+    def notify_did_delete_files(self, params: DeleteFilesParams) -> None:
+        for session in self.get_sessions():
+            if filters := session.get_capability('workspace.fileOperations.didDelete.filters', []):
+                if files := [
+                    file_delete for file_delete in params['files']
+                    if match_file_operation_filters(filters, file_delete['uri'])
+                ]:
+                    session.send_notification(Notification.didDeleteFiles({'files': files}))
 
     # --- Implements WindowConfigChangeListener ------------------------------------------------------------------------
 

--- a/plugin/rename_file.py
+++ b/plugin/rename_file.py
@@ -5,7 +5,6 @@ from .core.logging import debug
 from .core.open import open_file_uri
 from .core.promise import Promise
 from .core.protocol import Error
-from .core.protocol import Notification
 from .core.protocol import Request
 from .core.registry import LspWindowCommand
 from .core.types import match_file_operation_filters
@@ -111,8 +110,8 @@ class LspRenamePathCommand(LspWindowCommand):
         self.rename_path(old_path, new_name).then(lambda success: self.on_rename_path(success, file_rename))
 
     def on_rename_path(self, success: bool, file_rename: FileRename) -> None:
-        if success:
-            self.notify_did_rename(file_rename)
+        if success and (mgr := self.manager()):
+            mgr.notify_did_rename_files({'files': [file_rename]})
 
     def prompt_rename_async(self, file_rename: FileRename, label: str, rename_command_args: dict[str, Any]) -> None:
         Promise.all(list(self.create_will_rename_requests_async(file_rename))) \
@@ -181,12 +180,6 @@ class LspRenamePathCommand(LspWindowCommand):
             open_file_uri(self.window, file_name, group=group[0]).then(partial(self.restore_view, selection, group))
             for file_name, group, selection in reversed(restore_files)
         ]).then(lambda _: self.focus_view(last_active_view)).then(lambda _: True)
-
-    def notify_did_rename(self, file_rename: FileRename) -> None:
-        for session in self.sessions():
-            filters = session.get_capability('workspace.fileOperations.didRename.filters') or []
-            if filters and match_file_operation_filters(filters, file_rename['oldUri']):
-                session.send_notification(Notification.didRenameFiles({'files': [file_rename]}))
 
     def restore_view(self, selection: list[sublime.Region], group: tuple[int, int], view: sublime.View | None) -> None:
         if not view:

--- a/plugin/rename_file.py
+++ b/plugin/rename_file.py
@@ -111,7 +111,7 @@ class LspRenamePathCommand(LspWindowCommand):
 
     def on_rename_path(self, success: bool, file_rename: FileRename) -> None:
         if success and (mgr := self.manager()):
-            mgr.notify_did_rename_files({'files': [file_rename]})
+            mgr.notify_did_rename_files([file_rename])
 
     def prompt_rename_async(self, file_rename: FileRename, label: str, rename_command_args: dict[str, Any]) -> None:
         Promise.all(list(self.create_will_rename_requests_async(file_rename))) \

--- a/tests/test_server_requests.py
+++ b/tests/test_server_requests.py
@@ -5,13 +5,11 @@ from LSP.plugin.core.types import ClientConfig
 from LSP.plugin.core.url import filename_to_uri
 from LSP.protocol import ErrorCodes
 from LSP.protocol import TextDocumentSyncKind
-from pathlib import Path
 from typing import Any
 from typing import Generator
 from typing import TYPE_CHECKING
 import os
 import sublime
-import tempfile
 
 if TYPE_CHECKING:
     from LSP.plugin.core.sessions import SessionBufferProtocol
@@ -55,151 +53,6 @@ class ServerRequests(TextDocumentTestCase):
         expected_output = [{"bar": "X", "baz": "Y", "a": 1, "b": None, "c": ["asdf X Y"]}]
         yield from verify(self, method, params, expected_output)
         self.session.config.settings.clear()
-
-    def test_m_workspace_applyEdit(self) -> Generator:
-        old_change_count = self.insert_characters("hello\nworld\n")
-        edit = {
-            "newText": "there",
-            "range": {"start": {"line": 1, "character": 0}, "end": {"line": 1, "character": 5}}}
-        params = {"edit": {"changes": {filename_to_uri(self.view.file_name()): [edit]}}}
-        yield from verify(self, "workspace/applyEdit", params, {"applied": True})
-        yield lambda: self.view.change_count() > old_change_count
-        self.assertEqual(self.view.substr(sublime.Region(0, self.view.size())), "hello\nthere\n")
-
-    def test_m_workspace_applyEdit_with_nontrivial_promises(self) -> Generator:
-        with tempfile.TemporaryDirectory() as dirpath:
-            initial_text = ["a b", "c d"]
-            file_paths = []
-            for i in range(2):
-                file_paths.append(os.path.join(dirpath, f"file{i}.txt"))
-                Path(file_paths[-1]).write_text(initial_text[i], encoding="utf-8")
-            yield from verify(
-                self,
-                "workspace/applyEdit",
-                {
-                    "edit": {
-                        "changes": {
-                            filename_to_uri(file_paths[0]):
-                            [
-                                {
-                                    "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 1}},
-                                    "newText": "hello"
-                                },
-                                {
-                                    "range": {"start": {"line": 0, "character": 2}, "end": {"line": 0, "character": 3}},
-                                    "newText": "there"
-                                }
-                            ],
-                            filename_to_uri(file_paths[1]):
-                            [
-                                {
-                                    "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 1}},
-                                    "newText": "general"
-                                },
-                                {
-                                    "range": {"start": {"line": 0, "character": 2}, "end": {"line": 0, "character": 3}},
-                                    "newText": "kenobi"
-                                }
-                            ]
-                        }
-                    }
-                },
-                {"applied": True}
-            )
-            # Changes should have been applied
-            expected = ["hello there", "general kenobi"]
-            for i in range(2):
-                view = self.view.window().find_open_file(file_paths[i])
-                self.assertTrue(view)
-                view.set_scratch(True)
-                self.assertTrue(view.is_valid())
-                self.assertFalse(view.is_loading())
-                self.assertEqual(view.substr(sublime.Region(0, view.size())), expected[i])
-                view.close()
-
-    def test_m_workspace_applyEdit_with_wrong_uri(self) -> Generator:
-        uri = "file:///C:/wrong/uri.txt"
-        yield from verify(
-            self,
-            "workspace/applyEdit",
-            {
-                "edit": {
-                    "documentChanges": [
-                        {
-                            "textDocument": {
-                                "uri": uri,
-                                "version": None
-                            },
-                            "edits": [
-                                {
-                                    "range": {
-                                        "start": {"line": 0, "character": 0},
-                                        "end": {"line": 0, "character": 1}
-                                    },
-                                    "newText": "hello"
-                                },
-                                {
-                                    "range": {
-                                        "start": {"line": 0, "character": 2},
-                                        "end": {"line": 0, "character": 3}
-                                    },
-                                    "newText": "there"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            },
-            {
-                "applied": False,
-                "failureReason": f"Failed to open URI {uri}",
-                "failedChange": 0
-            }
-        )
-
-    def test_m_workspace_applyEdit_with_wrong_document_version(self) -> Generator:
-        with tempfile.TemporaryDirectory() as dirpath:
-            file_name = os.path.join(dirpath, "file3.txt")
-            uri = filename_to_uri(file_name)
-            version = 123
-            Path(file_name).write_text("a b", encoding="utf-8")
-            yield from verify(
-                self,
-                "workspace/applyEdit",
-                {
-                    "edit": {
-                        "documentChanges": [
-                            {
-                                "textDocument": {
-                                    "uri": uri,
-                                    "version": version
-                                },
-                                "edits": [
-                                    {
-                                        "range": {
-                                            "start": {"line": 0, "character": 0},
-                                            "end": {"line": 0, "character": 1}
-                                        },
-                                        "newText": "hello"
-                                    },
-                                    {
-                                        "range": {
-                                            "start": {"line": 0, "character": 2},
-                                            "end": {"line": 0, "character": 3}
-                                        },
-                                        "newText": "there"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                },
-                {
-                    "applied": False,
-                    "failureReason": f"Document version for URI {uri} is 0, but required {version}",
-                    "failedChange": 0
-                }
-            )
 
     def test_m_client_registerCapability(self) -> Generator:
         yield from verify(

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -9,13 +9,13 @@ from LSP.plugin.core.sessions import Manager
 from LSP.plugin.core.sessions import Session
 from LSP.plugin.core.types import ClientConfig
 from LSP.plugin.core.workspace import WorkspaceFolder
-from LSP.protocol import CreateFilesParams
-from LSP.protocol import DeleteFilesParams
 from LSP.protocol import Diagnostic
 from LSP.protocol import DocumentUri
+from LSP.protocol import FileCreate
+from LSP.protocol import FileDelete
+from LSP.protocol import FileRename
 from LSP.protocol import LogMessageParams
 from LSP.protocol import MessageActionItem
-from LSP.protocol import RenameFilesParams
 from LSP.protocol import ShowMessageParams
 from LSP.protocol import ShowMessageRequestParams
 from LSP.protocol import TextDocumentSyncKind
@@ -75,13 +75,13 @@ class MockManager(Manager):
     def handle_stderr_log(self, config_name: str, message: str) -> None:
         ...
 
-    def notify_did_create_files(self, params: CreateFilesParams) -> None:
+    def notify_did_create_files(self, created_files: list[FileCreate]) -> None:
         pass
 
-    def notify_did_rename_files(self, params: RenameFilesParams) -> None:
+    def notify_did_rename_files(self, renamed_files: list[FileRename]) -> None:
         pass
 
-    def notify_did_delete_files(self, params: DeleteFilesParams) -> None:
+    def notify_did_delete_files(self, deleted_files: list[FileDelete]) -> None:
         pass
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -9,10 +9,13 @@ from LSP.plugin.core.sessions import Manager
 from LSP.plugin.core.sessions import Session
 from LSP.plugin.core.types import ClientConfig
 from LSP.plugin.core.workspace import WorkspaceFolder
+from LSP.protocol import CreateFilesParams
+from LSP.protocol import DeleteFilesParams
 from LSP.protocol import Diagnostic
 from LSP.protocol import DocumentUri
 from LSP.protocol import LogMessageParams
 from LSP.protocol import MessageActionItem
+from LSP.protocol import RenameFilesParams
 from LSP.protocol import ShowMessageParams
 from LSP.protocol import ShowMessageRequestParams
 from LSP.protocol import TextDocumentSyncKind
@@ -71,6 +74,15 @@ class MockManager(Manager):
 
     def handle_stderr_log(self, config_name: str, message: str) -> None:
         ...
+
+    def notify_did_create_files(self, params: CreateFilesParams) -> None:
+        pass
+
+    def notify_did_rename_files(self, params: RenameFilesParams) -> None:
+        pass
+
+    def notify_did_delete_files(self, params: DeleteFilesParams) -> None:
+        pass
 
 
 class MockLogger(Logger):

--- a/tests/test_workspace_edit.py
+++ b/tests/test_workspace_edit.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from .setup import TextDocumentTestCase
+from LSP.plugin.core.url import filename_to_uri
+from pathlib import Path
+from typing import Any
+from typing import Generator
+import os
+import sublime
+import tempfile
+
+
+def verify(testcase: TextDocumentTestCase, method: str, input_params: Any, expected_result: Any) -> Generator:
+    promise = testcase.make_server_do_fake_request(method, input_params)
+    yield from testcase.await_promise(promise)
+    testcase.assertEqual(promise.result(), expected_result)
+
+
+class ApplyWorkspaceEditTests(TextDocumentTestCase):
+
+    def test_m_workspace_applyEdit(self) -> Generator:
+        old_change_count = self.insert_characters("hello\nworld\n")
+        edit = {
+            "newText": "there",
+            "range": {"start": {"line": 1, "character": 0}, "end": {"line": 1, "character": 5}}}
+        params = {"edit": {"changes": {filename_to_uri(self.view.file_name()): [edit]}}}
+        yield from verify(self, "workspace/applyEdit", params, {"applied": True})
+        yield lambda: self.view.change_count() > old_change_count
+        self.assertEqual(self.view.substr(sublime.Region(0, self.view.size())), "hello\nthere\n")
+
+    def test_m_workspace_applyEdit_with_nontrivial_promises(self) -> Generator:
+        with tempfile.TemporaryDirectory() as dirpath:
+            initial_text = ["a b", "c d"]
+            file_paths = []
+            for i in range(2):
+                file_paths.append(os.path.join(dirpath, f"file{i}.txt"))
+                Path(file_paths[-1]).write_text(initial_text[i], encoding="utf-8")
+            yield from verify(
+                self,
+                "workspace/applyEdit",
+                {
+                    "edit": {
+                        "changes": {
+                            filename_to_uri(file_paths[0]):
+                            [
+                                {
+                                    "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 1}},
+                                    "newText": "hello"
+                                },
+                                {
+                                    "range": {"start": {"line": 0, "character": 2}, "end": {"line": 0, "character": 3}},
+                                    "newText": "there"
+                                }
+                            ],
+                            filename_to_uri(file_paths[1]):
+                            [
+                                {
+                                    "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 1}},
+                                    "newText": "general"
+                                },
+                                {
+                                    "range": {"start": {"line": 0, "character": 2}, "end": {"line": 0, "character": 3}},
+                                    "newText": "kenobi"
+                                }
+                            ]
+                        }
+                    }
+                },
+                {"applied": True}
+            )
+            # Changes should have been applied
+            expected = ["hello there", "general kenobi"]
+            for i in range(2):
+                view = self.view.window().find_open_file(file_paths[i])
+                self.assertTrue(view)
+                view.set_scratch(True)
+                self.assertTrue(view.is_valid())
+                self.assertFalse(view.is_loading())
+                self.assertEqual(view.substr(sublime.Region(0, view.size())), expected[i])
+                view.close()
+
+    def test_m_workspace_applyEdit_with_wrong_uri(self) -> Generator:
+        uri = "file:///C:/wrong/uri.txt"
+        yield from verify(
+            self,
+            "workspace/applyEdit",
+            {
+                "edit": {
+                    "documentChanges": [
+                        {
+                            "textDocument": {
+                                "uri": uri,
+                                "version": None
+                            },
+                            "edits": [
+                                {
+                                    "range": {
+                                        "start": {"line": 0, "character": 0},
+                                        "end": {"line": 0, "character": 1}
+                                    },
+                                    "newText": "hello"
+                                },
+                                {
+                                    "range": {
+                                        "start": {"line": 0, "character": 2},
+                                        "end": {"line": 0, "character": 3}
+                                    },
+                                    "newText": "there"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "applied": False,
+                "failureReason": f"Failed to open URI {uri}",
+                "failedChange": 0
+            }
+        )
+
+    def test_m_workspace_applyEdit_with_wrong_document_version(self) -> Generator:
+        with tempfile.TemporaryDirectory() as dirpath:
+            file_name = os.path.join(dirpath, "file3.txt")
+            uri = filename_to_uri(file_name)
+            version = 123
+            Path(file_name).write_text("a b", encoding="utf-8")
+            yield from verify(
+                self,
+                "workspace/applyEdit",
+                {
+                    "edit": {
+                        "documentChanges": [
+                            {
+                                "textDocument": {
+                                    "uri": uri,
+                                    "version": version
+                                },
+                                "edits": [
+                                    {
+                                        "range": {
+                                            "start": {"line": 0, "character": 0},
+                                            "end": {"line": 0, "character": 1}
+                                        },
+                                        "newText": "hello"
+                                    },
+                                    {
+                                        "range": {
+                                            "start": {"line": 0, "character": 2},
+                                            "end": {"line": 0, "character": 3}
+                                        },
+                                        "newText": "there"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                {
+                    "applied": False,
+                    "failureReason": f"Document version for URI {uri} is 0, but required {version}",
+                    "failedChange": 0
+                }
+            )
+

--- a/tests/test_workspace_edit.py
+++ b/tests/test_workspace_edit.py
@@ -41,7 +41,7 @@ class ApplyWorkspaceEditTests(TextDocumentTestCase):
         expected_result: ApplyWorkspaceEditResult = {'applied': True}
         yield from verify(self, 'workspace/applyEdit', params, expected_result)
         # `changes` should increase the document version
-        yield lambda: self.view.change_count() > old_change_count
+        self.assertTrue(self.view.change_count() > old_change_count)
         # `changes` should have been applied
         self.assertEqual(entire_content(self.view), 'hello\nthere\n')
 
@@ -65,7 +65,7 @@ class ApplyWorkspaceEditTests(TextDocumentTestCase):
         expected_result: ApplyWorkspaceEditResult = {'applied': True}
         yield from verify(self, 'workspace/applyEdit', params, expected_result)
         # `documentChanges` should increase the document version by exactly 1
-        yield lambda: self.view.change_count() == version + 1
+        self.assertEqual(self.view.change_count(), version + 1)
         # `documentChanges` should have been applied
         self.assertEqual(entire_content(self.view), 'hello\nthere\n')
 

--- a/tests/test_workspace_edit.py
+++ b/tests/test_workspace_edit.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
-from ..protocol import ApplyWorkspaceEditParams
-from ..protocol import ApplyWorkspaceEditResult
-from ..protocol import WorkspaceEdit
 from .setup import TextDocumentTestCase
 from LSP.plugin.core.url import filename_to_uri
 from LSP.plugin.core.views import entire_content
 from pathlib import Path
 from typing import Any
 from typing import Generator
+from typing import TYPE_CHECKING
 import os
 import tempfile
+
+if TYPE_CHECKING:
+    from ..protocol import ApplyWorkspaceEditParams
+    from ..protocol import ApplyWorkspaceEditResult
+    from ..protocol import WorkspaceEdit
 
 
 def verify(testcase: TextDocumentTestCase, method: str, input_params: Any, expected_result: Any) -> Generator:

--- a/tests/test_workspace_edit.py
+++ b/tests/test_workspace_edit.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import Any
 from typing import Generator
 import os
-import sublime
 import tempfile
 
 
@@ -38,10 +37,34 @@ class ApplyWorkspaceEditTests(TextDocumentTestCase):
         params: ApplyWorkspaceEditParams = {'edit': workspace_edit}
         expected_result: ApplyWorkspaceEditResult = {'applied': True}
         yield from verify(self, 'workspace/applyEdit', params, expected_result)
-        # Changes should increase the document version
+        # `changes` should increase the document version
         yield lambda: self.view.change_count() > old_change_count
-        # Changes should have been applied
-        self.assertEqual(self.view.substr(sublime.Region(0, self.view.size())), 'hello\nthere\n')
+        # `changes` should have been applied
+        self.assertEqual(entire_content(self.view), 'hello\nthere\n')
+
+    def test_document_changes(self) -> Generator:
+        uri = filename_to_uri(self.view.file_name())
+        version = self.view.change_count()
+        workspace_edit: WorkspaceEdit = {
+            'documentChanges': [
+                {
+                    'textDocument': {'uri': uri, 'version': version},
+                    'edits': [
+                        {
+                            'range': {'start': {'line': 1, 'character': 0}, 'end': {'line': 1, 'character': 5}},
+                            'newText': 'world'
+                        }
+                    ]
+                }
+            ]
+        }
+        params: ApplyWorkspaceEditParams = {'edit': workspace_edit}
+        expected_result: ApplyWorkspaceEditResult = {'applied': True}
+        yield from verify(self, 'workspace/applyEdit', params, expected_result)
+        # `documentChanges` should increase the document version by exactly 1
+        yield lambda: self.view.change_count() == version + 1
+        # `documentChanges` should have been applied
+        self.assertEqual(entire_content(self.view), 'hello\nworld\n')
 
     def test_changes_for_unopened_files(self) -> Generator:
         with tempfile.TemporaryDirectory() as dirpath:

--- a/tests/test_workspace_edit.py
+++ b/tests/test_workspace_edit.py
@@ -47,7 +47,7 @@ class ApplyWorkspaceEditTests(TextDocumentTestCase):
 
     def test_document_changes(self) -> Generator:
         uri = filename_to_uri(self.view.file_name())
-        version = self.view.change_count()
+        version = self.insert_characters('hello\nworld\n')
         workspace_edit: WorkspaceEdit = {
             'documentChanges': [
                 {
@@ -55,7 +55,7 @@ class ApplyWorkspaceEditTests(TextDocumentTestCase):
                     'edits': [
                         {
                             'range': {'start': {'line': 1, 'character': 0}, 'end': {'line': 1, 'character': 5}},
-                            'newText': 'world'
+                            'newText': 'there'
                         }
                     ]
                 }
@@ -67,7 +67,7 @@ class ApplyWorkspaceEditTests(TextDocumentTestCase):
         # `documentChanges` should increase the document version by exactly 1
         yield lambda: self.view.change_count() == version + 1
         # `documentChanges` should have been applied
-        self.assertEqual(entire_content(self.view), 'hello\nworld\n')
+        self.assertEqual(entire_content(self.view), 'hello\nthere\n')
 
     def test_changes_for_unopened_files(self) -> Generator:
         with tempfile.TemporaryDirectory() as dirpath:

--- a/tests/test_workspace_edit.py
+++ b/tests/test_workspace_edit.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+from ..protocol import ApplyWorkspaceEditParams
+from ..protocol import ApplyWorkspaceEditResult
+from ..protocol import WorkspaceEdit
 from .setup import TextDocumentTestCase
 from LSP.plugin.core.url import filename_to_uri
+from LSP.plugin.core.views import entire_content
 from pathlib import Path
 from typing import Any
 from typing import Generator
@@ -18,148 +22,115 @@ def verify(testcase: TextDocumentTestCase, method: str, input_params: Any, expec
 
 class ApplyWorkspaceEditTests(TextDocumentTestCase):
 
-    def test_m_workspace_applyEdit(self) -> Generator:
-        old_change_count = self.insert_characters("hello\nworld\n")
-        edit = {
-            "newText": "there",
-            "range": {"start": {"line": 1, "character": 0}, "end": {"line": 1, "character": 5}}}
-        params = {"edit": {"changes": {filename_to_uri(self.view.file_name()): [edit]}}}
-        yield from verify(self, "workspace/applyEdit", params, {"applied": True})
-        yield lambda: self.view.change_count() > old_change_count
-        self.assertEqual(self.view.substr(sublime.Region(0, self.view.size())), "hello\nthere\n")
-
-    def test_m_workspace_applyEdit_with_nontrivial_promises(self) -> Generator:
-        with tempfile.TemporaryDirectory() as dirpath:
-            initial_text = ["a b", "c d"]
-            file_paths = []
-            for i in range(2):
-                file_paths.append(os.path.join(dirpath, f"file{i}.txt"))
-                Path(file_paths[-1]).write_text(initial_text[i], encoding="utf-8")
-            yield from verify(
-                self,
-                "workspace/applyEdit",
-                {
-                    "edit": {
-                        "changes": {
-                            filename_to_uri(file_paths[0]):
-                            [
-                                {
-                                    "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 1}},
-                                    "newText": "hello"
-                                },
-                                {
-                                    "range": {"start": {"line": 0, "character": 2}, "end": {"line": 0, "character": 3}},
-                                    "newText": "there"
-                                }
-                            ],
-                            filename_to_uri(file_paths[1]):
-                            [
-                                {
-                                    "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 1}},
-                                    "newText": "general"
-                                },
-                                {
-                                    "range": {"start": {"line": 0, "character": 2}, "end": {"line": 0, "character": 3}},
-                                    "newText": "kenobi"
-                                }
-                            ]
-                        }
+    def test_changes(self) -> Generator:
+        old_change_count = self.insert_characters('hello\nworld\n')
+        uri = filename_to_uri(self.view.file_name())
+        workspace_edit: WorkspaceEdit = {
+            'changes': {
+                uri: [
+                    {
+                        'range': {'start': {'line': 1, 'character': 0}, 'end': {'line': 1, 'character': 5}},
+                        'newText': 'there'
                     }
-                },
-                {"applied": True}
-            )
-            # Changes should have been applied
-            expected = ["hello there", "general kenobi"]
-            for i in range(2):
-                view = self.view.window().find_open_file(file_paths[i])
-                self.assertTrue(view)
-                view.set_scratch(True)
-                self.assertTrue(view.is_valid())
-                self.assertFalse(view.is_loading())
-                self.assertEqual(view.substr(sublime.Region(0, view.size())), expected[i])
-                view.close()
+                ]
+            }
+        }
+        params: ApplyWorkspaceEditParams = {'edit': workspace_edit}
+        expected_result: ApplyWorkspaceEditResult = {'applied': True}
+        yield from verify(self, 'workspace/applyEdit', params, expected_result)
+        # Changes should increase the document version
+        yield lambda: self.view.change_count() > old_change_count
+        # Changes should have been applied
+        self.assertEqual(self.view.substr(sublime.Region(0, self.view.size())), 'hello\nthere\n')
 
-    def test_m_workspace_applyEdit_with_wrong_uri(self) -> Generator:
-        uri = "file:///C:/wrong/uri.txt"
-        yield from verify(
-            self,
-            "workspace/applyEdit",
-            {
-                "edit": {
-                    "documentChanges": [
+    def test_changes_for_unopened_files(self) -> Generator:
+        with tempfile.TemporaryDirectory() as dirpath:
+            file1 = os.path.join(dirpath, 'file1.txt')
+            file2 = os.path.join(dirpath, 'file2.txt')
+            Path(file1).write_text('a b', encoding='utf-8')
+            Path(file2).write_text('c d', encoding='utf-8')
+            uri1 = filename_to_uri(file1)
+            uri2 = filename_to_uri(file2)
+            workspace_edit: WorkspaceEdit = {
+                'changes': {
+                    uri1: [
                         {
-                            "textDocument": {
-                                "uri": uri,
-                                "version": None
-                            },
-                            "edits": [
-                                {
-                                    "range": {
-                                        "start": {"line": 0, "character": 0},
-                                        "end": {"line": 0, "character": 1}
-                                    },
-                                    "newText": "hello"
-                                },
-                                {
-                                    "range": {
-                                        "start": {"line": 0, "character": 2},
-                                        "end": {"line": 0, "character": 3}
-                                    },
-                                    "newText": "there"
-                                }
-                            ]
+                            'range': {'start': {'line': 0, 'character': 0}, 'end': {'line': 0, 'character': 1}},
+                            'newText': 'hello'
+                        },
+                        {
+                            'range': {'start': {'line': 0, 'character': 2}, 'end': {'line': 0, 'character': 3}},
+                            'newText': 'there'
+                        }
+                    ],
+                    uri2: [
+                        {
+                            'range': {'start': {'line': 0, 'character': 0}, 'end': {'line': 0, 'character': 1}},
+                            'newText': 'general'
+                        },
+                        {
+                            'range': {'start': {'line': 0, 'character': 2}, 'end': {'line': 0, 'character': 3}},
+                            'newText': 'kenobi'
                         }
                     ]
                 }
-            },
-            {
-                "applied": False,
-                "failureReason": f"Failed to open URI {uri}",
-                "failedChange": 0
             }
-        )
+            params: ApplyWorkspaceEditParams = {'edit': workspace_edit}
+            expected_result: ApplyWorkspaceEditResult = {'applied': True}
+            yield from verify(self, 'workspace/applyEdit', params, expected_result)
+            # Changes should have been applied
+            window = self.view.window()
+            for file, expected_text in zip([file1, file2], ['hello there', 'general kenobi']):
+                view = window.find_open_file(file)
+                self.assertTrue(view)
+                self.assertEqual(entire_content(view), expected_text)
+                view.set_scratch(True)
+                view.close()
 
-    def test_m_workspace_applyEdit_with_wrong_document_version(self) -> Generator:
-        with tempfile.TemporaryDirectory() as dirpath:
-            file_name = os.path.join(dirpath, "file3.txt")
-            uri = filename_to_uri(file_name)
-            version = 123
-            Path(file_name).write_text("a b", encoding="utf-8")
-            yield from verify(
-                self,
-                "workspace/applyEdit",
+    def test_fails_on_wrong_uri(self) -> Generator:
+        uri = 'file:///C:/wrong/uri.txt'
+        workspace_edit: WorkspaceEdit = {
+            'documentChanges': [
                 {
-                    "edit": {
-                        "documentChanges": [
-                            {
-                                "textDocument": {
-                                    "uri": uri,
-                                    "version": version
-                                },
-                                "edits": [
-                                    {
-                                        "range": {
-                                            "start": {"line": 0, "character": 0},
-                                            "end": {"line": 0, "character": 1}
-                                        },
-                                        "newText": "hello"
-                                    },
-                                    {
-                                        "range": {
-                                            "start": {"line": 0, "character": 2},
-                                            "end": {"line": 0, "character": 3}
-                                        },
-                                        "newText": "there"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                },
-                {
-                    "applied": False,
-                    "failureReason": f"Document version for URI {uri} is 0, but required {version}",
-                    "failedChange": 0
+                    'textDocument': {'uri': uri, 'version': None},
+                    'edits': [
+                        {
+                            'range': {'start': {'line': 0, 'character': 0}, 'end': {'line': 0, 'character': 1}},
+                            'newText': 'hello'
+                        }
+                    ]
                 }
-            )
+            ]
+        }
+        params: ApplyWorkspaceEditParams = {'edit': workspace_edit}
+        expected_result: ApplyWorkspaceEditResult = {
+            'applied': False,
+            'failureReason': f'Failed to open URI {uri}',
+            'failedChange': 0
+        }
+        yield from verify(self, 'workspace/applyEdit', params, expected_result)
 
+    def test_fails_on_wrong_document_version(self) -> Generator:
+        change_count = self.view.change_count()
+        uri = filename_to_uri(self.view.file_name())
+        version = change_count - 1
+        workspace_edit: WorkspaceEdit = {
+            'documentChanges': [
+                {
+                    'textDocument': {'uri': uri, 'version': version},
+                    'edits': [
+                        {
+                            'range': {'start': {'line': 0, 'character': 0}, 'end': {'line': 0, 'character': 1}},
+                            'newText': 'hello'
+                        }
+                    ]
+                }
+            ]
+        }
+        params: ApplyWorkspaceEditParams = {'edit': workspace_edit}
+        expected_result: ApplyWorkspaceEditResult = {
+            'applied': False,
+            'failureReason': f'Document version for URI {uri} is {change_count}, but required {version}',
+            'failedChange': 0
+        }
+        yield from verify(self, 'workspace/applyEdit', params, expected_result)

--- a/tests/test_workspace_edit.py
+++ b/tests/test_workspace_edit.py
@@ -107,8 +107,7 @@ class ApplyWorkspaceEditTests(TextDocumentTestCase):
             # Changes should have been applied
             window = self.view.window()
             for file, expected_text in zip([file1, file2], ['hello there', 'general kenobi']):
-                view = window.find_open_file(file)
-                self.assertTrue(view)
+                view = window.open_file(file)
                 self.assertEqual(entire_content(view), expected_text)
                 view.set_scratch(True)
                 view.close()
@@ -160,3 +159,327 @@ class ApplyWorkspaceEditTests(TextDocumentTestCase):
             'failedChange': 0
         }
         yield from verify(self, 'workspace/applyEdit', params, expected_result)
+
+    def test_create_file(self) -> Generator:
+        window = self.view.window()
+        with tempfile.TemporaryDirectory() as dirpath:
+            filepath = os.path.join(dirpath, 'newfile.txt')
+            uri = filename_to_uri(filepath)
+            new_text = 'hello\nworld\n'
+            workspace_edit: WorkspaceEdit = {
+                'documentChanges': [
+                    {
+                        'kind': 'create',
+                        'uri': uri
+                    },
+                    {
+                        'textDocument': {'uri': uri, 'version': None},
+                        'edits': [
+                            {
+                                'range': {'start': {'line': 0, 'character': 0}, 'end': {'line': 0, 'character': 0}},
+                                'newText': new_text
+                            }
+                        ]
+                    }
+                ]
+            }
+            params: ApplyWorkspaceEditParams = {'edit': workspace_edit}
+            expected_result: ApplyWorkspaceEditResult = {'applied': True}
+            self.assertFalse(os.path.isfile(filepath))
+            yield from verify(self, 'workspace/applyEdit', params, expected_result)
+            # The file should have been created
+            self.assertTrue(os.path.isfile(filepath))
+            # The TextDocumentEdit (second item in `documentChanges`) should have been applied
+            content = entire_content(window.open_file(filepath))
+            self.assertEqual(content, new_text)
+
+    def test_fails_create_file_exists(self) -> Generator:
+        with tempfile.TemporaryDirectory() as dirpath:
+            filepath = os.path.join(dirpath, 'newfile.txt')
+            old_text = 'hello\nthere\n'
+            new_text = 'hello\nworld\n'
+            Path(filepath).write_text(old_text, encoding='utf-8')
+            uri = filename_to_uri(filepath)
+            workspace_edit: WorkspaceEdit = {
+                'documentChanges': [
+                    {
+                        'kind': 'create',
+                        'uri': uri
+                    },
+                    {
+                        'textDocument': {'uri': uri, 'version': None},
+                        'edits': [
+                            {
+                                'range': {'start': {'line': 0, 'character': 0}, 'end': {'line': 0, 'character': 0}},
+                                'newText': new_text
+                            }
+                        ]
+                    }
+                ]
+            }
+            params: ApplyWorkspaceEditParams = {'edit': workspace_edit}
+            expected_result: ApplyWorkspaceEditResult = {
+                'applied': False,
+                'failureReason': f'CreateFile failed because a file already exists at target {uri}',
+                'failedChange': 0
+            }
+            yield from verify(self, 'workspace/applyEdit', params, expected_result)
+            # The file should still have its original content
+            content = Path(filepath).read_text(encoding='utf-8')
+            self.assertEqual(content, old_text)
+
+    def test_create_file_exists_ignore(self) -> Generator:
+        window = self.view.window()
+        with tempfile.TemporaryDirectory() as dirpath:
+            filepath = os.path.join(dirpath, 'newfile.txt')
+            old_text = 'hello\nthere\n'
+            new_text = 'hello\nworld\n'
+            Path(filepath).write_text(old_text, encoding='utf-8')
+            uri = filename_to_uri(filepath)
+            workspace_edit: WorkspaceEdit = {
+                'documentChanges': [
+                    {
+                        'kind': 'create',
+                        'uri': uri,
+                        'options': {
+                            'ignoreIfExists': True
+                        }
+                    },
+                    {
+                        'textDocument': {'uri': uri, 'version': None},
+                        'edits': [
+                            {
+                                'range': {'start': {'line': 0, 'character': 0}, 'end': {'line': 0, 'character': 0}},
+                                'newText': new_text
+                            }
+                        ]
+                    }
+                ]
+            }
+            params: ApplyWorkspaceEditParams = {'edit': workspace_edit}
+            expected_result: ApplyWorkspaceEditResult = {'applied': True}
+            yield from verify(self, 'workspace/applyEdit', params, expected_result)
+            # The TextDocumentEdit (second item in `documentChanges`) should have been applied
+            content = entire_content(window.open_file(filepath))
+            self.assertEqual(content, new_text + old_text)
+
+    def test_create_file_exists_overwrite(self) -> Generator:
+        window = self.view.window()
+        with tempfile.TemporaryDirectory() as dirpath:
+            filepath = os.path.join(dirpath, 'newfile.txt')
+            old_text = 'hello\nthere\n'
+            new_text = 'hello\nworld\n'
+            Path(filepath).write_text(old_text, encoding='utf-8')
+            uri = filename_to_uri(filepath)
+            workspace_edit: WorkspaceEdit = {
+                'documentChanges': [
+                    {
+                        'kind': 'create',
+                        'uri': uri,
+                        'options': {
+                            'overwrite': True,
+                            'ignoreIfExists': True  # Overwrite wins over `ignoreIfExists`
+                        }
+                    },
+                    {
+                        'textDocument': {'uri': uri, 'version': None},
+                        'edits': [
+                            {
+                                'range': {'start': {'line': 0, 'character': 0}, 'end': {'line': 0, 'character': 0}},
+                                'newText': new_text
+                            }
+                        ]
+                    }
+                ]
+            }
+            params: ApplyWorkspaceEditParams = {'edit': workspace_edit}
+            expected_result: ApplyWorkspaceEditResult = {'applied': True}
+            yield from verify(self, 'workspace/applyEdit', params, expected_result)
+            # The file content should only be the new text because the file was overwritten
+            content = entire_content(window.open_file(filepath))
+            self.assertEqual(content, new_text)
+
+    def test_rename_file(self) -> Generator:
+        window = self.view.window()
+        with tempfile.TemporaryDirectory() as dirpath:
+            old_path = os.path.join(dirpath, 'old_file.txt')
+            new_path = os.path.join(dirpath, 'new_file.txt')
+            old_uri = filename_to_uri(old_path)
+            new_uri = filename_to_uri(new_path)
+            old_text = 'hello\nthere\n'
+            new_text = 'hello\nworld\n'
+            Path(old_path).write_text(old_text, encoding='utf-8')
+            workspace_edit: WorkspaceEdit = {
+                'documentChanges': [
+                    {
+                        'kind': 'rename',
+                        'oldUri': old_uri,
+                        'newUri': new_uri
+                    },
+                    {
+                        'textDocument': {'uri': new_uri, 'version': None},
+                        'edits': [
+                            {
+                                'range': {'start': {'line': 0, 'character': 0}, 'end': {'line': 0, 'character': 0}},
+                                'newText': new_text
+                            }
+                        ]
+                    }
+                ]
+            }
+            params: ApplyWorkspaceEditParams = {'edit': workspace_edit}
+            expected_result: ApplyWorkspaceEditResult = {'applied': True}
+            yield from verify(self, 'workspace/applyEdit', params, expected_result)
+            # The file should have been renamed
+            self.assertFalse(os.path.isfile(old_path))
+            self.assertTrue(os.path.isfile(new_path))
+            # The TextDocumentEdit (second item in `documentChanges`) should have been applied
+            content = entire_content(window.open_file(new_path))
+            self.assertEqual(content, new_text + old_text)
+
+    def test_rename_file_exists(self) -> Generator:
+        with tempfile.TemporaryDirectory() as dirpath:
+            old_path = os.path.join(dirpath, 'old_file.txt')
+            new_path = os.path.join(dirpath, 'new_file.txt')
+            old_uri = filename_to_uri(old_path)
+            new_uri = filename_to_uri(new_path)
+            old_text1 = 'hello\nthere 1\n'
+            old_text2 = 'hello\nthere 2\n'
+            new_text = 'hello\nworld\n'
+            Path(old_path).write_text(old_text1, encoding='utf-8')
+            Path(new_path).write_text(old_text2, encoding='utf-8')
+            workspace_edit: WorkspaceEdit = {
+                'documentChanges': [
+                    {
+                        'kind': 'rename',
+                        'oldUri': old_uri,
+                        'newUri': new_uri
+                    },
+                    {
+                        'textDocument': {'uri': new_uri, 'version': None},
+                        'edits': [
+                            {
+                                'range': {'start': {'line': 0, 'character': 0}, 'end': {'line': 0, 'character': 0}},
+                                'newText': new_text
+                            }
+                        ]
+                    }
+                ]
+            }
+            params: ApplyWorkspaceEditParams = {'edit': workspace_edit}
+            expected_result: ApplyWorkspaceEditResult = {
+                'applied': False,
+                'failureReason': f'RenameFile failed because target {new_uri} already exists',
+                'failedChange': 0
+            }
+            yield from verify(self, 'workspace/applyEdit', params, expected_result)
+            # The old file should *not* have been deleted (rename operation failed)
+            self.assertTrue(os.path.isfile(old_path))
+            # The target file should still have its original content
+            content = Path(new_path).read_text(encoding='utf-8')
+            self.assertEqual(content, old_text2)
+
+    def test_rename_file_exists_ignore(self) -> Generator:
+        window = self.view.window()
+        with tempfile.TemporaryDirectory() as dirpath:
+            old_path = os.path.join(dirpath, 'old_file.txt')
+            new_path = os.path.join(dirpath, 'new_file.txt')
+            old_uri = filename_to_uri(old_path)
+            new_uri = filename_to_uri(new_path)
+            old_text1 = 'hello\nthere 1\n'
+            old_text2 = 'hello\nthere 2\n'
+            new_text = 'hello\nworld\n'
+            Path(old_path).write_text(old_text1, encoding='utf-8')
+            Path(new_path).write_text(old_text2, encoding='utf-8')
+            workspace_edit: WorkspaceEdit = {
+                'documentChanges': [
+                    {
+                        'kind': 'rename',
+                        'oldUri': old_uri,
+                        'newUri': new_uri,
+                        'options': {
+                            'ignoreIfExists': True
+                        }
+                    },
+                    {
+                        'textDocument': {'uri': new_uri, 'version': None},
+                        'edits': [
+                            {
+                                'range': {'start': {'line': 0, 'character': 0}, 'end': {'line': 0, 'character': 0}},
+                                'newText': new_text
+                            }
+                        ]
+                    }
+                ]
+            }
+            params: ApplyWorkspaceEditParams = {'edit': workspace_edit}
+            expected_result: ApplyWorkspaceEditResult = {'applied': True}
+            yield from verify(self, 'workspace/applyEdit', params, expected_result)
+            # The old file should *not* have been deleted (rename operation ignored)
+            self.assertTrue(os.path.isfile(old_path))
+            # The TextDocumentEdit (second item in `documentChanges`) should have been applied to the target file
+            content = entire_content(window.open_file(new_path))
+            self.assertEqual(content, new_text + old_text2)
+
+    def test_rename_file_exists_overwrite(self) -> Generator:
+        window = self.view.window()
+        with tempfile.TemporaryDirectory() as dirpath:
+            old_path = os.path.join(dirpath, 'old_file.txt')
+            new_path = os.path.join(dirpath, 'new_file.txt')
+            old_uri = filename_to_uri(old_path)
+            new_uri = filename_to_uri(new_path)
+            old_text1 = 'hello\nthere 1\n'
+            old_text2 = 'hello\nthere 2\n'
+            new_text = 'hello\nworld\n'
+            Path(old_path).write_text(old_text1, encoding='utf-8')
+            Path(new_path).write_text(old_text2, encoding='utf-8')
+            workspace_edit: WorkspaceEdit = {
+                'documentChanges': [
+                    {
+                        'kind': 'rename',
+                        'oldUri': old_uri,
+                        'newUri': new_uri,
+                        'options': {
+                            'overwrite': True,
+                            'ignoreIfExists': True  # Overwrite wins over `ignoreIfExists`
+                        }
+                    },
+                    {
+                        'textDocument': {'uri': new_uri, 'version': None},
+                        'edits': [
+                            {
+                                'range': {'start': {'line': 0, 'character': 0}, 'end': {'line': 0, 'character': 0}},
+                                'newText': new_text
+                            }
+                        ]
+                    }
+                ]
+            }
+            params: ApplyWorkspaceEditParams = {'edit': workspace_edit}
+            expected_result: ApplyWorkspaceEditResult = {'applied': True}
+            yield from verify(self, 'workspace/applyEdit', params, expected_result)
+            # The old file should have been deleted (rename operation succeeded)
+            self.assertFalse(os.path.isfile(old_path))
+            # The TextDocumentEdit (second item in `documentChanges`) should have been applied to the renamed file
+            content = entire_content(window.open_file(new_path))
+            self.assertEqual(content, new_text + old_text1)
+
+    def test_delete_file(self) -> Generator:
+        with tempfile.TemporaryDirectory() as dirpath:
+            filepath = os.path.join(dirpath, 'newfile.txt')
+            Path(filepath).write_text('hello\nworld\n', encoding='utf-8')
+            uri = filename_to_uri(filepath)
+            workspace_edit: WorkspaceEdit = {
+                'documentChanges': [
+                    {
+                        'kind': 'delete',
+                        'uri': uri
+                    }
+                ]
+            }
+            params: ApplyWorkspaceEditParams = {'edit': workspace_edit}
+            expected_result: ApplyWorkspaceEditResult = {'applied': True}
+            self.assertTrue(os.path.isfile(filepath))
+            yield from verify(self, 'workspace/applyEdit', params, expected_result)
+            # The file should have been deleted
+            self.assertFalse(os.path.isfile(filepath))


### PR DESCRIPTION
Resolves #2706

I haven't tested in practice, but provided that tests are passing, I think it should be working.

Iirc the PHP server wanted to use resource operations, so feel free to test with that (or with another server if you know one that uses resource operations).

*Edit:* According to https://github.com/sublimelsp/LSP-intelephense/issues/112, testing with the PHP server would require a licensed version of that server. But it looks like there is also a code action in rust-analyzer that wants to use this: https://github.com/sublimelsp/LSP-rust-analyzer/issues/119