### PR TITLE
remove text decoration on link within kbd in popups

### DIFF
--- a/popups.css
+++ b/popups.css
@@ -112,7 +112,8 @@ html.light .diagnostics code.highlight {
 .actions {
     background-color: color(var(--foreground) alpha(0.1));
 }
-.actions a {
+.actions a,
+kbd a {
     text-decoration: none;
 }
 .lightbulb {


### PR DESCRIPTION
Typescript has a custom feature that allows for expanding hover responses. I want to implement it in LSP-tsgo and I came up with a syntax like `<kbd>[+](verbosity:+1)</kbd>` which looks bad due to link having an underline:

<img width="204" height="63" alt="Screenshot 2026-05-17 at 17 42 20" src="https://github.com/user-attachments/assets/1fb59b71-1e4a-4285-abf4-990f8a65a6e8" />

It looks better with this change:

<img width="206" height="66" alt="Screenshot 2026-05-17 at 17 39 26" src="https://github.com/user-attachments/assets/cef30c51-0142-4826-85fe-c9da97bea3f3" />

(I'm injecting this content into the hover response so I can't affect the styles that are used)