### PR TITLE
refactor: remove Session.__getattr__

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1030,20 +1030,6 @@ class Session(APIHandler, TransportCallbacks):
         self._logged_unsupported_commands: set[str] = set()
         super().__init__()
 
-    def __getattr__(self, name: str) -> Any:
-        """If we don't have a request/notification handler, look up the request/notification handler in the plugin."""
-        if name.startswith('m_'):
-            if self._plugin:
-                # Handler added through decorator.
-                if handler_name := self._plugin.handler_attr_map.get(name):
-                    return getattr(self._plugin, handler_name)
-                # Handler added through 'm_*' method.
-                if isinstance(self._plugin, AbstractPlugin) and (plugin_handler := getattr(self._plugin, name, None)):
-                    return plugin_handler
-            if handler_name := self.handler_attr_map.get(name):
-                return getattr(self, handler_name)
-        raise AttributeError(name)
-
     # TODO: Create an assurance that the API doesn't change here as it can be used by plugins.
     def get_workspace_folders(self) -> list[WorkspaceFolder]:
         return self._workspace_folders
@@ -2503,4 +2489,15 @@ class Session(APIHandler, TransportCallbacks):
         return (error_handler, request.method, error, True)
 
     def _get_handler(self, method: str) -> Callable | None:
-        return getattr(self, method2attr(method), None)
+        """If we don't have a request/notification handler, look up the request/notification handler in the plugin."""
+        name = method2attr(method)
+        if self._plugin:
+            # Handler added through decorator.
+            if handler_name := self._plugin.handler_attr_map.get(name):
+                return getattr(self._plugin, handler_name)
+            # Handler added through 'm_*' method.
+            if isinstance(self._plugin, AbstractPlugin) and (plugin_handler := getattr(self._plugin, name, None)):
+                return plugin_handler
+        if handler_name := self.handler_attr_map.get(name):
+            return getattr(self, handler_name)
+        raise AttributeError(name)

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -2500,4 +2500,4 @@ class Session(APIHandler, TransportCallbacks):
                 return plugin_handler
         if handler_name := self.handler_attr_map.get(name):
             return getattr(self, handler_name)
-        raise AttributeError(name)
+        return None

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -551,6 +551,7 @@ _METHOD_TO_CAPABILITY_EXCEPTIONS: dict[str, tuple[str, str | None]] = {
 }
 
 
+@deprecated('Remove once lsp_utils drops it from the code')
 def method2attr(method: str) -> str:
     # window/messageRequest -> m_window_messageRequest
     # $/progress -> m___progress


### PR DESCRIPTION
`__getattr__` isn't needed since we are not using `m_*` convention in `Session` anymore.

As @rwols pointed out, having it had implications on type-checking - type-checker couldn't flag cases when unknown attributes were accessed.