### PR TITLE
show "Follow link" in hover popup for unknown links

### DIFF
--- a/plugin/core/open.py
+++ b/plugin/core/open.py
@@ -51,7 +51,6 @@ def lsp_range_from_uri_fragment(fragment: str) -> Range | None:
 def open_file_uri(
     window: sublime.Window, uri: DocumentUri, flags: sublime.NewFileFlags = sublime.NewFileFlags.NONE, group: int = -1
 ) -> Promise[sublime.View | None]:
-
     decoded_uri = unquote(uri)  # decode percent-encoded characters
     open_promise = open_file(window, decoded_uri, flags, group)
     if fragment := urlparse(decoded_uri).fragment:

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -231,7 +231,7 @@ class LspHoverCommand(LspTextCommand):
         if len(self._document_links) == 1:
             link = self._document_links[0]
             target = link.get("target")
-            label = "Follow Link" if link.get("target", "file:").startswith("file:") else "Open in Browser"
+            label = "Open in Browser" if target and target.startswith(("http:", "https:")) else "Follow Link"
             title = link.get("tooltip")
             tooltip = f' title="{html.escape(title)}"' if title else ""
             region = range_to_region(link["range"], self.view)

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -231,7 +231,7 @@ class LspHoverCommand(LspTextCommand):
         if len(self._document_links) == 1:
             link = self._document_links[0]
             target = link.get("target")
-            label = "Open in Browser" if target and target.startswith(("http:", "https:")) else "Follow Link"
+            label = "Open in Browser" if target and target.startswith(("http:", "https:")) else "Open Link"
             title = link.get("tooltip")
             tooltip = f' title="{html.escape(title)}"' if title else ""
             region = range_to_region(link["range"], self.view)


### PR DESCRIPTION
The text shown when hovering document links was not ideal for unknown schemas. In JSON we've shown "Open in browser" for links with `json-schema` schema.

<img width="472" height="109" alt="Screenshot 2026-05-17 at 22 33 20" src="https://github.com/user-attachments/assets/8885b11a-d30c-44e5-8ba5-a85662359af8" />

Show "Open in browser" only for URIs with http/https schema. For other show "Follow link".

If we don't have `target` then we don't know schema until resolve and we'll also show "Follow link".