### PR TITLE
Fix on_sheet_opened called twice from uri_handler

### DIFF
--- a/docs/src/migrating_to_lsp_plugin.md
+++ b/docs/src/migrating_to_lsp_plugin.md
@@ -435,7 +435,7 @@ from LSP.plugin import uri_handler
 def on_open_foo_uri(self, uri: DocumentUri, flags: sublime.NewFileFlags) -> Promise[sublime.Sheet | None]:
     title, content, syntax = render_foo_uri(uri)
     if session := self.weaksession():
-        return session.open_scratch_buffer(title, content, syntax, uri, None, flags).then(_: None)
+        return session.open_scratch_buffer(title, content, syntax, flags).then(lambda view: view.sheet())
     return Promise.resolve(None)
 ```
 

--- a/docs/src/migrating_to_lsp_plugin.md
+++ b/docs/src/migrating_to_lsp_plugin.md
@@ -435,7 +435,7 @@ from LSP.plugin import uri_handler
 def on_open_foo_uri(self, uri: DocumentUri, flags: sublime.NewFileFlags) -> Promise[sublime.Sheet | None]:
     title, content, syntax = render_foo_uri(uri)
     if session := self.weaksession():
-        return session.open_scratch_buffer(title, content, syntax, uri, None, flags)
+        return session.open_scratch_buffer(title, content, syntax, uri, None, flags).then(_: None)
     return Promise.resolve(None)
 ```
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1476,7 +1476,7 @@ class Session(APIHandler, TransportCallbacks):
             if isinstance(self._plugin, LspPlugin):
                 scheme, _ = parse_uri(uri)
                 if handler := self._plugin.get_uri_handler(scheme):
-                    return handler(uri, flags).then(lambda sheet: self._on_sheet_opened(sheet, uri, r))
+                    return handler(uri, flags).then(lambda sheet: sheet.view() if sheet else None)
             else:
                 return self._open_uri_with_plugin_async(self._plugin, uri, r, flags, group)
         return None

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1567,21 +1567,20 @@ class Session(APIHandler, TransportCallbacks):
             view.set_name(title)
             view.run_command("append", {"characters": content})
             view.set_read_only(True)
-            self._on_sheet_opened(view.sheet(), uri, r).then(lambda _: resolve(view))
+            self._on_sheet_opened(view.sheet(), uri, r)
+            resolve(view)
 
         sublime.set_timeout(continue_on_main_thread)
         return promise
 
-    def _on_sheet_opened(
-        self, sheet: sublime.Sheet | None, uri: DocumentUri, r: Range | None
-    ) -> Promise[sublime.View | None]:
+    def _on_sheet_opened(self, sheet: sublime.Sheet | None, uri: DocumentUri, r: Range | None) -> sublime.View | None:
         if sheet and (view := sheet.view()):
             uri_no_fragment = urldefrag(uri).url
             view.settings().set('lsp_uri', uri_no_fragment)
             if r:
                 center_selection(view, r)
-            return Promise.resolve(view)
-        return Promise.resolve(None)
+            return view
+        return None
 
     def open_location_async(
         self,

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1476,7 +1476,7 @@ class Session(APIHandler, TransportCallbacks):
             if isinstance(self._plugin, LspPlugin):
                 scheme, _ = parse_uri(uri)
                 if handler := self._plugin.get_uri_handler(scheme):
-                    return handler(uri, flags).then(lambda sheet: sheet.view() if sheet else None)
+                    return handler(uri, flags).then(lambda sheet: self._on_sheet_opened(sheet, uri, r))
             else:
                 return self._open_uri_with_plugin_async(self._plugin, uri, r, flags, group)
         return None

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1523,7 +1523,7 @@ class Session(APIHandler, TransportCallbacks):
         # I cannot type-hint an unpacked tuple
         pair: PackagedTask[tuple[str, str, str]] = Promise.packaged_task()
         # It'd be nice to have automatic tuple unpacking continuations
-        callback = lambda a, b, c: pair[1]((a or 'Untitled', b, c))  # noqa: E731
+        callback = lambda a, b, c: pair[1]((a or 'untitled', b, c))  # noqa: E731
         if plugin.on_open_uri_async(uri, callback):
             result: PackagedTask[sublime.View | None] = Promise.packaged_task()
             pair[0].then(lambda tup: self.open_scratch_buffer(*tup, uri, r, flags, group)).then(result[1])

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1549,8 +1549,8 @@ class Session(APIHandler, TransportCallbacks):
         title: str,
         content: str,
         syntax: str,
-        uri: DocumentUri,
-        r: Range | None,
+        uri: DocumentUri | None = None,
+        r: Range | None = None,
         flags: sublime.NewFileFlags = sublime.NewFileFlags.NONE,
         group: int = -1,
     ) -> Promise[sublime.View]:
@@ -1573,10 +1573,13 @@ class Session(APIHandler, TransportCallbacks):
         sublime.set_timeout(continue_on_main_thread)
         return promise
 
-    def _on_sheet_opened(self, sheet: sublime.Sheet | None, uri: DocumentUri, r: Range | None) -> sublime.View | None:
+    def _on_sheet_opened(
+        self, sheet: sublime.Sheet | None, uri: DocumentUri | None, r: Range | None
+    ) -> sublime.View | None:
         if sheet and (view := sheet.view()):
-            uri_no_fragment = urldefrag(uri).url
-            view.settings().set('lsp_uri', uri_no_fragment)
+            if uri:
+                uri_no_fragment = urldefrag(uri).url
+                view.settings().set('lsp_uri', uri_no_fragment)
             if r:
                 center_selection(view, r)
             return view

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1535,9 +1535,9 @@ class Session(APIHandler, TransportCallbacks):
         group: int,
     ) -> Promise[sublime.View | None] | None:
         # I cannot type-hint an unpacked tuple
-        pair: PackagedTask[tuple[str | None, str, str]] = Promise.packaged_task()
+        pair: PackagedTask[tuple[str, str, str]] = Promise.packaged_task()
         # It'd be nice to have automatic tuple unpacking continuations
-        callback = lambda a, b, c: pair[1]((a, b, c))  # noqa: E731
+        callback = lambda a, b, c: pair[1]((a or 'Untitled', b, c))  # noqa: E731
         if plugin.on_open_uri_async(uri, callback):
             result: PackagedTask[sublime.View | None] = Promise.packaged_task()
             pair[0].then(lambda tup: self.open_scratch_buffer(*tup, uri, r, flags, group)).then(result[1])
@@ -1546,21 +1546,18 @@ class Session(APIHandler, TransportCallbacks):
 
     def open_scratch_buffer(
         self,
-        title: str | None,
+        title: str,
         content: str,
         syntax: str,
         uri: DocumentUri,
         r: Range | None,
         flags: sublime.NewFileFlags = sublime.NewFileFlags.NONE,
         group: int = -1,
-    ) -> Promise[sublime.View | None]:
-        task: PackagedTask[sublime.View | None] = Promise.packaged_task()
+    ) -> Promise[sublime.View]:
+        task: PackagedTask[sublime.View] = Promise.packaged_task()
         promise, resolve = task
 
         def continue_on_main_thread() -> None:
-            if title is None:
-                resolve(None)
-                return
             if group > -1:
                 self.window.focus_group(group)
             view = self.window.new_file(syntax=syntax, flags=flags)
@@ -1570,7 +1567,7 @@ class Session(APIHandler, TransportCallbacks):
             view.set_name(title)
             view.run_command("append", {"characters": content})
             view.set_read_only(True)
-            self._on_sheet_opened(view.sheet(), uri, r).then(resolve)
+            self._on_sheet_opened(view.sheet(), uri, r).then(lambda _: resolve(view))
 
         sublime.set_timeout(continue_on_main_thread)
         return promise

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1528,6 +1528,8 @@ class Session(APIHandler, TransportCallbacks):
         if plugin.on_open_uri_async(uri, callback):
             return promise.then(lambda tup: self.open_scratch_buffer(*tup, flags, group)) \
                 .then(lambda view: self._on_sheet_opened(view.sheet(), uri, r))
+        # resolve unused promise
+        resolve(('', '', ''))
         return None
 
     def open_scratch_buffer(

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -172,6 +172,7 @@ from typing import TypeVar
 from typing import Union
 from typing_extensions import TypeAlias
 from typing_extensions import TypeGuard
+from urllib.parse import urldefrag
 from weakref import WeakSet
 import itertools
 import mdpopups
@@ -1578,7 +1579,8 @@ class Session(APIHandler, TransportCallbacks):
         self, sheet: sublime.Sheet | None, uri: DocumentUri, r: Range | None
     ) -> Promise[sublime.View | None]:
         if sheet and (view := sheet.view()):
-            view.settings().set('lsp_uri', uri)  # Preserve original URI given by the language server
+            uri_no_fragment = urldefrag(uri).url
+            view.settings().set('lsp_uri', uri_no_fragment)
             if r:
                 center_selection(view, r)
             return Promise.resolve(view)

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1522,12 +1522,12 @@ class Session(APIHandler, TransportCallbacks):
     ) -> Promise[sublime.View | None] | None:
         # I cannot type-hint an unpacked tuple
         pair: PackagedTask[tuple[str, str, str]] = Promise.packaged_task()
+        promise, resolve = pair
         # It'd be nice to have automatic tuple unpacking continuations
-        callback = lambda a, b, c: pair[1]((a or 'untitled', b, c))  # noqa: E731
+        callback = lambda a, b, c: resolve((a or 'untitled', b, c))  # noqa: E731
         if plugin.on_open_uri_async(uri, callback):
-            result: PackagedTask[sublime.View | None] = Promise.packaged_task()
-            pair[0].then(lambda tup: self.open_scratch_buffer(*tup, uri, r, flags, group)).then(result[1])
-            return result[0]
+            return promise.then(lambda tup: self.open_scratch_buffer(*tup, flags, group)) \
+                .then(lambda view: self._on_sheet_opened(view.sheet(), uri, r))
         return None
 
     def open_scratch_buffer(
@@ -1535,8 +1535,6 @@ class Session(APIHandler, TransportCallbacks):
         title: str,
         content: str,
         syntax: str,
-        uri: DocumentUri | None = None,
-        r: Range | None = None,
         flags: sublime.NewFileFlags = sublime.NewFileFlags.NONE,
         group: int = -1,
     ) -> Promise[sublime.View]:
@@ -1553,19 +1551,15 @@ class Session(APIHandler, TransportCallbacks):
             view.set_name(title)
             view.run_command("append", {"characters": content})
             view.set_read_only(True)
-            self._on_sheet_opened(view.sheet(), uri, r)
             resolve(view)
 
         sublime.set_timeout(continue_on_main_thread)
         return promise
 
-    def _on_sheet_opened(
-        self, sheet: sublime.Sheet | None, uri: DocumentUri | None, r: Range | None
-    ) -> sublime.View | None:
+    def _on_sheet_opened(self, sheet: sublime.Sheet | None, uri: DocumentUri, r: Range | None) -> sublime.View | None:
         if sheet and (view := sheet.view()):
-            if uri:
-                uri_no_fragment = urldefrag(uri).url
-                view.settings().set('lsp_uri', uri_no_fragment)
+            uri_no_fragment = urldefrag(uri).url
+            view.settings().set('lsp_uri', uri_no_fragment)
             if r:
                 center_selection(view, r)
             return view


### PR DESCRIPTION
This is a bit rushed fix so might need to have another, more thorough, look.

Problem:

When following the [migration guide](https://lsp.sublimetext.io/migrating_to_lsp_plugin/#13-replace-on_open_uri_async-with-uri_handler) and using `session.open_scratch_buffer`, the `_on_sheet_opened` was called [two](https://github.com/sublimelsp/LSP/blob/9c689ccbfbdf62f29b44a57fbdcf409752c7558b/plugin/core/sessions.py#L1479-L1479) [times](https://github.com/sublimelsp/LSP/blob/9c689ccbfbdf62f29b44a57fbdcf409752c7558b/plugin/core/sessions.py#L1572-L1572). Once with the `uri` provided by the handler and then overridden with the original `uri`.

Remove the `_on_sheet_opened` call chained to the handler - if handler uses `session.open_scratch_buffer` then it is not needed. When handler doesn't use `session.open_scratch_buffer` then this might be problematic to not call it though...

(Another issue is that when following the migration guide the types are not validating because `session.open_scratch_buffer` returns `View` while `uri_handler` wants `sheet` so there is extra `then` needed to convert the return value.)