### PR TITLE
Fix lsp_code_lens command executing last code lens on cancel

### DIFF
--- a/plugin/code_lens.py
+++ b/plugin/code_lens.py
@@ -171,10 +171,7 @@ class LspCodeLensCommand(LspTextCommand):
     def on_select(self, commands: list[tuple[str, Command]], index: int) -> None:
         if index == -1:
             return
-        try:
-            session_name, command = commands[index]
-        except IndexError:
-            return
+        session_name, command = commands[index]
         args = {
             "session_name": session_name,
             "command_name": command["command"],

--- a/plugin/code_lens.py
+++ b/plugin/code_lens.py
@@ -169,6 +169,8 @@ class LspCodeLensCommand(LspTextCommand):
         return False
 
     def on_select(self, commands: list[tuple[str, Command]], index: int) -> None:
+        if index == -1:
+            return
         try:
             session_name, command = commands[index]
         except IndexError:


### PR DESCRIPTION
When `Window.show_quick_panel` is cancelled with <kbd>Esc</kbd>, it returns the index `-1` to the callback function. This would accidentally cause the last code lens in the list to be executed, because indexing a list with `-1` returns the last list item in Python.