### PR TITLE
run handlers after responding instead of from set_timeout_async

### DIFF
--- a/plugin/api.py
+++ b/plugin/api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from ..protocol import LSPAny
 from .core.constants import ST_STORAGE_PATH
 from .core.logging import exception_log
+from .core.promise import Promise
 from .core.protocol import Response
 from .core.settings import client_configs
 from .core.types import method2attr
@@ -17,8 +18,10 @@ from typing import Any
 from typing import Callable
 from typing import Final
 from typing import final
+from typing import Tuple
 from typing import TYPE_CHECKING
 from typing import TypeVar
+from typing import Union
 from typing_extensions import deprecated
 import inspect
 import sublime
@@ -29,7 +32,6 @@ if TYPE_CHECKING:
     from ..protocol import ExecuteCommandParams
     from .core.collections import DottedDict
     from .core.constants import MarkdownLangMap
-    from .core.promise import Promise
     from .core.protocol import ClientNotification
     from .core.protocol import ClientRequest
     from .core.protocol import ClientResponse
@@ -58,6 +60,8 @@ UriHandler = Callable[['DocumentUri', sublime.NewFileFlags], 'Promise[sublime.Sh
 # Decorator needs a dedicated type with `Any` as the first parameter representing `Self` to make its
 # implementation happy. I couldn't find a better way (Concatenate and ParamSpec don't seem to help here).
 UriHandlerForDecorator = Callable[[Any, 'DocumentUri', sublime.NewFileFlags], 'Promise[sublime.Sheet | None]']
+PostResponseCallback = Callable[[], None]
+RequestHandlerResponse = Union[Promise[R], Tuple[Promise[R], PostResponseCallback]]
 
 
 g_plugins: dict[str, type[AbstractPlugin | LspPlugin]] = {}
@@ -221,7 +225,7 @@ def notification_handler(method: str) -> Callable[[Callable[[Any, P], None]], Ca
 
 def request_handler(
     method: str
-) -> Callable[[Callable[[Any, P], Promise[R]]], Callable[[Any, P, int], Promise[Response[R]]]]:
+) -> Callable[[Callable[[Any, P], RequestHandlerResponse]], Callable[[Any, P, int], Promise[Response[R]]]]:
     """
     Decorator to mark a method as a handler for a specific LSP request.
 
@@ -240,12 +244,17 @@ def request_handler(
     :returns:   A decorator that registers the function as a request handler.
     """
 
-    def decorator(func: Callable[[Any, P], Promise[R]]) -> Callable[[Any, P, int], Promise[Response[R]]]:
+    def decorator(func: Callable[[Any, P], RequestHandlerResponse]) -> Callable[[Any, P, int], Promise[Response[R]]]:
 
         @wraps(func)
         def wrapper(self: Any, params: P, request_id: int) -> Promise[Response[Any]]:
-            promise = func(self, params)
-            return promise.then(lambda result: Response(request_id, result))
+            promise_or_tuple = func(self, params)
+            if isinstance(promise_or_tuple, tuple):
+                promise, post_request_callback = promise_or_tuple
+            else:
+                promise = promise_or_tuple
+                post_request_callback = None
+            return promise.then(lambda result: Response(request_id, result, post_request_callback))
 
         setattr(wrapper, HANDLER_MARKER, method)
         return wrapper

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -16,6 +16,7 @@ from typing_extensions import NotRequired
 from typing_extensions import TypeAlias
 
 if TYPE_CHECKING:
+    from plugin.api import PostResponseCallback
     import sublime
 
 INT_MAX = 2**31 - 1
@@ -319,11 +320,14 @@ class Error(Exception):
 
 class Response(Generic[P]):
 
-    __slots__ = ('request_id', 'result')
+    __slots__ = ('request_id', 'result', 'post_response_callback')
 
-    def __init__(self, request_id: str | int, result: P) -> None:
+    def __init__(
+        self, request_id: str | int, result: P, post_response_callback: PostResponseCallback | None = None
+    ) -> None:
         self.request_id = request_id
         self.result = result
+        self.post_response_callback = post_response_callback
 
     def to_payload(self) -> ResponseMessage:
         return {

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -86,6 +86,7 @@ from ..api import AbstractPlugin
 from ..api import APIHandler
 from ..api import LspPlugin
 from ..api import notification_handler
+from ..api import PostResponseCallback
 from ..api import request_handler
 from ..diagnostics import DiagnosticsIdentifier
 from ..diagnostics import DiagnosticsStorage
@@ -1970,7 +1971,7 @@ class Session(APIHandler, TransportCallbacks):
         ).then(itemgetter(0))
 
     @request_handler('workspace/codeLens/refresh')
-    def on_workspace_code_lens_refresh(self, _: None) -> Promise[None]:
+    def on_workspace_code_lens_refresh(self, _: None) -> tuple[Promise[None], PostResponseCallback]:
 
         def continue_after_response() -> None:
             visible_session_buffers, not_visible_session_buffers = self.session_buffers_by_visibility()
@@ -1979,11 +1980,10 @@ class Session(APIHandler, TransportCallbacks):
             for session_buffer in not_visible_session_buffers:
                 session_buffer.set_pending_refresh(RequestFlags.CODE_LENS)
 
-        sublime.set_timeout_async(continue_after_response)
-        return Promise.resolve(None)
+        return (Promise.resolve(None), continue_after_response)
 
     @request_handler('workspace/semanticTokens/refresh')
-    def on_workspace_semantic_tokens_refresh(self, _: None) -> Promise[None]:
+    def on_workspace_semantic_tokens_refresh(self, _: None) -> tuple[Promise[None], PostResponseCallback]:
 
         def continue_after_response() -> None:
             visible_session_buffers, not_visible_session_buffers = self.session_buffers_by_visibility()
@@ -1995,11 +1995,10 @@ class Session(APIHandler, TransportCallbacks):
             for session_buffer in not_visible_session_buffers:
                 session_buffer.set_pending_refresh(RequestFlags.SEMANTIC_TOKENS)
 
-        sublime.set_timeout_async(continue_after_response)
-        return Promise.resolve(None)
+        return (Promise.resolve(None), continue_after_response)
 
     @request_handler('workspace/inlayHint/refresh')
-    def on_workspace_inlay_hint_refresh(self, _: None) -> Promise[None]:
+    def on_workspace_inlay_hint_refresh(self, _: None) -> tuple[Promise[None], PostResponseCallback]:
 
         def continue_after_response() -> None:
             visible_session_buffers, not_visible_session_buffers = self.session_buffers_by_visibility()
@@ -2011,13 +2010,11 @@ class Session(APIHandler, TransportCallbacks):
             for session_buffer in not_visible_session_buffers:
                 session_buffer.set_pending_refresh(RequestFlags.INLAY_HINT)
 
-        sublime.set_timeout_async(continue_after_response)
-        return Promise.resolve(None)
+        return (Promise.resolve(None), continue_after_response)
 
     @request_handler('workspace/diagnostic/refresh')
-    def on_workspace_diagnostic_refresh(self, _: None) -> Promise[None]:
-        sublime.set_timeout_async(self._refresh_diagnostics)
-        return Promise.resolve(None)
+    def on_workspace_diagnostic_refresh(self, _: None) -> tuple[Promise[None], PostResponseCallback]:
+        return (Promise.resolve(None), self._refresh_diagnostics)
 
     def _refresh_diagnostics(self) -> None:
         visible_session_buffers, not_visible_session_buffers = self.session_buffers_by_visibility()
@@ -2053,7 +2050,7 @@ class Session(APIHandler, TransportCallbacks):
             mgr.on_diagnostics_updated()
 
     @request_handler('client/registerCapability')
-    def on_client_register_capability(self, params: RegistrationParams) -> Promise[None]:
+    def on_client_register_capability(self, params: RegistrationParams) -> tuple[Promise[None], PostResponseCallback]:
         new_diagnostics_provider = False
         new_workspace_diagnostics_provider = False
         for registration in params["registrations"]:
@@ -2099,8 +2096,7 @@ class Session(APIHandler, TransportCallbacks):
             if new_workspace_diagnostics_provider:
                 self.do_workspace_diagnostics_async()
 
-        sublime.set_timeout_async(continue_after_response)
-        return Promise.resolve(None)
+        return (Promise.resolve(None), continue_after_response)
 
     @request_handler('client/unregisterCapability')
     def on_client_unregister_capability(self, params: UnregistrationParams) -> Promise[None]:
@@ -2371,6 +2367,8 @@ class Session(APIHandler, TransportCallbacks):
     def send_response(self, response: Response[P]) -> None:
         self._logger.outgoing_response(response.request_id, response.result)
         self.send_payload(response.to_payload())
+        if response.post_response_callback:
+            response.post_response_callback()
 
     def send_error_response(self, request_id: int | str, error: Error) -> None:
         self._logger.outgoing_error_response(request_id, error)


### PR DESCRIPTION
I thought hard how to avoid set_timeout_async but still run handler after responding and this is the solution.

Request handler can return a `tuple(Promise, callback)` instead of `Promise` to run `callback` right after responding, without posting a new task with `set_timeout_async`.

Fixes #2926 