### PR TITLE
Add link to Civet LSP

### DIFF
--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -60,6 +60,10 @@ Follow installation instructions on [LSP-clangd](https://github.com/sublimelsp/L
 
 Follow installation instructions on [LSP-OmniSharp](https://github.com/sublimelsp/LSP-OmniSharp).
 
+## Civet
+
+Follow installation instructions in the [Civet Sublime Text package](https://github.com/DanielXMoore/Civet/tree/main/lsp/sublime).
+
 ## Clojure
 
 1. Download [clojure-lsp](https://clojure-lsp.io/installation/).


### PR DESCRIPTION
[Civet](https://civet.dev) is a language that compiles to TypeScript. We just tested Civet's LSP in Sublime; see [these demo screens](https://github.com/DanielXMoore/Civet/pull/2111). So thought it might help to add to this list.