### PR TITLE
fix project overrides getting lost on saving global configs

### DIFF
--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -99,6 +99,7 @@ class WindowConfigManager:
                 self.all[name] = updated_config
                 configs_recreated.append(updated_config)
             elif stored_config.settings != updated_config.settings:
+                stored_config.settings = updated_config.settings
                 configs_with_changed_settings.append(updated_config)
         # project_settings no longer contains config_names that were handled above.
         for name, config in project_settings.items():
@@ -118,6 +119,7 @@ class WindowConfigManager:
                     self.all[name] = updated_config
                     configs_recreated.append(updated_config)
                 elif stored_config.settings != updated_config.settings:
+                    stored_config.settings = updated_config.settings
                     configs_with_changed_settings.append(updated_config)
         if notify_listeners:
             if configs_with_changed_settings:

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -30,6 +30,10 @@ class WindowConfigChangeListener(ABC):
     def on_configs_changed(self, configs: list[ClientConfig]) -> None:
         raise NotImplementedError
 
+    @abstractmethod
+    def on_server_settings_changed(self, configs: list[ClientConfig]) -> None:
+        raise NotImplementedError
+
 
 class WindowConfigManager:
     def __init__(self, window: sublime.Window, global_configs: dict[str, ClientConfig]) -> None:
@@ -75,7 +79,8 @@ class WindowConfigManager:
     def _reload_configs(self, updated_config_name: str | None = None, notify_listeners: bool = False) -> None:
         project_data = self._window.project_data()
         project_settings = project_data.get("settings", {}).get("LSP", {}) if isinstance(project_data, dict) else {}
-        updated_configs: list[ClientConfig] = []
+        configs_with_changed_settings: list[ClientConfig] = []
+        configs_recreated: list[ClientConfig] = []
         if updated_config_name is None:
             self.all.clear()
         for name, config in self._global_configs.items():
@@ -88,9 +93,14 @@ class WindowConfigManager:
                 overrides = {}
             if name in self._disabled_for_session:
                 overrides["enabled"] = False
+            stored_config = self.all.get(name)
             updated_config = ClientConfig.from_config(config, overrides)
-            self.all[name] = updated_config
-            updated_configs.append(updated_config)
+            if not stored_config or stored_config != updated_config:
+                self.all[name] = updated_config
+                configs_recreated.append(updated_config)
+            elif stored_config.settings != updated_config.settings:
+                configs_with_changed_settings.append(updated_config)
+        # project_settings no longer contains config_names that were handled above.
         for name, config in project_settings.items():
             if updated_config_name and updated_config_name != name:
                 continue
@@ -99,13 +109,23 @@ class WindowConfigManager:
                 config["enabled"] = False
             try:
                 updated_config = ClientConfig.from_dict(name, config)
-                self.all[name] = updated_config
-                updated_configs.append(updated_config)
             except Exception as ex:
+                updated_config = None
                 exception_log(f"failed to load project-only configuration {name}", ex)
+            if updated_config:
+                stored_config = self.all.get(name)
+                if not stored_config or stored_config != updated_config:
+                    self.all[name] = updated_config
+                    configs_recreated.append(updated_config)
+                elif stored_config.settings != updated_config.settings:
+                    configs_with_changed_settings.append(updated_config)
         if notify_listeners:
-            for listener in self._change_listeners:
-                listener.on_configs_changed(updated_configs)
+            if configs_with_changed_settings:
+                for listener in self._change_listeners:
+                    listener.on_server_settings_changed(configs_with_changed_settings)
+            if configs_recreated:
+                for listener in self._change_listeners:
+                    listener.on_configs_changed(configs_recreated)
 
     def enable_config(self, config_name: str) -> None:
         if not self._reenable_disabled_for_session(config_name):

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -24,10 +24,6 @@ class LspSettingsChangeListener(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def on_server_settings_changed(self, config_name: str, settings: DottedDict) -> None:
-        raise NotImplementedError
-
-    @abstractmethod
     def on_userprefs_updated(self) -> None:
         raise NotImplementedError
 
@@ -94,13 +90,7 @@ class ClientConfigs:
             # handle this
             return
         self.external[name] = config
-        if stored_config := self.all.get(name):
-            if stored_config != config:
-                self.update_config(name, config)
-            elif stored_config.settings != config.settings:
-                self.on_server_settings_changed(name, config.settings)
-        else:
-            self.update_config(name, config)
+        self.update_config(name, config)
 
     def update_configs(self) -> None:
         if _settings_registration is None:
@@ -125,11 +115,6 @@ class ClientConfigs:
     def update_config(self, name: str, config: ClientConfig) -> None:
         self.all[name] = config
         self._notify_clients_listener(name)
-
-    def on_server_settings_changed(self, name: str, settings: DottedDict) -> None:
-        self.all[name].settings = settings
-        if self._listener:
-            self._listener.on_server_settings_changed(name, settings)
 
     def _set_enabled(self, config_name: str, is_enabled: bool) -> None:
         from ..api import get_plugin
@@ -181,15 +166,7 @@ def _on_server_configs_changed(settings_registration: SettingsRegistration) -> N
     if _configs_registration is None:
         return
     for name, config_dict in settings_registration.settings.to_dict().items():
-        if not isinstance(config_dict, dict):
-            continue
-        if stored_config := client_configs.all.get(name):
-            config = ClientConfig.from_dict(name, config_dict)
-            if stored_config != config:
-                client_configs.update_config(name, config)
-            elif stored_config.settings != config.settings:
-                client_configs.on_server_settings_changed(name, config.settings)
-        else:
+        if isinstance(config_dict, dict):
             client_configs.update_config(name, ClientConfig.from_dict(name, config_dict))
 
 

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -65,7 +65,6 @@ import sublime
 import threading
 
 if TYPE_CHECKING:
-    from .collections import DottedDict
     from .tree_view import TreeViewSheet
 
 
@@ -560,6 +559,11 @@ class WindowManager(Manager, WindowConfigChangeListener, ViewStatusHandler):
         config_names = [config.name for config in configs]
         sublime.set_timeout_async(lambda: self.restart_sessions_async(config_names))
 
+    def on_server_settings_changed(self, configs: list[ClientConfig]) -> None:
+        for config in configs:
+            if session := self.get_session(config.name):
+                session.on_server_settings_changed(config.settings)
+
     # --- Implements ViewStatusHandler ---------------------------------------------------------------------------------
 
     @override
@@ -627,11 +631,6 @@ class WindowRegistry(LspSettingsChangeListener):
     def on_client_config_updated(self, config_name: str | None = None) -> None:
         for wm in self._windows.values():
             wm.get_config_manager().update(config_name)
-
-    def on_server_settings_changed(self, config_name: str, settings: DottedDict) -> None:
-        for wm in self._windows.values():
-            if session := wm.get_session(config_name):
-                session.on_server_settings_changed(settings)
 
     def on_userprefs_updated(self) -> None:
         for wm in self._windows.values():


### PR DESCRIPTION
I've discovered a bug with saving  LSP packages preferences.

After making any change in `settings` and saving, we'd send `workspace/didChangeConfiguration` to the server without including project overrides.

To reproduce:

1. Set in project settings:
```jsonc
{
    "settings": {
        "LSP": {
            "LSP-pyright": {
                "settings": {
                    "pyright.dev_environment": "sublime_text"
                }
            }
        }
    }
}
```
2. Open `Preferences: LSP-pyright Settings`
3. Change (add/remove) some other key in `settings`
4. Save

We'd send updated configuration without `pyright.dev_environment`.

The issue was that we've evaluated whether config has changed too early (in `ClientConfigs`). We have to let `WindowConfigManager` evaluate that after merging project overrides and then notify session about changes from within `WindowManager`.
  