### PR TITLE
Focus view on open file URI from hover

### DIFF
--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -317,7 +317,7 @@ class LspHoverCommand(LspTextCommand):
             pass
         elif scheme == 'file':
             if window := self.view.window():
-                open_file_uri(window, uri)
+                open_file_uri(window, uri).then(lambda view: window.focus_view(view) if view else None)
         elif scheme == CODE_ACTION_SCHEME:
             session_name, version, action = decode_code_action_uri(uri)
             if version == self.view.change_count() and (session := self.session_by_name(session_name)):


### PR DESCRIPTION
If a link with a `file` URI in the hover popup is clicked, and the file is already open in the editor, seemingly nothing happens because `open_file_uri` does not automatically focus the resulting view.

I think it's expected to focus the view, and that is also more consistent, because in case the file was not open in the editor before, it will automatically take focus when newly opened by ST.