### PR TITLE
Only request documentLink after changes if underline enabled

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -213,16 +213,12 @@
   // customize the color.
   "hover_highlight_style": "",
 
-  // Highlight style of links to internal or external resources, like another text
-  // document or a web site. Link navigation is implemented via the popup on mouse hover.
+  // Highlight style of links to internal or external resources, for example another
+  // file or a website. Link navigation is implemented via the popup on mouse hover.
   // Valid values are:
-  // "underline"
-  // "none" - disables special highlighting, but still allows to navigate links in the
-  //          hover popup
-  // "disabled" - disables highlighting and the hover popup for links
-  // Note that depending on the syntax and color scheme, some internet URLs may still be
-  // underlined via regular syntax highlighting.
-  "link_highlight_style": "underline",
+  // "underline" - draw links with underline decoration
+  // "" - don't draw links with underline decoration
+  "link_highlight_style": "",
 
   // Enable semantic highlighting in addition to standard syntax highlighting.
   // Note: Must be supported by the language server and also requires a special rule in

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -213,7 +213,7 @@
         "command": "lsp_symbol_references"
       },
       {
-        "caption": "LSP: Follow Link",
+        "caption": "LSP: Open Link",
         "command": "lsp_open_link"
       }
     ]

--- a/plugin/api.py
+++ b/plugin/api.py
@@ -225,7 +225,7 @@ def notification_handler(method: str) -> Callable[[Callable[[Any, P], None]], Ca
 
 def request_handler(
     method: str
-) -> Callable[[Callable[[Any, P], RequestHandlerResponse]], Callable[[Any, P, int], Promise[Response[R]]]]:
+) -> Callable[[Callable[[Any, P], RequestHandlerResponse]], Callable[[Any, P, int], Promise[Response[R]]]]:  # pyright: ignore[reportInvalidTypeVarUse]
     """
     Decorator to mark a method as a handler for a specific LSP request.
 

--- a/plugin/core/url.py
+++ b/plugin/core/url.py
@@ -20,11 +20,13 @@ import sys
 if TYPE_CHECKING:
     from ...protocol import CodeAction
     from ...protocol import Command
+    from ...protocol import DocumentLink
     from ...protocol import DocumentUri
     from ...protocol import URI
     import sublime
 
 CODE_ACTION_SCHEME = 'code-action'
+DOCUMENT_LINK_SCHEME = 'document-link'
 
 
 def normalize_uri(uri: DocumentUri) -> DocumentUri:
@@ -121,3 +123,16 @@ def decode_code_action_uri(uri: URI) -> tuple[str, int, Command | CodeAction]:
     session_name, version, data = uri[len(CODE_ACTION_SCHEME) + 1:].split('/')
     action = cast('Command | CodeAction', json.loads(urlsafe_b64decode(data.encode()).decode()))
     return session_name, int(version), action
+
+
+def encode_document_link_uri(session_name: str, version: int, link: DocumentLink) -> URI:
+    return f'{DOCUMENT_LINK_SCHEME}:{session_name}/{version}/{urlsafe_b64encode(json.dumps(link).encode()).decode()}'
+
+
+def decode_document_link_uri(uri: URI) -> tuple[str, int, DocumentLink]:
+    scheme = parse_uri(uri)[0]
+    if scheme != DOCUMENT_LINK_SCHEME:
+        raise ValueError(f'Unsupported URI scheme: {scheme}')
+    session_name, version, data = uri[len(DOCUMENT_LINK_SCHEME) + 1:].split('/')
+    link = cast('DocumentLink', json.loads(urlsafe_b64decode(data.encode()).decode()))
+    return session_name, int(version), link

--- a/plugin/document_link.py
+++ b/plugin/document_link.py
@@ -5,6 +5,7 @@ from .core.open import open_in_browser
 from .core.protocol import Request
 from .core.registry import get_position
 from .core.registry import LspTextCommand
+from .core.settings import userprefs
 from .core.url import parse_uri
 from .core.views import range_to_region
 from .core.views import text_document_identifier
@@ -22,11 +23,22 @@ class LspOpenLinkCommand(LspTextCommand):
 
     capability = 'documentLinkProvider'
 
-    def run(self, edit: sublime.Edit, event: dict | None = None) -> None:
-        sublime.set_timeout_async(lambda: self._run_async(event))
+    def is_enabled(self, event: dict | None = None, point: int | None = None) -> bool:
+        if not super().is_enabled(event, point):
+            return False
+        if userprefs().link_highlight_style == 'underline':
+            if (position := get_position(self.view, event, point)) is not None:
+                if session := self.best_session(self.capability, position):
+                    if sv := session.session_view_for_view_async(self.view):
+                        return sv.session_buffer.get_document_link_at_point(self.view, position) is not None
+            return False
+        return True
 
-    def _run_async(self, event: dict | None) -> None:
-        if (position := get_position(self.view, event)) is not None:
+    def run(self, edit: sublime.Edit, event: dict | None = None, point: int | None = None) -> None:
+        sublime.set_timeout_async(lambda: self._run_async(event, point))
+
+    def _run_async(self, event: dict | None, point: int | None) -> None:
+        if (position := get_position(self.view, event, point)) is not None:
             if session := self.best_session(self.capability, position):
                 session.send_request_async(
                     Request.documentLink({'textDocument': text_document_identifier(self.view)}, self.view),
@@ -34,9 +46,7 @@ class LspOpenLinkCommand(LspTextCommand):
                 )
 
     def _on_response_async(self, session: Session, point: int, response: list[DocumentLink] | None) -> None:
-        if not response:
-            return
-        for link in response:
+        for link in response or []:
             if range_to_region(link['range'], self.view).contains(point):
                 if (uri := link.get('target')) is not None:
                     self._open_uri_async(session, uri)
@@ -44,6 +54,8 @@ class LspOpenLinkCommand(LspTextCommand):
                     request = Request.resolveDocumentLink(link, self.view)
                     session.send_request_async(request, partial(self._on_resolved_async, session))
                 return
+        if window := self.view.window():
+            window.status_message('No link available')
 
     def _on_resolved_async(self, session: Session, response: DocumentLink) -> None:
         if uri := response.get('target'):

--- a/plugin/document_link.py
+++ b/plugin/document_link.py
@@ -1,51 +1,60 @@
 from __future__ import annotations
 
-from .core.logging import debug
 from .core.open import open_file_uri
 from .core.open import open_in_browser
 from .core.protocol import Request
 from .core.registry import get_position
 from .core.registry import LspTextCommand
+from .core.url import parse_uri
+from .core.views import range_to_region
+from .core.views import text_document_identifier
+from functools import partial
 from typing import TYPE_CHECKING
+import sublime
 
 if TYPE_CHECKING:
     from ..protocol import DocumentLink
     from ..protocol import URI
-    import sublime
+    from .core.sessions import Session
 
 
 class LspOpenLinkCommand(LspTextCommand):
+
     capability = 'documentLinkProvider'
 
-    def is_enabled(self, event: dict | None = None, point: int | None = None) -> bool:
-        if not super().is_enabled(event, point):
-            return False
-        if position := get_position(self.view, event):
-            if session := self.best_session(self.capability, position):
-                if sv := session.session_view_for_view_async(self.view):
-                    return sv.session_buffer.get_document_link_at_point(self.view, position) is not None
-        return False
-
     def run(self, edit: sublime.Edit, event: dict | None = None) -> None:
-        if position := get_position(self.view, event):
+        sublime.set_timeout_async(lambda: self._run_async(event))
+
+    def _run_async(self, event: dict | None) -> None:
+        if (position := get_position(self.view, event)) is not None:
             if session := self.best_session(self.capability, position):
-                if sv := session.session_view_for_view_async(self.view):
-                    if link := sv.session_buffer.get_document_link_at_point(self.view, position):
-                        if (target := link.get("target")) is not None:
-                            self.open_target(target)
-                        elif session.has_capability("documentLinkProvider.resolveProvider"):
-                            request = Request.resolveDocumentLink(link, self.view)
-                            session.send_request_async(request, self._on_resolved_async)
-                        else:
-                            debug("DocumentLink.target is missing, but the server doesn't support documentLink/resolve")
+                session.send_request_async(
+                    Request.documentLink({'textDocument': text_document_identifier(self.view)}, self.view),
+                    partial(self._on_response_async, session, position)
+                )
 
-    def _on_resolved_async(self, response: DocumentLink) -> None:
-        if target := response.get("target"):
-            self.open_target(target)
+    def _on_response_async(self, session: Session, point: int, response: list[DocumentLink] | None) -> None:
+        if not response:
+            return
+        for link in response:
+            if range_to_region(link['range'], self.view).contains(point):
+                if (uri := link.get('target')) is not None:
+                    self._open_uri_async(session, uri)
+                elif session.has_capability('documentLinkProvider.resolveProvider'):
+                    request = Request.resolveDocumentLink(link, self.view)
+                    session.send_request_async(request, partial(self._on_resolved_async, session))
+                return
 
-    def open_target(self, target: URI) -> None:
-        if target.startswith("file:"):
+    def _on_resolved_async(self, session: Session, response: DocumentLink) -> None:
+        if uri := response.get('target'):
+            self._open_uri_async(session, uri)
+
+    def _open_uri_async(self, session: Session, uri: URI) -> None:
+        scheme = parse_uri(uri)[0]
+        if scheme == 'file':
             if window := self.view.window():
-                open_file_uri(window, target)
+                open_file_uri(window, uri)
+        elif scheme.lower() in {'http', 'https'} or (not scheme and uri.startswith('www.')):
+            open_in_browser(uri)
         else:
-            open_in_browser(target)
+            session.open_uri_async(uri)

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -549,16 +549,13 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         if key == "lsp.signature_help_available" and operator == sublime.QueryOperator.EQUAL:
             return operand == bool(not self.view.is_popup_visible() and self._get_signature_help_session())
         if key == "lsp.link_available" and operator == sublime.QueryOperator.EQUAL:
-            position = get_position(self.view)
-            if position is None:
+            if userprefs().link_highlight_style != 'underline':
                 return not operand
-            session = self.session_async('documentLinkProvider', position)
-            if not session:
-                return not operand
-            session_view = session.session_view_for_view_async(self.view)
-            if not session_view:
-                return not operand
-            return operand == bool(session_view.session_buffer.get_document_link_at_point(self.view, position))
+            if (position := get_position(self.view)) is not None and \
+                    (session := self.session_async('documentLinkProvider', position)) and \
+                    (session_view := session.session_view_for_view_async(self.view)):
+                return operand == bool(session_view.session_buffer.get_document_link_at_point(self.view, position))
+            return not operand
         return None
 
     @requires_session

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -25,6 +25,9 @@ from .core.registry import windows
 from .core.settings import userprefs
 from .core.url import CODE_ACTION_SCHEME
 from .core.url import decode_code_action_uri
+from .core.url import decode_document_link_uri
+from .core.url import DOCUMENT_LINK_SCHEME
+from .core.url import encode_document_link_uri
 from .core.url import parse_uri
 from .core.views import format_diagnostics_for_html
 from .core.views import FORMAT_MARKED_STRING
@@ -35,6 +38,7 @@ from .core.views import make_command_link
 from .core.views import minihtml
 from .core.views import range_to_region
 from .core.views import show_lsp_popup
+from .core.views import text_document_identifier
 from .core.views import text_document_position_params
 from .core.views import unpack_href_location
 from .core.views import update_lsp_popup
@@ -92,6 +96,7 @@ class LspHoverCommand(LspTextCommand):
         super().__init__(view)
         self._base_dir: str | None = None
         self._image_resolver = None
+        self._document_link_cache: tuple[str, int, list[DocumentLink]] = ('', -1, [])
 
     def run(
         self,
@@ -108,7 +113,7 @@ class LspHoverCommand(LspTextCommand):
             return
         self._base_dir = wm.get_project_path(self.view.file_name() or "")
         self._hover_responses: list[tuple[Hover, MarkdownLangMap | None]] = []
-        self._document_links: list[DocumentLink] = []
+        self._document_link: tuple[str, int, DocumentLink] | None = None
         self._actions_by_config: dict[str, list[Command | CodeAction]] = {}
         self._diagnostics_by_config: Sequence[tuple[SessionBufferProtocol, Sequence[Diagnostic]]] = []
         # TODO: For code actions it makes more sense to use the whole selection under mouse (if available)
@@ -119,9 +124,8 @@ class LspHoverCommand(LspTextCommand):
             if not listener:
                 return
             if not only_diagnostics:
+                self.request_document_link_async(listener, hover_point)
                 self.request_symbol_hover_async(listener, hover_point)
-                if userprefs().link_highlight_style in {"underline", "none"}:
-                    self.request_document_link_async(listener, hover_point)
             self._diagnostics_by_config = listener.get_diagnostics_async(
                 hover_point, userprefs().show_diagnostics_severity_level)
             if self._diagnostics_by_config:
@@ -143,10 +147,9 @@ class LspHoverCommand(LspTextCommand):
     def request_symbol_hover_async(self, listener: AbstractViewListener, point: int) -> None:
         hover_promises: list[Promise[ResolvedHover]] = []
         language_maps: list[MarkdownLangMap | None] = []
+        request = Request('textDocument/hover', text_document_position_params(self.view, point), self.view)
         for session in listener.sessions_async('hoverProvider'):
-            hover_promises.append(session.send_request_task(
-                Request("textDocument/hover", text_document_position_params(self.view, point), self.view)
-            ))
+            hover_promises.append(session.send_request_task(request))
             language_maps.append(session.markdown_language_id_to_st_syntax_map())
         Promise.all(hover_promises).then(partial(self._on_all_settled, listener, point, language_maps))
 
@@ -172,36 +175,46 @@ class LspHoverCommand(LspTextCommand):
         self.show_hover(listener, point, only_diagnostics=False)
 
     def request_document_link_async(self, listener: AbstractViewListener, point: int) -> None:
-        link_promises: list[Promise[DocumentLink | None]] = []
-        for sv in listener.session_views_async():
-            if not sv.has_capability_async("documentLinkProvider"):
-                continue
-            link = sv.session_buffer.get_document_link_at_point(sv.view, point)
-            if link is None:
-                continue
-            if link.get("target"):
-                link_promises.append(Promise.resolve(link))
-            elif sv.has_capability_async("documentLinkProvider.resolveProvider"):
-                link_promises.append(
-                    sv.session.send_request_task(Request.resolveDocumentLink(link, sv.view))
-                    .then(partial(self._on_resolved_link, sv.session_buffer)))
-        if link_promises:
-            Promise.all(link_promises).then(partial(self._on_all_document_links_resolved, listener, point))
+        if session := self.best_session('documentLinkProvider', point):
+            if sv := session.session_view_for_view_async(self.view):
+                session_name = session.config.name
+                version = self.view.change_count()
+                if userprefs().link_highlight_style == 'underline':
+                    # If underline for links is enabled, textDocument/documentLink is requested after each buffer change
+                    if link := sv.session_buffer.get_document_link_at_point(self.view, point):
+                        self._document_link = (session_name, version, link)
+                elif self._document_link_cache[0] == session_name and self._document_link_cache[1] == version:
+                    # Use cache from previous hover if the result is not outdated
+                    self._process_cached_document_links_async(point)
+                else:
+                    session.send_request_async(
+                        Request.documentLink({'textDocument': text_document_identifier(self.view)}, self.view),
+                        partial(self._on_document_link_response_async, listener, point, version, session_name)
+                    )
 
-    def _on_resolved_link(
-        self, session_buffer: SessionBufferProtocol, link: DocumentLink | Error
-    ) -> DocumentLink | None:
-        if isinstance(link, Error):
-            return None
-        session_buffer.update_document_link(link)
-        return link
-
-    def _on_all_document_links_resolved(
-        self, listener: AbstractViewListener, point: int, links: list[DocumentLink | None]
+    def _on_document_link_response_async(
+        self,
+        listener: AbstractViewListener,
+        point: int,
+        version: int,
+        session_name: str,
+        response: list[DocumentLink] | None
     ) -> None:
-        if document_links := list(filter(None, links)):
-            self._document_links = document_links
-            self.show_hover(listener, point, only_diagnostics=False)
+        self._document_link_cache = (session_name, version, response or [])
+        self._process_cached_document_links_async(point)
+        self.show_hover(listener, point, only_diagnostics=False)
+
+    def _process_cached_document_links_async(self, point: int) -> None:
+        for link in self._document_link_cache[2]:
+            if range_to_region(link['range'], self.view).contains(point):
+                session_name = self._document_link_cache[0]
+                version = self._document_link_cache[1]
+                self._document_link = (session_name, version, link)
+                return
+
+    def _on_link_resolved_async(self, link: DocumentLink) -> None:
+        if uri := link.get('target'):
+            self._on_navigate(uri)
 
     def _handle_code_actions(
         self,
@@ -221,22 +234,19 @@ class LspHoverCommand(LspTextCommand):
         return " | ".join(actions) if actions else ""
 
     def link_content_and_range(self) -> tuple[str, sublime.Region | None]:
-        if len(self._document_links) > 1:
-            combined_region = range_to_region(self._document_links[0]["range"], self.view)
-            for link in self._document_links[1:]:
-                combined_region = combined_region.cover(range_to_region(link["range"], self.view))
-            if all(link.get("target") for link in self._document_links):
-                return '<a href="quick-panel:DocumentLink">Follow Link…</a>', combined_region
-            return "Follow Link…", combined_region
-        if len(self._document_links) == 1:
-            link = self._document_links[0]
-            target = link.get("target")
-            label = "Open in Browser" if target and target.startswith(("http:", "https:")) else "Open Link"
-            title = link.get("tooltip")
-            tooltip = f' title="{html.escape(title)}"' if title else ""
-            region = range_to_region(link["range"], self.view)
-            return f'<a href="{html.escape(target)}"{tooltip}>{label}</a>' if target else label, region
-        return "", None
+        if self._document_link is None:
+            return "", None
+        session_name, version, link = self._document_link
+        region = range_to_region(link['range'], self.view)
+        title = link.get('tooltip')
+        tooltip = f' title="{html.escape(title)}"' if title else ""
+        if (uri := link.get('target')) is not None:
+            label = "Open in Browser" if uri.startswith(('http:', 'https:')) else "Open Link"
+            uri = html.escape(uri)
+        else:
+            label = "Open Link"
+            uri = encode_document_link_uri(session_name, version, link)
+        return f'<a href="{uri}"{tooltip}>{label}</a>', region
 
     def hover_content(self) -> str:
         contents: list[str] = []
@@ -323,16 +333,12 @@ class LspHoverCommand(LspTextCommand):
             if version == self.view.change_count() and (session := self.session_by_name(session_name)):
                 sublime.set_timeout_async(lambda: session.run_code_action_async(action, progress=True, view=self.view))
                 self.view.hide_popup()
-        elif uri == "quick-panel:DocumentLink":
-            if window := self.view.window():
-                targets = [link["target"] for link in self._document_links]  # pyright: ignore
-
-                def on_select(targets: list[str], idx: int) -> None:
-                    if idx > -1:
-                        self._on_navigate(targets[idx])
-
-                window.show_quick_panel(
-                    [parse_uri(target)[1] for target in targets], partial(on_select, targets), placeholder="Open Link")
+        elif scheme == DOCUMENT_LINK_SCHEME:
+            session_name, version, link = decode_document_link_uri(uri)
+            if version == self.view.change_count() and (session := self.session_by_name(session_name)) and \
+                    session.has_capability('documentLinkProvider.resolveProvider'):
+                request = Request.resolveDocumentLink(link, self.view)
+                sublime.set_timeout_async(lambda: session.send_request_async(request, self._on_link_resolved_async))
         elif is_location_href(uri):
             session_name, uri, row, col_utf16 = unpack_href_location(uri)
             if session := self.session_by_name(session_name):
@@ -384,6 +390,7 @@ class LspToggleHoverPopupsCommand(sublime_plugin.WindowCommand):
 
 
 class LspCopyTextCommand(sublime_plugin.WindowCommand):
+
     def run(self, text: str) -> None:
         sublime.set_clipboard(text)
         text_length = len(text)

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -233,7 +233,7 @@ class SessionBuffer:
             if request_flags & RequestFlags.INLAY_HINT:
                 self.do_inlay_hints_async(view)
             self.do_code_lenses_async(view)
-            if userprefs().link_highlight_style in {"underline", "none"}:
+            if userprefs().link_highlight_style == 'underline':
                 self._do_document_link_async(view, version)
             self.session.notify_plugin_on_session_buffer_change(self)
 
@@ -453,7 +453,7 @@ class SessionBuffer:
             self.do_document_diagnostic_async(view, version)
             if request_flags & RequestFlags.SEMANTIC_TOKENS:
                 self.do_semantic_tokens_async(view)
-            if userprefs().link_highlight_style in {"underline", "none"}:
+            if userprefs().link_highlight_style == 'underline':
                 self._do_document_link_async(view, version)
             if request_flags & RequestFlags.INLAY_HINT:
                 self.do_inlay_hints_async(view)

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -485,7 +485,11 @@ class SessionBuffer:
         self.session.do_workspace_diagnostics_async()
 
     def on_userprefs_changed_async(self) -> None:
-        self._redraw_document_links_async()
+        if userprefs().link_highlight_style == 'underline':
+            if view := self.some_view():
+                self._do_document_link_async(view, view.change_count())
+        else:
+            self._redraw_document_links_async()
         if userprefs().semantic_highlighting:
             self.set_pending_refresh(RequestFlags.SEMANTIC_TOKENS)
         else:

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -653,11 +653,12 @@
             "link_highlight_style": {
               "enum": [
                 "underline",
-                "none",
-                "disabled"
+                "none", // For backwards-compatibility, same as ""
+                "disabled", // For backwards-compatibility, same as ""
+                ""
               ],
-              "default": "underline",
-              "markdownDescription": "Highlight style of links to internal or external resources, like another text document or a web site."
+              "default": "",
+              "markdownDescription": "Highlight style of links to internal or external resources, for example another file or a website."
             },
             "semantic_highlighting": {
               "type": "boolean",


### PR DESCRIPTION
I though about how LSP handles `textDocument/documentLink` request, and I think we can make it more efficient than the current implementation. Currently, this request is made after each change while typing. This is necessary if links should be underlined in the editor.

But the main interaction with links is via the hover popup which shows a "Open Link" (or "Open in Browser") link at the bottom of the popup, if applicable. But the mouse hover probably happens significantly less often than the (debounced) changes from typing, and that means if the user has disabled the underline for links in the LSP settings, we do a lot of unnecessary `textDocument/documentLink` requests. In that case it would be sufficient to only do that request on demand when the hover popup is requested. I have implemented that in this PR, including result caching if there are multiple hover actions without a buffer change in between. Also the `DocumentLink`s are only resolved (if necessary) when the link in the popup is clicked. If the underline style is used, requests are still made after each change, like before.

Currently there are 3 different options for the "link_highlight_style" setting, one of it is "disabled" which disabled the DocumentLink functionality completely. I think with this refactoring the "disabled" option isn't needed anymore, because if the underline style isn't used, the requests are only done on demand, so it should have any performance impact. In case someone really wants to disable any DocumentLink functionality, they of course still can do that via "disabled_capabilities" in the server config.

I think the on-demand-request strategy for DocumentLink is also a good reason to not use the underline style by default, so I changed that default value (probably worth to mention that in the change log, if we want to do this change).

There is only small drawback, but I think it's only an extremely niche use case; there is a `lsp.link_available` context for key bindings that would check whether there is a link on the given point (caret position). This was implemented for a special user request to use the same key binding for opening a DocumentLink and for the "Goto Definition" feature. So you could use both of these commands with the same key trigger, but prioritize `lsp_open_link` while using the mentioned "context" to fall back to "Goto Definition" if there is no link at the given point. But if we don't trigger the DocumentLink request after each change, we can't tell that anymore. So this only works like before if the "link_highlight_style" setting is set to "underline" now.

---

I've also rewritten the `lsp_open_link` command to always fetch the latest links from the server via `textDocument/documentLink` request, which is needed now in case of the underline style being disabled.

And another change from this PR is that the hover popup only uses the result from one documentLinkProvider session now (in case of multi-session setup), which means that if you click on "Open Link" and there are multiple session with that capability, we don't show the quick panel anymore to select one of the results. I assume that if there are multiple sessions, the link targets would be the same anyway, so I think we can save that additional step and the quick panel wasn't really useful.