### PR TITLE
fix ClientConfig equality check

### DIFF
--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -768,15 +768,18 @@ class ClientConfig:
     """
 
     CONFIG_KEYS: Final[set[str]] = {
+        'auto_complete_selector',
         'command',
         'diagnostics_mode',
         'disabled_capabilities',
         'enabled',
         'env',
         'experimental_capabilities',
+        'file_watcher',
         'initialization_options',
         'markdown_language_map',
         'priority_selector',
+        'semantic_tokens',
         'selector',
         'settings',
         'tcp_port',

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -27,6 +27,7 @@ from typing import Any
 from typing import Callable
 from typing import cast
 from typing import Dict
+from typing import Final
 from typing import Generator
 from typing import Iterable
 from typing import List
@@ -766,6 +767,22 @@ class ClientConfig:
     file) are accessible through attribute access (`.foo`).
     """
 
+    CONFIG_KEYS: Final[set[str]] = {
+        'command',
+        'diagnostics_mode',
+        'disabled_capabilities',
+        'enabled',
+        'env',
+        'experimental_capabilities',
+        'initialization_options',
+        'markdown_language_map',
+        'priority_selector',
+        'selector',
+        'settings',
+        'tcp_port',
+    }
+    """Server configuration keys that we have dedicated handling for."""
+
     def __init__(
         self,
         *,
@@ -853,13 +870,13 @@ class ClientConfig:
         # Transformed mapping that uses tuples instead of lists for mdpopups.
         self.resolved_markdown_language_map: MarkdownLangMap | None = None
         self.markdown_language_map = markdown_language_map  # use the setter to populate resolved_markdown_language_map
-        # For accessing configuration keys not explicitly handled above. Accessable through dunder methods below.
         self._settings_registration = settings_registration
         if isinstance(all_settings, dict):
             self._all_settings = all_settings
-            # Exclude 'settings' because it shouldn't be considered when ClientConfig is checked for equality
-            if 'settings' in self._all_settings:
-                del self._all_settings['settings']
+            # Only retain server configuration keys that we don't have dedicated properties for.
+            for key in self.CONFIG_KEYS:
+                if key in self._all_settings:
+                    del self._all_settings[key]
         else:
             self._all_settings = {}
         self._view_status_handler = default_status_view_handler
@@ -872,6 +889,7 @@ class ClientConfig:
 
     @property
     def root_settings(self) -> dict[str, Any]:
+        """Provides access to configuration keys that are not explicitly exposed on ClientConfig."""
         return self._all_settings
 
     @property

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -1185,9 +1185,13 @@ class ClientConfig:
         return "{}({})".format(self.__class__.__name__, ", ".join(items))
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, ClientConfig):
+        if not isinstance(other, ClientConfig) or self.name != other.name or self._all_settings != other._all_settings:
             return False
-        return self.name == other.name and self._all_settings == other._all_settings
+        for k, v in self.__dict__.items():
+            # "settings" are not considered when checking for equality
+            if not k.startswith("_") and k != 'settings' and v != getattr(other, k):
+                return False
+        return True
 
     def __hash__(self) -> int:
         return hash(self.__repr__())

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -889,7 +889,7 @@ class ClientConfig:
 
     @property
     def root_settings(self) -> dict[str, Any]:
-        """Provides access to configuration keys that are not explicitly exposed on ClientConfig."""
+        """Provides access to server configuration keys that are not explicitly exposed on ClientConfig."""
         return self._all_settings
 
     @property

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -1185,7 +1185,7 @@ class ClientConfig:
         return "{}({})".format(self.__class__.__name__, ", ".join(items))
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, ClientConfig) or self.name != other.name or self._all_settings != other._all_settings:
+        if not isinstance(other, ClientConfig) or self._all_settings != other._all_settings:
             return False
         for k, v in self.__dict__.items():
             # "settings" are not considered when checking for equality

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -781,7 +781,7 @@ class ClientConfig:
         'settings',
         'tcp_port',
     }
-    """Server configuration keys that we have dedicated handling for."""
+    """All server configuration keys that we recognize and have handling for."""
 
     def __init__(
         self,

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from .test_mocks import TEST_CONFIG
 from LSP.plugin.core.collections import DottedDict
 from LSP.plugin.core.transports import TransportConfig
 from LSP.plugin.core.types import ClientConfig
@@ -69,6 +70,33 @@ class ConfigParsingTests(DeferrableTestCase):
         original_path = environ.copy()['PATH']
         resolved_path = launch_config.env['PATH']
         self.assertEqual(resolved_path, f'/a/b/{pathsep}{original_path}')
+
+    def test_are_equal(self) -> None:
+        config1 = ClientConfig.from_config(TEST_CONFIG, {})
+        config2 = ClientConfig.from_config(TEST_CONFIG, {})
+        self.assertEqual(config1, config2)
+
+    def test_are_with_different_settings1(self) -> None:
+        config1 = ClientConfig.from_config(TEST_CONFIG, {})
+        config2 = ClientConfig.from_config(TEST_CONFIG, {'settings': {'foo': 'bar'}})
+        self.assertEqual(config1, config2)
+
+    def test_are_with_different_settings2(self) -> None:
+        config1 = ClientConfig.from_config(TEST_CONFIG, {})
+        config2 = ClientConfig.from_config(TEST_CONFIG, {})
+        config2.settings.set('foo', 'bar')
+        self.assertEqual(config1, config2)
+
+    def test_are_not_equal_selector(self) -> None:
+        config1 = ClientConfig.from_config(TEST_CONFIG, {})
+        config2 = ClientConfig.from_config(TEST_CONFIG, {'selector': 'other'})
+        self.assertNotEqual(config1, config2)
+
+    def test_are_not_equal_initialization_options(self) -> None:
+        config1 = ClientConfig.from_config(TEST_CONFIG, {})
+        config2 = ClientConfig.from_config(TEST_CONFIG, {})
+        config2.initialization_options.set('foo', 'bar')
+        self.assertNotEqual(config1, config2)
 
     def test_disabled_capabilities(self) -> None:
         settings = {

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -76,12 +76,12 @@ class ConfigParsingTests(DeferrableTestCase):
         config2 = ClientConfig.from_config(TEST_CONFIG, {})
         self.assertEqual(config1, config2)
 
-    def test_are_with_different_settings1(self) -> None:
+    def test_are_with_different_settings(self) -> None:
         config1 = ClientConfig.from_config(TEST_CONFIG, {})
         config2 = ClientConfig.from_config(TEST_CONFIG, {'settings': {'foo': 'bar'}})
         self.assertEqual(config1, config2)
 
-    def test_are_with_different_settings2(self) -> None:
+    def test_are_with_different_settings_after_create(self) -> None:
         config1 = ClientConfig.from_config(TEST_CONFIG, {})
         config2 = ClientConfig.from_config(TEST_CONFIG, {})
         config2.settings.set('foo', 'bar')
@@ -92,7 +92,7 @@ class ConfigParsingTests(DeferrableTestCase):
         config2 = ClientConfig.from_config(TEST_CONFIG, {'selector': 'other'})
         self.assertNotEqual(config1, config2)
 
-    def test_are_not_equal_initialization_options(self) -> None:
+    def test_are_not_equal_initialization_options_after_create(self) -> None:
         config1 = ClientConfig.from_config(TEST_CONFIG, {})
         config2 = ClientConfig.from_config(TEST_CONFIG, {})
         config2.initialization_options.set('foo', 'bar')


### PR DESCRIPTION
In a3bd1df the ClientConfig equality check was simplified to checking `_all_settings` but that's not correct in case someone changes `config.initialization_options` (or any other explicitly exposed property) after config was created because `_all_settings` wouldn't get updated in that case.

In practice this was maybe not a problem (or not always a problem) because before checking for equality the new config would be re-created from latest sublime settings so both `_all_settings` and `initialization_options` would change in sync.