### PR TITLE
Always notify correctly on config changes including in projects

### DIFF
--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -12,7 +12,6 @@ from abc import abstractmethod
 from collections import deque
 from datetime import datetime
 from datetime import timedelta
-from typing import Any
 from typing import Generator
 from typing import Literal
 from typing import TYPE_CHECKING
@@ -89,41 +88,33 @@ class WindowConfigManager:
             for name, config in self._global_configs.items():
                 if updated_config_name and updated_config_name != name:
                     continue
-                yield resolve_global_config(name, config)
+                overrides = project_settings.pop(name, None)
+                if not isinstance(overrides, dict):
+                    overrides = {}
+                if name in self._disabled_for_session:
+                    overrides["enabled"] = False
+                stored_config = self.all.get(name)
+                updated_config = ClientConfig.from_config(config, overrides)
                 seen_config_names.add(name)
+                yield compare_configs(stored_config, updated_config)
             for name, config in project_settings.items():
                 if updated_config_name and updated_config_name != name:
                     continue
-                if new_config := resolve_project_config(name, config):
-                    yield new_config
-                    seen_config_names.add(name)
+                if name in self._disabled_for_session:
+                    config["enabled"] = False
+                try:
+                    updated_config = ClientConfig.from_dict(name, config)
+                except Exception as ex:
+                    updated_config = None
+                    exception_log(f"failed to load project-only configuration {name}", ex)
+                if updated_config:
+                    stored_config = self.all.get(name)
+                    yield compare_configs(stored_config, updated_config)
+                seen_config_names.add(name)
             # Configs in "all" that were not seen are gone.
             removed_names = self.all.keys() - seen_config_names
             for name in removed_names:
                 yield ('removed', self.all[name])
-
-        def resolve_global_config(name: str, config: ClientConfig) -> tuple[ChangeType, ClientConfig]:
-            overrides = project_settings.pop(name, None)
-            if not isinstance(overrides, dict):
-                overrides = {}
-            if name in self._disabled_for_session:
-                overrides["enabled"] = False
-            stored_config = self.all.get(name)
-            updated_config = ClientConfig.from_config(config, overrides)
-            return compare_configs(stored_config, updated_config)
-
-        def resolve_project_config(name: str, config: dict[str, Any]) -> tuple[ChangeType, ClientConfig] | None:
-            if name in self._disabled_for_session:
-                config["enabled"] = False
-            try:
-                updated_config = ClientConfig.from_dict(name, config)
-            except Exception as ex:
-                updated_config = None
-                exception_log(f"failed to load project-only configuration {name}", ex)
-            if updated_config:
-                stored_config = self.all.get(name)
-                return compare_configs(stored_config, updated_config)
-            return None
 
         def compare_configs(
             old_config: ClientConfig | None, new_config: ClientConfig

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from .logging import debug
 from .logging import exception_log
 from .logging import printf
 from .types import ClientConfig
@@ -13,7 +12,9 @@ from abc import abstractmethod
 from collections import deque
 from datetime import datetime
 from datetime import timedelta
+from typing import Any
 from typing import Generator
+from typing import Literal
 from typing import TYPE_CHECKING
 from weakref import WeakSet
 
@@ -22,6 +23,9 @@ if TYPE_CHECKING:
 
 RETRY_MAX_COUNT = 5
 RETRY_COUNT_TIMEDELTA = timedelta(minutes=3)
+
+
+ChangeType = Literal['added', 'removed', 'root_changed', 'settings_changed', 'unchanged']
 
 
 class WindowConfigChangeListener(ABC):
@@ -79,33 +83,36 @@ class WindowConfigManager:
     def _reload_configs(self, updated_config_name: str | None = None, notify_listeners: bool = False) -> None:
         project_data = self._window.project_data()
         project_settings = project_data.get("settings", {}).get("LSP", {}) if isinstance(project_data, dict) else {}
-        configs_with_changed_settings: list[ClientConfig] = []
-        configs_recreated: list[ClientConfig] = []
-        if updated_config_name is None:
-            self.all.clear()
-        for name, config in self._global_configs.items():
-            if updated_config_name and updated_config_name != name:
-                continue
+
+        def resolve_configs(updated_config_name: str | None = None) -> Generator[tuple[ChangeType, ClientConfig]]:
+            seen_config_names: set[str] = set()
+            for name, config in self._global_configs.items():
+                if updated_config_name and updated_config_name != name:
+                    continue
+                yield resolve_global_config(name, config)
+                seen_config_names.add(name)
+            for name, config in project_settings.items():
+                if updated_config_name and updated_config_name != name:
+                    continue
+                if new_config := resolve_project_config(name, config):
+                    yield new_config
+                    seen_config_names.add(name)
+            # Configs in "all" that were not seen are gone.
+            removed_names = self.all.keys() - seen_config_names
+            for name in removed_names:
+                yield ('removed', self.all[name])
+
+        def resolve_global_config(name: str, config: ClientConfig) -> tuple[ChangeType, ClientConfig]:
             overrides = project_settings.pop(name, None)
-            if isinstance(overrides, dict):
-                debug("applying .sublime-project override for", name)
-            else:
+            if not isinstance(overrides, dict):
                 overrides = {}
             if name in self._disabled_for_session:
                 overrides["enabled"] = False
             stored_config = self.all.get(name)
             updated_config = ClientConfig.from_config(config, overrides)
-            if not stored_config or stored_config != updated_config:
-                self.all[name] = updated_config
-                configs_recreated.append(updated_config)
-            elif stored_config.settings != updated_config.settings:
-                stored_config.settings = updated_config.settings
-                configs_with_changed_settings.append(updated_config)
-        # project_settings no longer contains config_names that were handled above.
-        for name, config in project_settings.items():
-            if updated_config_name and updated_config_name != name:
-                continue
-            debug("loading project-only configuration", name)
+            return compare_configs(stored_config, updated_config)
+
+        def resolve_project_config(name: str, config: dict[str, Any]) -> tuple[ChangeType, ClientConfig] | None:
             if name in self._disabled_for_session:
                 config["enabled"] = False
             try:
@@ -115,19 +122,49 @@ class WindowConfigManager:
                 exception_log(f"failed to load project-only configuration {name}", ex)
             if updated_config:
                 stored_config = self.all.get(name)
-                if not stored_config or stored_config != updated_config:
-                    self.all[name] = updated_config
-                    configs_recreated.append(updated_config)
-                elif stored_config.settings != updated_config.settings:
-                    stored_config.settings = updated_config.settings
-                    configs_with_changed_settings.append(updated_config)
+                return compare_configs(stored_config, updated_config)
+            return None
+
+        def compare_configs(
+            old_config: ClientConfig | None, new_config: ClientConfig
+        ) -> tuple[ChangeType, ClientConfig]:
+            if old_config:
+                if old_config != new_config:
+                    return ('root_changed', new_config)
+                if old_config.settings != new_config.settings:
+                    return ('settings_changed', new_config)
+                return ('unchanged', old_config)
+            return ('added', new_config)
+
+        changes: dict[ChangeType, list[ClientConfig]] = {
+            'added': [],
+            'removed': [],
+            'root_changed': [],
+            'settings_changed': [],
+            'unchanged': []
+        }
+        if updated_config_name:
+            if result := next(resolve_configs(updated_config_name), None):
+                change_type, config = result
+                changes[change_type].append(config)
+                self.all[config.name] = config
+        else:
+            for result in resolve_configs():
+                change_type, config = result
+                changes[change_type].append(config)
+            self.all = {
+                **{c.name: c for c in changes['root_changed']},
+                **{c.name: c for c in changes['settings_changed']},
+                **{c.name: c for c in changes['unchanged']},
+                **{c.name: c for c in changes['added']},
+            }
         if notify_listeners:
-            if configs_with_changed_settings:
+            if changed := changes['settings_changed']:
                 for listener in self._change_listeners:
-                    listener.on_server_settings_changed(configs_with_changed_settings)
-            if configs_recreated:
+                    listener.on_server_settings_changed(changed)
+            if changed := changes['root_changed'] + changes['removed']:
                 for listener in self._change_listeners:
-                    listener.on_configs_changed(configs_recreated)
+                    listener.on_configs_changed(changed)
 
     def enable_config(self, config_name: str) -> None:
         if not self._reenable_disabled_for_session(config_name):

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -24,7 +24,7 @@ RETRY_MAX_COUNT = 5
 RETRY_COUNT_TIMEDELTA = timedelta(minutes=3)
 
 
-ChangeType = Literal['added', 'removed', 'root_changed', 'settings_changed', 'unchanged']
+ConfigChangeType = Literal['added', 'removed', 'root_changed', 'settings_changed', 'unchanged']
 
 
 class WindowConfigChangeListener(ABC):
@@ -83,7 +83,7 @@ class WindowConfigManager:
         project_data = self._window.project_data()
         project_settings = project_data.get("settings", {}).get("LSP", {}) if isinstance(project_data, dict) else {}
 
-        def resolve_configs(updated_config_name: str | None = None) -> Generator[tuple[ChangeType, ClientConfig]]:
+        def resolve_configs(updated_config_name: str | None = None) -> Generator[tuple[ConfigChangeType, ClientConfig]]:
             seen_config_names: set[str] = set()
             for name, config in self._global_configs.items():
                 if updated_config_name and updated_config_name != name:
@@ -118,7 +118,7 @@ class WindowConfigManager:
 
         def compare_configs(
             old_config: ClientConfig | None, new_config: ClientConfig
-        ) -> tuple[ChangeType, ClientConfig]:
+        ) -> tuple[ConfigChangeType, ClientConfig]:
             if old_config:
                 if old_config != new_config:
                     return ('root_changed', new_config)
@@ -127,7 +127,7 @@ class WindowConfigManager:
                 return ('unchanged', old_config)
             return ('added', new_config)
 
-        changes: dict[ChangeType, list[ClientConfig]] = {
+        changes: dict[ConfigChangeType, list[ClientConfig]] = {
             'added': [],
             'removed': [],
             'root_changed': [],

--- a/tests/test_configurations.py
+++ b/tests/test_configurations.py
@@ -2,11 +2,30 @@ from __future__ import annotations
 
 from .test_mocks import DISABLED_CONFIG
 from .test_mocks import TEST_CONFIG
+from copy import deepcopy
+from LSP.plugin import ClientConfig
+from LSP.plugin.core.configurations import WindowConfigChangeListener
 from LSP.plugin.core.configurations import WindowConfigManager
 from unittest import TestCase
 from unittest.mock import MagicMock
 from unittesting import ViewTestCase
 import sublime
+
+PROJECT_TEST_CONFIG_NAME = 'test-project-config'
+PROJECT_TEST_CONFIG = {
+    'enabled': True,
+    'command': [],
+    'selector': 'plain.text'
+}
+
+
+class WindowConfigChangeTestListener(WindowConfigChangeListener):
+
+    def on_configs_changed(self, configs: list[ClientConfig]) -> None:
+        pass
+
+    def on_server_settings_changed(self, configs: list[ClientConfig]) -> None:
+        pass
 
 
 class GlobalConfigManagerTests(TestCase):
@@ -87,3 +106,203 @@ class WindowConfigManagerTests(ViewTestCase):
         # disables config in-memory
         manager.disable_config(DISABLED_CONFIG.name, only_for_session=True)
         self.assertFalse(any(manager.match_view(self.view, [])))
+
+    def test_global_update(self) -> None:
+        change_listener = WindowConfigChangeTestListener()
+        change_listener.on_configs_changed = MagicMock()
+        change_listener.on_server_settings_changed = MagicMock()
+        config = ClientConfig.from_config(TEST_CONFIG, {})
+        global_configs = {config.name: config}
+        manager = WindowConfigManager(self.window, global_configs)
+        manager.add_change_listener(change_listener)
+        manager.update()
+        change_listener.on_configs_changed.assert_not_called()
+        change_listener.on_server_settings_changed.assert_not_called()
+        self.assertIn(config.name, manager.all)
+
+    def test_global_config_not_changed(self) -> None:
+        change_listener = WindowConfigChangeTestListener()
+        change_listener.on_configs_changed = MagicMock()
+        change_listener.on_server_settings_changed = MagicMock()
+        manager = WindowConfigManager(self.window, {TEST_CONFIG.name: TEST_CONFIG})
+        self.assertIn(TEST_CONFIG.name, manager.all)
+        manager.add_change_listener(change_listener)
+        manager.update(TEST_CONFIG.name)
+        change_listener.on_configs_changed.assert_not_called()
+        change_listener.on_server_settings_changed.assert_not_called()
+        self.assertIn(TEST_CONFIG.name, manager.all)
+
+    def test_global_config_settings_changed(self) -> None:
+        change_listener = WindowConfigChangeTestListener()
+        change_listener.on_configs_changed = MagicMock()
+        change_listener.on_server_settings_changed = MagicMock()
+        config = ClientConfig.from_config(TEST_CONFIG, {})
+        manager = WindowConfigManager(self.window, {config.name: config})
+        manager.add_change_listener(change_listener)
+        config.settings.set('foo', 'bar')
+        manager.update(config.name)
+        change_listener.on_configs_changed.assert_not_called()
+        change_listener.on_server_settings_changed.assert_called_once_with([config])
+        self.assertIn(config.name, manager.all)
+
+    def test_global_config_root_changed(self) -> None:
+        change_listener = WindowConfigChangeTestListener()
+        change_listener.on_configs_changed = MagicMock()
+        change_listener.on_server_settings_changed = MagicMock()
+        config = ClientConfig.from_config(TEST_CONFIG, {})
+        manager = WindowConfigManager(self.window, {config.name: config})
+        manager.add_change_listener(change_listener)
+        config.initialization_options.set('foo', 'bar')
+        manager.update(config.name)
+        change_listener.on_configs_changed.assert_called_once_with([config])
+        change_listener.on_server_settings_changed.assert_not_called()
+        self.assertIn(config.name, manager.all)
+
+    def test_global_config_added(self) -> None:
+        change_listener = WindowConfigChangeTestListener()
+        change_listener.on_configs_changed = MagicMock()
+        change_listener.on_server_settings_changed = MagicMock()
+        global_configs = {}
+        manager = WindowConfigManager(self.window, global_configs)
+        manager.add_change_listener(change_listener)
+        global_configs[TEST_CONFIG.name] = TEST_CONFIG
+        manager.update(TEST_CONFIG.name)
+        change_listener.on_configs_changed.assert_not_called()
+        change_listener.on_server_settings_changed.assert_not_called()
+        self.assertIn(TEST_CONFIG.name, manager.all)
+
+    def test_global_config_removed(self) -> None:
+        change_listener = WindowConfigChangeTestListener()
+        change_listener.on_configs_changed = MagicMock()
+        change_listener.on_server_settings_changed = MagicMock()
+        config = ClientConfig.from_config(TEST_CONFIG, {})
+        global_configs = {config.name: config}
+        manager = WindowConfigManager(self.window, global_configs)
+        manager.add_change_listener(change_listener)
+        global_configs.pop(config.name)
+        manager.update()
+        change_listener.on_configs_changed.assert_called_once_with([config])
+        change_listener.on_server_settings_changed.assert_not_called()
+        self.assertNotIn(config.name, manager.all)
+
+    def test_project_update(self) -> None:
+        change_listener = WindowConfigChangeTestListener()
+        change_listener.on_configs_changed = MagicMock()
+        change_listener.on_server_settings_changed = MagicMock()
+        self.window.project_data = MagicMock(return_value={
+            "settings": {
+                "LSP": {
+                    PROJECT_TEST_CONFIG_NAME: deepcopy(PROJECT_TEST_CONFIG)
+                }
+            }
+        })
+        manager = WindowConfigManager(self.window, {})
+        self.assertIn(PROJECT_TEST_CONFIG_NAME, manager.all)
+        manager.add_change_listener(change_listener)
+        manager.update()
+        change_listener.on_configs_changed.assert_not_called()
+        change_listener.on_server_settings_changed.assert_not_called()
+        self.assertIn(PROJECT_TEST_CONFIG_NAME, manager.all)
+
+    def test_project_config_not_changed(self) -> None:
+        change_listener = WindowConfigChangeTestListener()
+        change_listener.on_configs_changed = MagicMock()
+        change_listener.on_server_settings_changed = MagicMock()
+        self.window.project_data = MagicMock(return_value={
+            "settings": {
+                "LSP": {
+                    PROJECT_TEST_CONFIG_NAME: deepcopy(PROJECT_TEST_CONFIG)
+                }
+            }
+        })
+        manager = WindowConfigManager(self.window, {})
+        self.assertIn(PROJECT_TEST_CONFIG_NAME, manager.all)
+        manager.add_change_listener(change_listener)
+        manager.update(PROJECT_TEST_CONFIG_NAME)
+        change_listener.on_configs_changed.assert_not_called()
+        change_listener.on_server_settings_changed.assert_not_called()
+        self.assertIn(PROJECT_TEST_CONFIG_NAME, manager.all)
+
+    def test_project_config_settings_changed(self) -> None:
+        change_listener = WindowConfigChangeTestListener()
+        change_listener.on_configs_changed = MagicMock()
+        change_listener.on_server_settings_changed = MagicMock()
+        config = deepcopy(PROJECT_TEST_CONFIG)
+        self.window.project_data = MagicMock()
+        self.window.project_data.return_value = {
+            "settings": {
+                "LSP": {
+                    PROJECT_TEST_CONFIG_NAME: config
+                }
+            }
+        }
+        manager = WindowConfigManager(self.window, {})
+        manager.add_change_listener(change_listener)
+        config['settings'] = {'foo': 'bar'}
+        manager.update(PROJECT_TEST_CONFIG_NAME)
+        changed_config = manager.all[PROJECT_TEST_CONFIG_NAME]
+        change_listener.on_configs_changed.assert_not_called()
+        change_listener.on_server_settings_changed.assert_called_once_with([changed_config])
+        self.assertIn(PROJECT_TEST_CONFIG_NAME, manager.all)
+
+    def test_project_config_root_changed(self) -> None:
+        change_listener = WindowConfigChangeTestListener()
+        change_listener.on_configs_changed = MagicMock()
+        change_listener.on_server_settings_changed = MagicMock()
+        config = deepcopy(PROJECT_TEST_CONFIG)
+        self.window.project_data = MagicMock()
+        self.window.project_data.return_value = {
+            "settings": {
+                "LSP": {
+                    PROJECT_TEST_CONFIG_NAME: config
+                }
+            }
+        }
+        manager = WindowConfigManager(self.window, {})
+        manager.add_change_listener(change_listener)
+        config['initialization_options'] = {'foo': 'bar'}
+        manager.update(PROJECT_TEST_CONFIG_NAME)
+        self.assertIn(PROJECT_TEST_CONFIG_NAME, manager.all)
+        change_listener.on_configs_changed.assert_called_once_with([manager.all[PROJECT_TEST_CONFIG_NAME]])
+        change_listener.on_server_settings_changed.assert_not_called()
+        self.assertIn(PROJECT_TEST_CONFIG_NAME, manager.all)
+
+    def test_project_config_added(self) -> None:
+        change_listener = WindowConfigChangeTestListener()
+        change_listener.on_configs_changed = MagicMock()
+        change_listener.on_server_settings_changed = MagicMock()
+        manager = WindowConfigManager(self.window, {})
+        manager.add_change_listener(change_listener)
+        self.window.project_data = MagicMock()
+        self.window.project_data.return_value = {
+            "settings": {
+                "LSP": {
+                    PROJECT_TEST_CONFIG_NAME: PROJECT_TEST_CONFIG
+                }
+            }
+        }
+        manager.update()
+        change_listener.on_configs_changed.assert_not_called()
+        change_listener.on_server_settings_changed.assert_not_called()
+        self.assertIn(PROJECT_TEST_CONFIG_NAME, manager.all)
+
+    def test_project_config_removed(self) -> None:
+        change_listener = WindowConfigChangeTestListener()
+        change_listener.on_configs_changed = MagicMock()
+        change_listener.on_server_settings_changed = MagicMock()
+        self.window.project_data = MagicMock()
+        self.window.project_data.return_value = {
+            "settings": {
+                "LSP": {
+                    PROJECT_TEST_CONFIG_NAME: PROJECT_TEST_CONFIG
+                }
+            }
+        }
+        manager = WindowConfigManager(self.window, {})
+        manager.add_change_listener(change_listener)
+        self.window.project_data.return_value = {}
+        manager.update()
+        removed_config = ClientConfig.from_dict(PROJECT_TEST_CONFIG_NAME, PROJECT_TEST_CONFIG)
+        change_listener.on_configs_changed.assert_called_once_with([removed_config])
+        change_listener.on_server_settings_changed.assert_not_called()
+        self.assertNotIn(PROJECT_TEST_CONFIG_NAME, manager.all)


### PR DESCRIPTION
This should properly detect whether only "settings" were updated (which shouldn't restart server) or also other settings (that should result in server restart).

Should handle changes in package, global and project settings.

Fixes case reported in https://github.com/sublimelsp/LSP/pull/2932#issuecomment-4563807717:

> I think there is still another bug that if you modify a server setting in project settings, then the server is restarted (but that also happens on main, so it's not a new bug).

Should also correctly handle cases when project-only server config is removed (should shut down server) but this is probably a rather rare use case.