### PR TITLE
Deprecate process_placeholders argument for apply_text_edits function

### DIFF
--- a/plugin/core/edit.py
+++ b/plugin/core/edit.py
@@ -11,6 +11,7 @@ from ...protocol import TextDocumentEdit
 from ...protocol import TextEdit
 from ...protocol import WorkspaceEdit
 from .logging import debug
+from .logging import printf
 from .promise import Promise
 from .protocol import UINT_MAX
 from typing import Dict
@@ -100,11 +101,14 @@ def apply_text_edits(
     if not edits:
         return Promise.resolve(view)
     if not view.is_valid():
-        print('LSP: ignoring edits due to view not being open')
+        printf('ignoring edits due to view not being open')
         return Promise.resolve(None)
     if process_placeholders:
-        # TODO: remove rust-analyzer specific handling for placeholders in TextEdit, because SnippetTextEdit is now part
-        # of the LSP specs.
+        # Deprecated because SnippetTextEdit is now part of the LSP 3.18 specs.
+        printf(
+            'The "process_placeholders" argument for the apply_text_edits function is deprecated.',
+            'Convert the TextEdit into a SnippetTextEdit instead.'
+        )
         view.run_command(
             'lsp_apply_document_edit',
             {

--- a/plugin/edit.py
+++ b/plugin/edit.py
@@ -19,6 +19,7 @@ from typing import Generator
 from typing import Iterable
 from typing import Tuple
 from typing import TYPE_CHECKING
+from typing_extensions import deprecated
 import operator
 import os
 import re
@@ -176,6 +177,7 @@ class LspApplyTextDocumentEditCommand(sublime_plugin.TextCommand):
             self.view.erase(edit, region)
 
 
+@deprecated('Use the lsp_apply_text_document_edit command instead')
 class LspApplyDocumentEditCommand(sublime_plugin.TextCommand):
     re_placeholder = re.compile(r'\$(0|\{0:([^}]*)\})')
 


### PR DESCRIPTION
Users of this function (LSP-rust-analyzer ?) can convert the TextEdit with placeholder(s) into a SnippetTextEdit instead, which is part of the LSP 3.18 specs. It's pretty simple; just copy the `newText` into `snippet['value']` and also add `snippet['kind'] = "snippet"` - for an example see https://github.com/sublimelsp/LSP-Tinymist/commit/70e6a50771398972a5dc3f2fe57eac9b5035c6a4

Then we can remove the `LspApplyDocumentEditCommand`.