### PR TITLE
type-check all LSP packages

### DIFF
--- a/.github/workflows/test-community-packages.yaml
+++ b/.github/workflows/test-community-packages.yaml
@@ -30,10 +30,10 @@ jobs:
           ln -s ${{ github.workspace }}/LSP lsp_maintainers/repositories/LSP
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
 
       - name: Sync venv and run basedpyright
         run: |
           uv sync
-          uv run basedpyright
+          uv run pyright
         working-directory: lsp_maintainers/repositories

--- a/.github/workflows/test-community-packages.yaml
+++ b/.github/workflows/test-community-packages.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           path: LSP
 
-      - name: Check out lsp_maintainers (feat/test)
+      - name: Check out lsp_maintainers
         uses: actions/checkout@v6
         with:
           repository: sublimelsp/lsp_maintainers

--- a/.github/workflows/test-community-packages.yaml
+++ b/.github/workflows/test-community-packages.yaml
@@ -27,6 +27,7 @@ jobs:
 
       - name: Use checkout of LSP from PR
         run: |
+          rm -rf ${{ github.workspace }}/LSP/tests
           ln -s ${{ github.workspace }}/LSP lsp_maintainers/repositories/LSP
 
       - name: Setup uv

--- a/.github/workflows/test-community-packages.yaml
+++ b/.github/workflows/test-community-packages.yaml
@@ -22,7 +22,7 @@ jobs:
           path: lsp_maintainers
 
       - name: Check out community package repositories
-        run: python3 scripts/checkout-repos.py --exclude LSP --exclude LSP-pyvoice --exclude WolframLanguage
+        run: python3 scripts/checkout-repos.py --preferred-branch ${{ github.head_ref }} --exclude LSP --exclude LSP-pyvoice --exclude WolframLanguage
         working-directory: lsp_maintainers
 
       - name: Use checkout of LSP from PR

--- a/.github/workflows/test-community-packages.yaml
+++ b/.github/workflows/test-community-packages.yaml
@@ -30,7 +30,7 @@ jobs:
           ln -s ${{ github.workspace }}/LSP lsp_maintainers/repositories/LSP
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Sync venv and run basedpyright
         run: |

--- a/.github/workflows/test-community-packages.yaml
+++ b/.github/workflows/test-community-packages.yaml
@@ -26,7 +26,7 @@ jobs:
         run: python3 scripts/checkout-repos.py --exclude LSP
         working-directory: lsp_maintainers
 
-      - name: Use PR checkout of LSP
+      - name: Use checkout of LSP from PR
         run: |
           ln -s ${{ github.workspace }}/LSP lsp_maintainers/repositories/LSP
 

--- a/.github/workflows/test-community-packages.yaml
+++ b/.github/workflows/test-community-packages.yaml
@@ -23,7 +23,7 @@ jobs:
           path: lsp_maintainers
 
       - name: Check out community package repositories
-        run: python3 scripts/checkout-repos.py --exclude LSP
+        run: python3 scripts/checkout-repos.py --exclude LSP --exclude LSP-pyvoice --exclude WolframLanguage
         working-directory: lsp_maintainers
 
       - name: Use checkout of LSP from PR

--- a/.github/workflows/test-community-packages.yaml
+++ b/.github/workflows/test-community-packages.yaml
@@ -1,7 +1,6 @@
 name: Test Community Packages
 
 on:
-  repository_dispatch:
   pull_request:
     branches:
       - main

--- a/.github/workflows/test-community-packages.yaml
+++ b/.github/workflows/test-community-packages.yaml
@@ -28,7 +28,8 @@ jobs:
       - name: Use checkout of LSP from PR
         run: |
           rm -rf ${{ github.workspace }}/LSP/tests
-          ln -s ${{ github.workspace }}/LSP lsp_maintainers/repositories/LSP
+          mv ${{ github.workspace }}/LSP/stubs lsp_maintainers/repositories/stubs
+          mv ${{ github.workspace }}/LSP lsp_maintainers/repositories
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v8.2.0

--- a/.github/workflows/test-community-packages.yaml
+++ b/.github/workflows/test-community-packages.yaml
@@ -27,6 +27,11 @@ jobs:
         run: python3 scripts/checkout-repos.py
         working-directory: lsp_maintainers
 
+      - name: Use PR checkout of LSP
+        run: |
+          rm -rf lsp_maintainers/repositories/LSP
+          ln -s ${{ github.workspace }}/LSP lsp_maintainers/repositories/LSP
+
       - name: Setup uv
         uses: astral-sh/setup-uv@v5
 

--- a/.github/workflows/test-community-packages.yaml
+++ b/.github/workflows/test-community-packages.yaml
@@ -34,8 +34,8 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@v8.2.0
 
-      - name: Sync venv and run basedpyright
+      - name: Sync venv and type check
         run: |
           uv sync
-          uv run pyright
+          uv run basedpyright
         working-directory: lsp_maintainers/repositories

--- a/.github/workflows/test-community-packages.yaml
+++ b/.github/workflows/test-community-packages.yaml
@@ -23,12 +23,11 @@ jobs:
           path: lsp_maintainers
 
       - name: Check out community package repositories
-        run: python3 scripts/checkout-repos.py
+        run: python3 scripts/checkout-repos.py --exclude LSP
         working-directory: lsp_maintainers
 
       - name: Use PR checkout of LSP
         run: |
-          rm -rf lsp_maintainers/repositories/LSP
           ln -s ${{ github.workspace }}/LSP lsp_maintainers/repositories/LSP
 
       - name: Setup uv

--- a/.github/workflows/test-community-packages.yaml
+++ b/.github/workflows/test-community-packages.yaml
@@ -1,0 +1,37 @@
+name: Test Community Packages
+
+on:
+  repository_dispatch:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  type-check:
+    name: Type-check community packages
+    runs-on: macOS-latest
+    steps:
+      - name: Check out PR branch
+        uses: actions/checkout@v6
+        with:
+          path: LSP
+
+      - name: Check out lsp_maintainers (feat/test)
+        uses: actions/checkout@v6
+        with:
+          repository: sublimelsp/lsp_maintainers
+          ref: feat/test
+          path: lsp_maintainers
+
+      - name: Check out community package repositories
+        run: python3 scripts/checkout-repos.py
+        working-directory: lsp_maintainers
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Sync venv and run basedpyright
+        run: |
+          uv sync
+          uv run basedpyright
+        working-directory: lsp_maintainers/repositories

--- a/.github/workflows/test-community-packages.yaml
+++ b/.github/workflows/test-community-packages.yaml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: sublimelsp/lsp_maintainers
-          ref: feat/test
           path: lsp_maintainers
 
       - name: Check out community package repositories

--- a/plugin/api.py
+++ b/plugin/api.py
@@ -432,7 +432,7 @@ class LspPlugin(APIHandler):
         unregister_plugin_impl(cls)
 
     @classmethod
-    def is_applicable_asyncX(cls, context: IsApplicableContext) -> bool:
+    def is_applicable_async(cls, context: IsApplicableContext) -> bool:
         """
         Determine whether the server should run on the view given by `context.view`.
 

--- a/plugin/api.py
+++ b/plugin/api.py
@@ -432,7 +432,7 @@ class LspPlugin(APIHandler):
         unregister_plugin_impl(cls)
 
     @classmethod
-    def is_applicable_async(cls, context: IsApplicableContext) -> bool:
+    def is_applicable_asyncX(cls, context: IsApplicableContext) -> bool:
         """
         Determine whether the server should run on the view given by `context.view`.
 


### PR DESCRIPTION
Workflow that checks out all LSP packages (known to me) + LSP + dependencies and runs basedpyright against those. The choice of type checking rules is a bit arbitrary - we want as many as possible to catch any breaking changes but we don't want to report package's own type issues as errors.

Utilizes script from https://github.com/sublimelsp/lsp_maintainers/blob/main/scripts/checkout-repos.py to check out and run type-checking. I'm using that repository since it has database of some third-party packages that are not in our main lsp repository channel.

A couple of third-party packages are ignored since those are either somewhat broken or I can't get them fixed at the moment.