### PR TITLE
Rename: protocol.Error -> protocol.ErrorResponseException

### DIFF
--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -26,10 +26,10 @@ from .core.promise import Promise
 from .core.protocol import ClientNotification
 from .core.protocol import ClientRequest
 from .core.protocol import ClientResponse
-from .core.protocol import Error
 from .core.protocol import Notification
 from .core.protocol import Request
 from .core.protocol import Response
+from .core.protocol import ResponseErrorException
 from .core.protocol import ServerNotification
 from .core.protocol import ServerRequest
 from .core.protocol import ServerResponse
@@ -59,7 +59,6 @@ __all__ = [
     'ClientResponse',
     'DebouncerNonThreadSafe',
     'DottedDict',
-    'Error',
     'FileWatcher',
     'FileWatcherEvent',
     'FileWatcherEventType',
@@ -76,6 +75,7 @@ __all__ = [
     'Promise',
     'Request',
     'Response',
+    'ResponseErrorException',
     'ServerNotification',
     'ServerRequest',
     'ServerResponse',

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -6,8 +6,8 @@ from ..protocol import CodeActionParams
 from ..protocol import Command
 from ..protocol import Diagnostic
 from .core.aio import run_coroutine
-from .core.protocol import Error
 from .core.protocol import Request
+from .core.protocol import ResponseErrorException
 from .core.registry import LspTextCommand
 from .core.registry import LspWindowCommand
 from .core.registry import windows
@@ -182,7 +182,7 @@ class CodeActionsManager:
                             # Return only results for non-empty lists.
                             (sb.session.config.name, [a for a in response_filter(sb, response) if len(a) > 0])
                         )
-                except Error:
+                except ResponseErrorException:
                     pass
         return results
 
@@ -211,7 +211,7 @@ class CodeActionsManager:
                         session_kinds = get_session_kinds(sb)
                         matching_kinds = get_matching_kinds(code_actions, session_kinds)
                         actions = [a for a in response if a.get('kind') in matching_kinds and not a.get('disabled')]
-                except Error:
+                except ResponseErrorException:
                     pass
                 yield (sb.session.config.name, actions)
 
@@ -413,7 +413,7 @@ class LspCodeActionsCommand(LspTextCommand):
         run_coroutine(run())
 
     def _handle_response_async(self, session_name: str, response: Any) -> None:
-        if isinstance(response, Error):
+        if isinstance(response, ResponseErrorException):
             sublime.error_message(f"{session_name}: {response}")
 
 
@@ -475,7 +475,7 @@ class LspMenuActionCommand(LspWindowCommand, ABC):
                 self._handle_response_async(config_name, response)
 
     def _handle_response_async(self, session_name: str, response: Any) -> None:
-        if isinstance(response, Error):
+        if isinstance(response, ResponseErrorException):
             sublime.error_message(f"{session_name}: {response}")
 
     def _is_cache_valid(self, event: dict | None) -> bool:

--- a/plugin/code_lens.py
+++ b/plugin/code_lens.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from .core.aio import run_on_asyncio_thread
 from .core.constants import CODE_LENS_ENABLED_KEY
-from .core.protocol import Error
 from .core.protocol import ResolvedCodeLens
+from .core.protocol import ResponseErrorException
 from .core.registry import LspTextCommand
 from .core.registry import LspWindowCommand
 from .core.registry import windows
@@ -49,8 +49,8 @@ class CachedCodeLens:
         self.range = HashableRange(data['range'])
         self.cached_command = data.get('command')
 
-    def on_resolve(self, response: CodeLens | Error) -> None:
-        if isinstance(response, Error):
+    def on_resolve(self, response: CodeLens | ResponseErrorException) -> None:
+        if isinstance(response, ResponseErrorException):
             return
         assert is_resolved(response)
         self.data = response

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -20,8 +20,8 @@ from .core.constants import MarkdownLangMap
 from .core.edit import apply_text_edits
 from .core.logging import debug
 from .core.promise import Promise
-from .core.protocol import Error
 from .core.protocol import Request
+from .core.protocol import ResponseErrorException
 from .core.registry import LspTextCommand
 from .core.settings import userprefs
 from .core.views import FORMAT_MARKUP_CONTENT
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
     from .core.sessions import Session
 
 SessionName: TypeAlias = str
-CompletionResponse: TypeAlias = Union[List[CompletionItem], CompletionList, Error, None]
+CompletionResponse: TypeAlias = Union[List[CompletionItem], CompletionList, ResponseErrorException, None]
 ResolvedCompletions: TypeAlias = Tuple[CompletionResponse, 'weakref.ref[Session]']
 CompletionsStore: TypeAlias = Tuple[List[CompletionItem], CompletionItemDefaults]
 
@@ -228,13 +228,13 @@ class QueryCompletionsTask:
         LspSelectCompletionCommand.completions = {}
         items: list[sublime.CompletionItem] = []
         item_defaults: CompletionItemDefaults = {}
-        errors: list[Error] = []
+        errors: list[ResponseErrorException] = []
         flags = self._get_userpref_flags()
         view_settings = self._view.settings()
         include_snippets = view_settings.get("auto_complete_include_snippets") and \
             (self._triggered_manually or view_settings.get("auto_complete_include_snippets_when_typing"))
         for response, weak_session in responses:
-            if isinstance(response, Error):
+            if isinstance(response, ResponseErrorException):
                 errors.append(response)
                 continue
             session = weak_session()
@@ -391,7 +391,7 @@ class LspSelectCompletionCommand(LspTextCommand):
         if session and not item.get('additionalTextEdits'):
             try:
                 item = await session.request(Request.resolveCompletionItem(item, self.view))
-            except Error as error:
+            except ResponseErrorException as error:
                 debug("Error resolving completion item:", error)
         if additional_edits := item.get('additionalTextEdits'):
             await apply_text_edits(self.view, additional_edits)

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -293,7 +293,7 @@ class Request(Generic[P, R]):
         return payload
 
 
-class Error(Exception):
+class ResponseErrorException(Exception):
 
     def __init__(self, code: int, message: str, data: Any = None) -> None:
         super().__init__(message)
@@ -301,8 +301,8 @@ class Error(Exception):
         self.data = data
 
     @classmethod
-    def from_lsp(cls, params: ResponseError) -> Error:
-        return Error(params["code"], params["message"], params.get("data"))
+    def from_lsp(cls, params: ResponseError) -> ResponseErrorException:
+        return ResponseErrorException(params["code"], params["message"], params.get("data"))
 
     def to_lsp(self) -> ResponseError:
         result: ResponseError = {"code": self.code, "message": super().__str__()}
@@ -314,8 +314,8 @@ class Error(Exception):
         return f"{super().__str__()} ({self.code})"
 
     @classmethod
-    def from_exception(cls, ex: Exception) -> Error:
-        return Error(ErrorCodes.InternalError, str(ex))
+    def from_exception(cls, ex: Exception) -> ResponseErrorException:
+        return ResponseErrorException(ErrorCodes.InternalError, str(ex))
 
 
 class Response(Generic[P]):

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -134,7 +134,6 @@ from .promise import Promise
 from .protocol import ClientNotification
 from .protocol import ClientRequest
 from .protocol import ClientResponse
-from .protocol import Error
 from .protocol import JSONRPCMessage
 from .protocol import Notification
 from .protocol import Point
@@ -142,6 +141,7 @@ from .protocol import Request
 from .protocol import ResolvedCodeLens
 from .protocol import Response
 from .protocol import ResponseError
+from .protocol import ResponseErrorException
 from .protocol import ServerNotification
 from .protocol import ServerResponse
 from .settings import globalprefs
@@ -972,7 +972,7 @@ class Logger(ABC):
         pass
 
     @abstractmethod
-    def outgoing_error_response(self, request_id: int | str, error: Error) -> None:
+    def outgoing_error_response(self, request_id: int | str, error: ResponseErrorException) -> None:
         pass
 
     @abstractmethod
@@ -1048,7 +1048,7 @@ class CancellableInflightStreamingRequest(CancellableRequest[R]):
 
     def __init__(self, req_id: int, session: Session) -> None:
         super().__init__(req_id, session)
-        self._queue: asyncio.Queue[R | Error | None] = asyncio.Queue()
+        self._queue: asyncio.Queue[R | ResponseErrorException | None] = asyncio.Queue()
         self._is_streaming = False
 
     @property
@@ -1077,7 +1077,7 @@ class CancellableInflightStreamingRequest(CancellableRequest[R]):
         self._queue.put_nowait(None)
 
     def _on_error(self, error: ResponseError) -> None:
-        self._queue.put_nowait(Error.from_lsp(error))
+        self._queue.put_nowait(ResponseErrorException.from_lsp(error))
 
     def __aiter__(self) -> CancellableInflightStreamingRequest:
         """Stream partial results using the `async for` syntax."""
@@ -1088,7 +1088,7 @@ class CancellableInflightStreamingRequest(CancellableRequest[R]):
         item = await self._queue.get()
         if item is None:
             raise StopAsyncIteration
-        if isinstance(item, Error):
+        if isinstance(item, ResponseErrorException):
             raise item
         return item
 
@@ -1516,7 +1516,7 @@ class Session(APIHandler, TransportCallbacks, TaskContainer):
                 if command_handler := self._plugin.get_command_handler(command_name):
                     return await command_handler(command.get('arguments'))
             else:
-                task: PackagedTask[LSPAny | Error | None] = Promise.packaged_task()
+                task: PackagedTask[LSPAny | ResponseErrorException | None] = Promise.packaged_task()
                 promise, resolve = task
                 if self._plugin.on_pre_server_command(command, lambda: resolve(None)):
                     return cast("LSPAny", await promise)
@@ -1808,10 +1808,12 @@ class Session(APIHandler, TransportCallbacks, TaskContainer):
                 return await self.request(Request("codeAction/resolve", code_action))
         return code_action
 
-    async def _apply_code_action(self, code_action: CodeAction | Error | None, view: sublime.View | None) -> None:
+    async def _apply_code_action(
+        self, code_action: CodeAction | ResponseErrorException | None, view: sublime.View | None
+    ) -> None:
         if not code_action:
             return
-        if isinstance(code_action, Error):
+        if isinstance(code_action, ResponseErrorException):
             # TODO: do something with the error?
             self.window.status_message(f"Failed to apply code action: {code_action}")
             return
@@ -2216,7 +2218,7 @@ class Session(APIHandler, TransportCallbacks, TaskContainer):
                         if is_workspace_full_document_diagnostic_report(diagnostic_report):
                             self.handle_diagnostics_async(uri, identifier, version, diagnostic_report['items'])
                 self.workspace_diagnostics_pending_responses[identifier] = None
-        except Error as e:
+        except ResponseErrorException as e:
             if e.code == LSPErrorCodes.ServerCancelled:
                 if is_diagnostic_server_cancellation_data(e.data) and e.data['retriggerRequest']:
                     # Retrigger the request after a short delay, but don't reset the pending response variable for this
@@ -2360,7 +2362,7 @@ class Session(APIHandler, TransportCallbacks, TaskContainer):
                 response: TextDocumentContentResult = await self.request(
                     Request('workspace/textDocumentContent', {'uri': uri})
                 )
-            except Error as error:
+            except ResponseErrorException as error:
                 sublime.status_message(f"Error getting content: {error}")
                 break
             new_content = response['text'].replace('\r', '')
@@ -2679,7 +2681,7 @@ class Session(APIHandler, TransportCallbacks, TaskContainer):
         def on_error(error: ResponseError) -> None:
             # Future may have been cancelled.
             if not future.done():
-                future.set_exception(Error.from_lsp(error))
+                future.set_exception(ResponseErrorException.from_lsp(error))
 
         self._response_handlers[request_id] = (r, on_result, on_error)
         self._invoke_views(r, "on_request_started_async", request_id, r)
@@ -2745,7 +2747,7 @@ class Session(APIHandler, TransportCallbacks, TaskContainer):
             if future.cancelled():
                 return
             if ex := future.exception():
-                if callable(on_error) and isinstance(ex, Error):
+                if callable(on_error) and isinstance(ex, ResponseErrorException):
                     on_error(ex.to_lsp())
                     return
                 exception_log("Response error is ignored", ex)
@@ -2766,17 +2768,17 @@ class Session(APIHandler, TransportCallbacks, TaskContainer):
         run_on_asyncio_thread(lambda: self.send_request_async(request, on_result, on_error))
 
     @deprecated("use Session.request or Session.stream instead")
-    def send_request_task(self, request: Request[P, R]) -> Promise[R | Error]:
+    def send_request_task(self, request: Request[P, R]) -> Promise[R | ResponseErrorException]:
         task: PackagedTask[Any] = Promise.packaged_task()
         promise, resolver = task
-        self.send_request(request, resolver, lambda x: resolver(Error.from_lsp(x)))
+        self.send_request(request, resolver, lambda x: resolver(ResponseErrorException.from_lsp(x)))
         return promise
 
     @deprecated("use Session.request or Session.stream instead")
-    def send_request_task_2(self, request: Request[P, R]) -> tuple[Promise[R | Error], int]:
-        task: PackagedTask[R | Error] = Promise.packaged_task()
+    def send_request_task_2(self, request: Request[P, R]) -> tuple[Promise[R | ResponseErrorException], int]:
+        task: PackagedTask[R | ResponseErrorException] = Promise.packaged_task()
         promise, resolver = task
-        request_id = self.send_request_async(request, resolver, lambda x: resolver(Error.from_lsp(x)))
+        request_id = self.send_request_async(request, resolver, lambda x: resolver(ResponseErrorException.from_lsp(x)))
         return (promise, request_id)
 
     def cancel_request_async(self, request_id: int) -> None:
@@ -2813,7 +2815,7 @@ class Session(APIHandler, TransportCallbacks, TaskContainer):
         if response.post_response_callback:
             response.post_response_callback()
 
-    async def send_error_response(self, request_id: int | str, error: Error) -> None:
+    async def send_error_response(self, request_id: int | str, error: ResponseErrorException) -> None:
         self._logger.outgoing_error_response(request_id, error)
         await self.send_payload({'jsonrpc': '2.0', 'id': request_id, 'error': error.to_lsp()})
 
@@ -2841,7 +2843,7 @@ class Session(APIHandler, TransportCallbacks, TaskContainer):
                 req_id = payload["id"]
                 self._logger.incoming_request(req_id, method, result)
                 if handler is None:
-                    await self.send_error_response(req_id, Error(ErrorCodes.MethodNotFound, method))
+                    await self.send_error_response(req_id, ResponseErrorException(ErrorCodes.MethodNotFound, method))
                 else:
                     return (handler, result, req_id, "request", method)
             else:
@@ -2890,10 +2892,10 @@ class Session(APIHandler, TransportCallbacks, TaskContainer):
                                 method, result, await handler(result, req_id)
                             )
                         )
-                    except Error as err:
+                    except ResponseErrorException as err:
                         await self.send_error_response(req_id, err)
                     except Exception as ex:
-                        await self.send_error_response(req_id, Error.from_exception(ex))
+                        await self.send_error_response(req_id, ResponseErrorException.from_exception(ex))
                         raise
             except Exception as err:
                 exception_log(f"Error handling {typestr}", err)

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -34,9 +34,9 @@ from .panels import MAX_LOG_LINES_LIMIT_OFF
 from .panels import MAX_LOG_LINES_LIMIT_ON
 from .panels import PanelManager
 from .panels import PanelName
-from .protocol import Error
 from .protocol import Notification
 from .protocol import Point
+from .protocol import ResponseErrorException
 from .sessions import AbstractViewListener
 from .sessions import Logger
 from .sessions import Manager
@@ -699,7 +699,7 @@ class PanelLogger(Logger):
         duration = self._request_time_tracker.end_tracking(request_id, server_initiated=True)
         self.log(self._format_response(">>>", request_id, duration), params)
 
-    def outgoing_error_response(self, request_id: int | str, error: Error) -> None:
+    def outgoing_error_response(self, request_id: int | str, error: ResponseErrorException) -> None:
         if not userprefs().log_server:
             return
         duration = self._request_time_tracker.end_tracking(request_id, server_initiated=True)
@@ -848,7 +848,7 @@ class RemoteLogger(Logger):
             'direction': self.DIRECTION_OUTGOING,
         })
 
-    def outgoing_error_response(self, request_id: int | str, error: Error) -> None:
+    def outgoing_error_response(self, request_id: int | str, error: ResponseErrorException) -> None:
         self._broadcast_json({
             'server': self._server_name,
             'id': request_id,

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from .core.aio import run_coroutine
 from .core.logging import debug
-from .core.protocol import Error
 from .core.protocol import LSPAny
+from .core.protocol import ResponseErrorException
 from .core.registry import LspTextCommand
 from .core.views import first_selection_region
 from .core.views import offset_to_point
@@ -41,7 +41,7 @@ class LspExecuteCommand(LspTextCommand):
         try:
             result: LSPAny = await session.run_command(params, progress=True, view=self.view)
             self.handle_success_async(result, command_name)
-        except Error as error:
+        except ResponseErrorException as error:
             self.handle_error_async(error, command_name)
 
     def handle_success_async(self, result: Any, command_name: str) -> None:
@@ -53,7 +53,7 @@ class LspExecuteCommand(LspTextCommand):
         """
         pass
 
-    def handle_error_async(self, error: Error, command_name: str) -> None:
+    def handle_error_async(self, error: ResponseErrorException, command_name: str) -> None:
         """
         Override this method to handle failed response to workspace/executeCommand.
 

--- a/plugin/formatting.py
+++ b/plugin/formatting.py
@@ -6,7 +6,7 @@ from .code_actions import CodeActionsOnFormatTask
 from .core.aio import run_coroutine
 from .core.collections import DottedDict
 from .core.edit import apply_text_edits
-from .core.protocol import Error
+from .core.protocol import ResponseErrorException
 from .core.registry import LspTextCommand
 from .core.registry import windows
 from .core.settings import userprefs
@@ -225,7 +225,7 @@ class LspFormatDocumentRangeCommand(LspTextCommand):
     async def _run(self) -> None:
         try:
             await format_selection(self.get_listener())
-        except Error as error:
+        except ResponseErrorException as error:
             sublime.status_message(f'Formatting error: {error}')
 
 

--- a/plugin/hierarchy.py
+++ b/plugin/hierarchy.py
@@ -11,8 +11,8 @@ from ..protocol import TypeHierarchyPrepareParams
 from .core.constants import SYMBOL_KINDS
 from .core.paths import simple_path
 from .core.promise import Promise
-from .core.protocol import Error
 from .core.protocol import Request
+from .core.protocol import ResponseErrorException
 from .core.registry import get_position
 from .core.registry import LspTextCommand
 from .core.registry import LspWindowCommand
@@ -102,17 +102,25 @@ def make_data_provider(
     return HierarchyDataProvider(weaksession, request, handler, response)
 
 
-def incoming_calls_handler(response: list[CallHierarchyIncomingCall] | Error | None) -> list[HierarchyItemWrapper]:
-    return [
-        to_hierarchy_data(call['from'], call['fromRanges'][0] if call['fromRanges'] else None) for call in response
-    ] if isinstance(response, list) else []
+def incoming_calls_handler(
+    response: list[CallHierarchyIncomingCall] | ResponseErrorException | None,
+) -> list[HierarchyItemWrapper]:
+    return (
+        [to_hierarchy_data(call['from'], call['fromRanges'][0] if call['fromRanges'] else None) for call in response]
+        if isinstance(response, list)
+        else []
+    )
 
 
-def outgoing_calls_handler(response: list[CallHierarchyOutgoingCall] | Error | None) -> list[HierarchyItemWrapper]:
+def outgoing_calls_handler(
+    response: list[CallHierarchyOutgoingCall] | ResponseErrorException | None,
+) -> list[HierarchyItemWrapper]:
     return [to_hierarchy_data(call['to']) for call in response] if isinstance(response, list) else []
 
 
-def type_hierarchy_handler(response: list[TypeHierarchyItem] | Error | None) -> list[HierarchyItemWrapper]:
+def type_hierarchy_handler(
+    response: list[TypeHierarchyItem] | ResponseErrorException | None,
+) -> list[HierarchyItemWrapper]:
     return [to_hierarchy_data(item) for item in response] if isinstance(response, list) else []
 
 

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -19,8 +19,8 @@ from .core.open import lsp_range_from_uri_fragment
 from .core.open import open_file_uri
 from .core.open import open_in_browser
 from .core.promise import Promise
-from .core.protocol import Error
 from .core.protocol import Request
+from .core.protocol import ResponseErrorException
 from .core.registry import get_position
 from .core.registry import LspTextCommand
 from .core.registry import windows
@@ -60,7 +60,7 @@ if TYPE_CHECKING:
     from .core.sessions import SessionBufferProtocol
 
 SessionName = str
-ResolvedHover = Union[Hover, Error]
+ResolvedHover = Union[Hover, ResponseErrorException]
 
 
 class LinkKind:
@@ -163,9 +163,9 @@ class LspHoverCommand(LspTextCommand):
         responses: list[ResolvedHover]
     ) -> None:
         hovers: list[tuple[Hover, MarkdownLangMap | None]] = []
-        errors: list[Error] = []
+        errors: list[ResponseErrorException] = []
         for response, language_map in zip(responses, language_maps):
-            if isinstance(response, Error):
+            if isinstance(response, ResponseErrorException):
                 errors.append(response)
                 continue
             if response:

--- a/plugin/rename_file.py
+++ b/plugin/rename_file.py
@@ -6,8 +6,8 @@ from .core.edit import show_summary_message
 from .core.logging import debug
 from .core.open import open_file_uri
 from .core.promise import Promise
-from .core.protocol import Error
 from .core.protocol import Request
+from .core.protocol import ResponseErrorException
 from .core.registry import LspWindowCommand
 from .core.types import match_file_operation_filters
 from .core.url import filename_to_uri
@@ -126,7 +126,7 @@ class LspRenamePathCommand(LspWindowCommand):
 
     def create_will_rename_requests_async(
         self, file_rename: FileRename
-    ) -> Generator[Promise[tuple[WorkspaceEdit | Error | None, weakref.ref[Session]]]]:
+    ) -> Generator[Promise[tuple[WorkspaceEdit | ResponseErrorException | None, weakref.ref[Session]]]]:
         for session in self.sessions():
             filters = session.get_capability('workspace.fileOperations.willRename.filters') or []
             if match_file_operation_filters(filters, file_rename['oldUri']):
@@ -134,20 +134,24 @@ class LspRenamePathCommand(LspWindowCommand):
                     .then(partial(self.return_response_with_session, weakref.ref(session)))
 
     def return_response_with_session(
-        self, weak_session: weakref.ref[Session], response: WorkspaceEdit | Error | None
-    ) -> tuple[WorkspaceEdit | Error | None, weakref.ref[Session]]:
+        self, weak_session: weakref.ref[Session], response: WorkspaceEdit | ResponseErrorException | None
+    ) -> tuple[WorkspaceEdit | ResponseErrorException | None, weakref.ref[Session]]:
         return (response, weak_session)
 
-    def handle_rename_async(self, responses: list[tuple[WorkspaceEdit | Error | None, weakref.ref[Session]]],
-                            label: str, rename_command_args: dict[str, Any]) -> None:
+    def handle_rename_async(
+        self,
+        responses: list[tuple[WorkspaceEdit | ResponseErrorException | None, weakref.ref[Session]]],
+        label: str,
+        rename_command_args: dict[str, Any],
+    ) -> None:
         for response, weak_session in responses:
             if (session := weak_session()) and response:
-                if isinstance(response, Error):
+                if isinstance(response, ResponseErrorException):
                     debug(f'LSP: Error response during rename: {response}')
                     return
-                prompt_for_workspace_edits(session, response, label=label) \
-                    .then(partial(self.on_prompt_for_workspace_edits_concluded, weak_session, response, label)) \
-                    .then(lambda accepted: accepted and self.window.run_command('lsp_rename_path', rename_command_args))
+                prompt_for_workspace_edits(session, response, label=label).then(
+                    partial(self.on_prompt_for_workspace_edits_concluded, weak_session, response, label)
+                ).then(lambda accepted: accepted and self.window.run_command('lsp_rename_path', rename_command_args))
                 return
         # Ensure file rename even if all WorkspaceEdit responses are empty
         self.window.run_command('lsp_rename_path', rename_command_args)

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -45,10 +45,10 @@ from .core.constants import SEMANTIC_TOKENS_MAP
 from .core.constants import SUPPORTED_DIAGNOSTIC_TAGS
 from .core.edit import apply_text_edits
 from .core.promise import Promise
-from .core.protocol import Error
 from .core.protocol import Request
 from .core.protocol import ResolvedCodeLens
 from .core.protocol import ResponseError
+from .core.protocol import ResponseErrorException
 from .core.sessions import is_diagnostic_server_cancellation_data
 from .core.sessions import Session
 from .core.sessions import SessionViewProtocol
@@ -417,7 +417,7 @@ class SessionBuffer(TaskContainer):
                         and change_count == view.change_count()
                     ):
                         await apply_text_edits(view, result)
-                except Error:
+                except ResponseErrorException:
                     pass
 
             self.create_task(purge_changes_and_do_on_type_formatting())
@@ -703,7 +703,7 @@ class SessionBuffer(TaskContainer):
             params['previousResultId'] = result_id
         req = self.session.request(Request.documentDiagnostic(params, view))
         self._document_diagnostic_pending_requests[identifier] = PendingDocumentDiagnosticRequest(version, req.id)
-        error: Error | None = None
+        error: ResponseErrorException | None = None
         try:
             response = await req
             self._diagnostics_versions[identifier] = version
@@ -716,7 +716,7 @@ class SessionBuffer(TaskContainer):
                     self.session.diagnostics_result_ids[(uri, identifier)] = diagnostic_report.get('resultId')
                     if is_full_document_diagnostic_report(diagnostic_report):
                         self.session.handle_diagnostics_async(uri, identifier, None, diagnostic_report['items'])
-        except Error as e:
+        except ResponseErrorException as e:
             error = e
         finally:
             self._document_diagnostic_pending_requests[identifier] = None

--- a/plugin/symbols.py
+++ b/plugin/symbols.py
@@ -13,10 +13,10 @@ from .core.constants import SYMBOL_KINDS
 from .core.input_handlers import DynamicListInputHandler
 from .core.input_handlers import PreselectedListInputHandler
 from .core.promise import Promise
-from .core.protocol import Error
 from .core.protocol import Point
 from .core.protocol import Request
 from .core.protocol import ResponseError
+from .core.protocol import ResponseErrorException
 from .core.registry import LspTextCommand
 from .core.registry import LspWindowCommand
 from .core.sessions import print_to_status_bar
@@ -373,13 +373,12 @@ class WorkspaceSymbolsInputHandler(DynamicListInputHandler):
         Promise.all(promises).then(partial(self._on_all_responses, change_count))
 
     def _handle_response_async(
-        self, session_name: str, response: list[SymbolInformation] | list[WorkspaceSymbol] | Error | None
+        self,
+        session_name: str,
+        response: list[SymbolInformation] | list[WorkspaceSymbol] | ResponseErrorException | None,
     ) -> list[sublime.ListInputItem]:
-        if response and not isinstance(response, Error):
-            return [
-                symbol_to_list_input_item(item, session_name=session_name)
-                for item in response
-            ]
+        if response and not isinstance(response, ResponseErrorException):
+            return [symbol_to_list_input_item(item, session_name=session_name) for item in response]
         return []
 
     def _on_all_responses(self, change_count: int, item_lists: list[list[sublime.ListInputItem]]) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ required-imports = ["from __future__ import annotations"]
 "protocol/__init__.py" = ["D400", "D415"]
 "plugin/core/protocol.py" = ["UP006", "UP007"]
 
+[tool.ruff.lint.pep8-naming]
+extend-ignore-names = ["ResponseErrorException"]
+
 [tool.ruff.lint]
 # Enable preview rules.
 preview = true

--- a/tests/test_server_requests.py
+++ b/tests/test_server_requests.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from .setup import TextDocumentTestCase
-from LSP.plugin import Error
+from LSP.plugin import ResponseErrorException
 from LSP.plugin.core.types import ClientConfig
 from LSP.plugin.core.url import filename_to_uri
 from LSP.protocol import ErrorCodes
@@ -34,7 +34,7 @@ async def verify(
     try:
         result = await testcase.make_server_do_fake_request(method, input_params)
         testcase.assertEqual(result, expected_output_params)
-    except Error as error:
+    except ResponseErrorException as error:
         if expected_error_code is not None:
             testcase.assertEqual(error.code, expected_error_code)
         else:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -26,7 +26,7 @@ import unittest
 import weakref
 
 if TYPE_CHECKING:
-    from LSP.plugin.core.protocol import Error
+    from LSP.plugin.core.protocol import ResponseErrorException
 
 
 class MockManager(Manager):
@@ -90,7 +90,7 @@ class MockLogger(Logger):
     def outgoing_response(self, request_id: Any, params: Any) -> None:
         pass
 
-    def outgoing_error_response(self, request_id: Any, error: Error) -> None:
+    def outgoing_error_response(self, request_id: Any, error: ResponseErrorException) -> None:
         pass
 
     def outgoing_request(self, request_id: int, method: str, params: Any, blocking: bool) -> None:

--- a/tests/test_workspace_edit.py
+++ b/tests/test_workspace_edit.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from .setup import CI
 from .setup import TextDocumentTestCase
-from LSP.plugin import Error
+from LSP.plugin import ResponseErrorException
 from LSP.plugin.core.url import filename_to_uri
 from LSP.plugin.core.views import entire_content
 from pathlib import Path
@@ -32,7 +32,7 @@ async def verify(
     try:
         result = await testcase.make_server_do_fake_request(method, input_params)
         testcase.assertEqual(result, expected_output_params)
-    except Error as error:
+    except ResponseErrorException as error:
         if expected_error_code is not None:
             testcase.assertEqual(error.code, expected_error_code)
         else:


### PR DESCRIPTION
This does trigger the [lint rule N818](https://docs.astral.sh/ruff/rules/error-suffix-on-exception-name/). I've added an exception for it in the pyproject.toml file.