### PR TITLE
Fix errors on re-enabling disabled LSP package

### DIFF
--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -7,6 +7,7 @@ from .types import debounced
 from .types import read_dict_setting
 from .types import Settings
 from .types import SettingsRegistration
+from .types import SettingsStore
 from abc import ABC
 from abc import abstractmethod
 from functools import partial
@@ -33,6 +34,7 @@ class ClientConfigs:
     def __init__(self) -> None:
         self.all: dict[str, ClientConfig] = {}
         self.external: dict[str, ClientConfig] = {}
+        self.external_settings_registrations: dict[str, SettingsRegistration] = {}
         self._listener: LspSettingsChangeListener | None = None
         self._clients_hash: int | None = None
 
@@ -57,8 +59,10 @@ class ClientConfigs:
         if name in self.external:
             return False
         settings = sublime.load_settings(basename(settings_path))
-        registration = SettingsRegistration(settings, settings_path, partial(self._update_external_config, name))
-        config = ClientConfig.from_sublime_settings(name, registration)
+        settings_store = SettingsStore(settings, settings_path)
+        config = ClientConfig.from_sublime_settings(name, settings_store)
+        registration = SettingsRegistration(settings, partial(self._update_external_config, name, settings_store))
+        self.external_settings_registrations[name] = registration
         self.external[name] = config
         self.all[name] = config
         if notify_listener:
@@ -78,13 +82,15 @@ class ClientConfigs:
         return True
 
     def remove_external_config(self, name: str) -> None:
+        if registration := self.external_settings_registrations.pop(name, None):
+            registration.unregister()
         self.external.pop(name, None)
         if self.all.pop(name, None):
             self._notify_clients_listener()
 
-    def _update_external_config(self, name: str, settings_registration: SettingsRegistration) -> None:
+    def _update_external_config(self, name: str, settings_store: SettingsStore) -> None:
         try:
-            config = ClientConfig.from_sublime_settings(name, settings_registration)
+            config = ClientConfig.from_sublime_settings(name, settings_store)
         except OSError:
             # The plugin is about to be disabled (for example by Package Control for an upgrade), let unregister_plugin
             # handle this
@@ -155,17 +161,17 @@ _global_settings: sublime.Settings | None = None
 client_configs = ClientConfigs()
 
 
-def _on_sublime_settings_changed(settings_registration: SettingsRegistration) -> None:
+def _on_sublime_settings_changed(settings: sublime.Settings) -> None:
     if _settings is None:
         return
-    _settings.update(settings_registration.settings)
+    _settings.update(settings)
     client_configs.update_configs()
 
 
-def _on_server_configs_changed(settings_registration: SettingsRegistration) -> None:
+def _on_server_configs_changed(settings: sublime.Settings) -> None:
     if _configs_registration is None:
         return
-    for name, config_dict in settings_registration.settings.to_dict().items():
+    for name, config_dict in settings.to_dict().items():
         if isinstance(config_dict, dict):
             client_configs.update_config(name, ClientConfig.from_dict(name, config_dict))
 
@@ -178,18 +184,20 @@ def load_settings() -> None:
         settings_filename = "LSP.sublime-settings"
         settings_obj = sublime.load_settings(settings_filename)
         _settings = Settings(settings_obj)
-        _settings_registration = SettingsRegistration(settings_obj, settings_filename, _on_sublime_settings_changed)
+        _settings_registration = SettingsRegistration(settings_obj, partial(_on_sublime_settings_changed, settings_obj))
     if _configs_registration is None:
         settings_obj = sublime.load_settings(SERVER_CONFIGS_FILENAME)
-        _configs_registration = SettingsRegistration(settings_obj, SERVER_CONFIGS_FILENAME, _on_server_configs_changed)
+        _configs_registration = SettingsRegistration(settings_obj, partial(_on_server_configs_changed, settings_obj))
 
 
 def unload_settings() -> None:
     global _settings, _settings_registration, _configs_registration
     if _settings_registration:
+        _settings_registration.unregister()
         _settings_registration = None
         _settings = Settings(sublime.load_settings(""))
     if _configs_registration:
+        _configs_registration.unregister()
         _configs_registration = None
 
 

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -190,11 +190,7 @@ class SettingsRegistration:
 
     def __init__(self, settings: sublime.Settings, on_change: Callable[[], None]) -> None:
         self.settings = settings
-
-        def on_change_handler() -> None:
-            on_change()
-
-        self.settings.add_on_change("LSP", on_change_handler)
+        self.settings.add_on_change("LSP", on_change)
 
     def unregister(self) -> None:
         self.settings.clear_on_change("LSP")

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -199,12 +199,6 @@ class SettingsRegistration:
     def unregister(self) -> None:
         self.settings.clear_on_change("LSP")
 
-    def __del__(self) -> None:
-        # FIXME: Relying on reference counts and garbage collection timings for the change listener handling is a very
-        # bad idea, because instances of this class are dynamically passed between other object instances, and it can
-        # easily cause bugs like https://github.com/sublimelsp/LSP/pull/2867
-        self.settings.clear_on_change("LSP")
-
 
 class DebouncerNonThreadSafe:
     """

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -48,7 +48,6 @@ import posixpath
 import re
 import sublime
 import time
-import weakref
 
 if TYPE_CHECKING:
     from .file_watcher import FileWatcherEventType
@@ -180,21 +179,25 @@ def debounced(f: Callable[[], Any], timeout_ms: int = 0, condition: Callable[[],
     runner(run, timeout_ms)
 
 
-class SettingsRegistration:
-    __slots__ = ("settings", "settings_path", "__weakref__")  # pyright: ignore[reportUninitializedInstanceVariable]
+@dataclass
+class SettingsStore:
+    settings: sublime.Settings
+    settings_path: str
 
-    def __init__(
-        self, settings: sublime.Settings, settings_path: str, on_change: Callable[[SettingsRegistration], None]
-    ) -> None:
+
+class SettingsRegistration:
+    __slots__ = ("settings", )
+
+    def __init__(self, settings: sublime.Settings, on_change: Callable[[], None]) -> None:
         self.settings = settings
-        self.settings_path = settings_path
-        weak_self = weakref.ref(self)
 
         def on_change_handler() -> None:
-            if self_ := weak_self():
-                on_change(self_)
+            on_change()
 
         self.settings.add_on_change("LSP", on_change_handler)
+
+    def unregister(self) -> None:
+        self.settings.clear_on_change("LSP")
 
     def __del__(self) -> None:
         # FIXME: Relying on reference counts and garbage collection timings for the change listener handling is a very
@@ -807,7 +810,7 @@ class ClientConfig:
         diagnostics_mode: str = "all_files",
         markdown_language_map: MarkdownLangMapJson | None = None,
         path_maps: list[PathMap] | None = None,
-        settings_registration: SettingsRegistration | None = None,
+        settings_store: SettingsStore | None = None,
         custom_config_keys: dict[str, Any] | None = None
     ) -> None:
         """
@@ -845,7 +848,7 @@ class ClientConfig:
             applies no extra mapping.
         :param path_maps: List of :class:`PathMap` entries for translating paths between the local machine and a remote
             server (e.g. inside a container).
-        :param settings_registration: The `SettingsRegistration` instance holding resource path and `Settings` instance
+        :param settings_store: The `SettingsStore` instance holding resource path and `Settings` instance
             for the plugin settings. Present only for `ClientConfig`s created through `from_sublime_settings()`.
         :param custom_config_keys: The complete raw settings dictionary. Used as a fallback for attribute/key access for
             settings not explicitly modelled above.
@@ -873,7 +876,7 @@ class ClientConfig:
         # Transformed mapping that uses tuples instead of lists for mdpopups.
         self.resolved_markdown_language_map: MarkdownLangMap | None = None
         self.markdown_language_map = markdown_language_map  # use the setter to populate resolved_markdown_language_map
-        self._settings_registration = settings_registration
+        self._settings_store = settings_store
         if isinstance(custom_config_keys, dict):
             self._custom_config_keys = custom_config_keys
             # Only retain server configuration keys that we don't have dedicated properties for.
@@ -908,9 +911,9 @@ class ClientConfig:
     def enabled(self, enabled: bool) -> None:
         if enabled == self._enabled:
             return
-        if self._settings_registration:
-            settings_basename = os.path.basename(self._settings_registration.settings_path)
-            self._settings_registration.settings.set("enabled", enabled)
+        if self._settings_store:
+            settings_basename = os.path.basename(self._settings_store.settings_path)
+            self._settings_store.settings.set("enabled", enabled)
             sublime.save_settings(settings_basename)
         self._enabled = enabled
 
@@ -938,7 +941,7 @@ class ClientConfig:
         return result
 
     @classmethod
-    def from_sublime_settings(cls, name: str, settings_registration: SettingsRegistration) -> ClientConfig:
+    def from_sublime_settings(cls, name: str, settings_store: SettingsStore) -> ClientConfig:
         """
         Create a ClientConfig from a Sublime Text `Settings` object.
 
@@ -946,10 +949,10 @@ class ClientConfig:
         overrides are layered on top from `Settings`.
 
         :param name: Unique server name.
-        :param settings_registration: The `SettingsRegistration` object for this client.
+        :param settings_store: The `SettingsStore` object for this client.
         """
-        s = settings_registration.settings
-        file = settings_registration.settings_path
+        s = settings_store.settings
+        file = settings_store.settings_path
         base = sublime.decode_value(sublime.load_resource(file))
         settings = DottedDict(deepcopy(base.get("settings", {})))  # defined by the plugin author
         settings.update(deepcopy(read_dict_setting(s, "settings", {})))  # overrides from the user
@@ -988,7 +991,7 @@ class ClientConfig:
             diagnostics_mode=str(s.get("diagnostics_mode", "all_files")),
             markdown_language_map=deepcopy(s.get("markdown_language_map")),
             path_maps=PathMap.parse(s.get("path_maps")),
-            settings_registration=settings_registration,
+            settings_store=settings_store,
             custom_config_keys=deepcopy(s.to_dict())
         )
 
@@ -1067,7 +1070,7 @@ class ClientConfig:
             diagnostics_mode=deepcopy(override.get("diagnostics_mode", src_config.diagnostics_mode)),
             markdown_language_map=deepcopy(override.get("markdown_language_map", src_config.markdown_language_map)),
             path_maps=PathMap.parse(override.get("path_maps")) or deepcopy(src_config.path_maps),
-            settings_registration=src_config._settings_registration,
+            settings_store=src_config._settings_store,
             custom_config_keys=deepcopy({**src_config._custom_config_keys, **override})
         )
 

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -87,7 +87,6 @@ from weakref import WeakValueDictionary
 import itertools
 import sublime
 import sublime_plugin
-import weakref
 import webbrowser
 
 if TYPE_CHECKING:
@@ -199,14 +198,6 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
 
     def __init__(self, view: sublime.View) -> None:
         super().__init__(view)
-        weakself = weakref.ref(self)
-
-        def on_change() -> None:
-            nonlocal weakself
-            this = weakself()
-            if this is not None:
-                this._on_settings_object_changed()
-
         settings = view.settings()
         self._uri = ''  # assumed to never be falsey
         self._current_syntax = settings.get("syntax")
@@ -217,7 +208,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             self.set_uri(view_to_uri(view))
         self._auto_complete_triggered_manually = False
         self._change_count_on_last_save = -1
-        self._registration = SettingsRegistration(settings, on_change=on_change)
+        self._registration = SettingsRegistration(settings, on_change=self._on_settings_object_changed)
         self._completions_task: QueryCompletionsTask | None = None
         self._is_documenation_popup_open = False
         self._stored_selection: list[sublime.Region] = []
@@ -524,6 +515,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             manager = self._manager
             sublime.set_timeout_async(lambda: manager.unregister_listener_async(self))
         self._clear_session_views_async()
+        self._registration.unregister()
 
     def on_query_context(self, key: str, operator: int, operand: Any, match_all: bool) -> bool | None:
         # You can filter key bindings by the precense of a provider,

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -201,7 +201,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         super().__init__(view)
         weakself = weakref.ref(self)
 
-        def on_change(_: SettingsRegistration) -> None:
+        def on_change() -> None:
             nonlocal weakself
             this = weakself()
             if this is not None:
@@ -217,7 +217,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
             self.set_uri(view_to_uri(view))
         self._auto_complete_triggered_manually = False
         self._change_count_on_last_save = -1
-        self._registration = SettingsRegistration(settings, '', on_change=on_change)
+        self._registration = SettingsRegistration(settings, on_change=on_change)
         self._completions_task: QueryCompletionsTask | None = None
         self._is_documenation_popup_open = False
         self._stored_selection: list[sublime.Region] = []

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -213,6 +213,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         self._is_documenation_popup_open = False
         self._stored_selection: list[sublime.Region] = []
         self._should_format_on_paste = False
+        self._closed = False
         self.hover_provider_count = 0
         self._setup()
 
@@ -238,6 +239,8 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         self._registered = False
 
     def _cleanup(self) -> None:
+        if self._closed:
+            return
         settings = self.view.settings()
         triggers: list[dict[str, str]] = settings.get("auto_complete_triggers") or []
         triggers = [trigger for trigger in triggers if 'server' not in trigger]
@@ -514,8 +517,9 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         if self._registered and self._manager:
             manager = self._manager
             sublime.set_timeout_async(lambda: manager.unregister_listener_async(self))
-        self._clear_session_views_async()
+        self._cleanup()
         self._registration.unregister()
+        self._closed = True
 
     def on_query_context(self, key: str, operator: int, operand: Any, match_all: bool) -> bool | None:
         # You can filter key bindings by the precense of a provider,


### PR DESCRIPTION
Fix issue mentioned in https://github.com/sublimelsp/LSP-basedpyright/issues/154 where disabling and then enabling LSP-* package triggers weird errors. The same issue can trigger on package updates.

The issue was that on disabling the plugin, the active settings listener from `SettingsRegistration` would trigger and [immediately re-register the external plugin](https://github.com/sublimelsp/LSP/blob/a04972b38024149f6c1873175a0f11047d3c8643/plugin/core/settings.py#L98). Fix by explicitly unregistering the listener when unregistering a plugin.

I think I've finally came up with a clean fix for the weird `SettingsRegistration` listener handling. Now `SettingsRegistration` is owned entirely by `ClientConfigs` where both registration and un-registration happens and it's not passed to `ClientConfig`s. `ClientConfig` only receives the new `SettingsStore` with `sublime.Settings` and settings path - all that it needs.