### PR TITLE
add focus state to minihtml tree view

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -244,41 +244,41 @@
         "args": {"async": true},
         "context": [{"key": "lsp.session_with_capability", "operand": "textDocumentSync.willSave | textDocumentSync.willSaveWaitUntil | codeActionProvider.codeActionKinds | documentFormattingProvider | documentRangeFormattingProvider"}]
     },
-    // Navigate in Tree Views
-    {
-        "keys": ["left"],
-        "command": "lsp_handle_tree_view_action",
-        "args": {"action": "move_left"},
-        "context": [{"key": "lsp.tree_view_sheet_has_focus"}]
-    },
-    {
-        "keys": ["right"],
-        "command": "lsp_handle_tree_view_action",
-        "args": {"action": "move_right"},
-        "context": [{"key": "lsp.tree_view_sheet_has_focus"}]
-    },
-    {
-        "keys": ["up"],
-        "command": "lsp_handle_tree_view_action",
-        "args": {"action": "move_up"},
-        "context": [{"key": "lsp.tree_view_sheet_has_focus"}]
-    },
-    {
-        "keys": ["down"],
-        "command": "lsp_handle_tree_view_action",
-        "args": {"action": "move_down"},
-        "context": [{"key": "lsp.tree_view_sheet_has_focus"}]
-    },
-    {
-        "keys": ["enter"],
-        "command": "lsp_handle_tree_view_action",
-        "args": {"action": "activate"},
-        "context": [{"key": "lsp.tree_view_sheet_has_focus"}]
-    },
-    {
-        "keys": ["escape"],
-        "command": "lsp_handle_tree_view_action",
-        "args": {"action": "close"},
-        "context": [{"key": "lsp.tree_view_sheet_has_focus"}]
-    },
+    // Navigate in Tree Views (pending keybinding support in Sheets - https://github.com/sublimehq/sublime_text/issues/5377)
+    // {
+    //     "keys": ["left"],
+    //     "command": "lsp_handle_tree_view_action",
+    //     "args": {"action": "move_left"},
+    //     "context": [{"key": "lsp.tree_view_sheet_has_focus"}]
+    // },
+    // {
+    //     "keys": ["right"],
+    //     "command": "lsp_handle_tree_view_action",
+    //     "args": {"action": "move_right"},
+    //     "context": [{"key": "lsp.tree_view_sheet_has_focus"}]
+    // },
+    // {
+    //     "keys": ["up"],
+    //     "command": "lsp_handle_tree_view_action",
+    //     "args": {"action": "move_up"},
+    //     "context": [{"key": "lsp.tree_view_sheet_has_focus"}]
+    // },
+    // {
+    //     "keys": ["down"],
+    //     "command": "lsp_handle_tree_view_action",
+    //     "args": {"action": "move_down"},
+    //     "context": [{"key": "lsp.tree_view_sheet_has_focus"}]
+    // },
+    // {
+    //     "keys": ["enter"],
+    //     "command": "lsp_handle_tree_view_action",
+    //     "args": {"action": "activate"},
+    //     "context": [{"key": "lsp.tree_view_sheet_has_focus"}]
+    // },
+    // {
+    //     "keys": ["escape"],
+    //     "command": "lsp_handle_tree_view_action",
+    //     "args": {"action": "close"},
+    //     "context": [{"key": "lsp.tree_view_sheet_has_focus"}]
+    // },
 ]

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -270,6 +270,12 @@
         "context": [{"key": "lsp.tree_view_sheet_has_focus"}]
     },
     {
+        "keys": ["enter"],
+        "command": "lsp_handle_tree_view_action",
+        "args": {"action": "activate"},
+        "context": [{"key": "lsp.tree_view_sheet_has_focus"}]
+    },
+    {
         "keys": ["escape"],
         "command": "lsp_handle_tree_view_action",
         "args": {"action": "close"},

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,4 +1,43 @@
 [
+    // TODO: Only for testing.
+    {
+        "keys": [
+            "left"
+        ],
+        "command": "lsp_move_focus",
+        "args": {
+            "direction": "left"
+        },
+    },
+    {
+        "keys": [
+            "right"
+        ],
+        "command": "lsp_move_focus",
+        "args": {
+            "direction": "right"
+        },
+    },
+    {
+        "keys": [
+            "up"
+        ],
+        "command": "lsp_move_focus",
+        "args": {
+            "direction": "up"
+        },
+    },
+    {
+        "keys": [
+            "down"
+        ],
+        "command": "lsp_move_focus",
+        "args": {
+            "direction": "down"
+        },
+    },
+
+
     // To enable or change an existing key binding, copy it to the right view and uncomment, if needed.
     // To change the associated key press, edit the "keys" value.
 

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,43 +1,4 @@
 [
-    // TODO: Only for testing.
-    {
-        "keys": [
-            "left"
-        ],
-        "command": "lsp_move_focus",
-        "args": {
-            "direction": "left"
-        },
-    },
-    {
-        "keys": [
-            "right"
-        ],
-        "command": "lsp_move_focus",
-        "args": {
-            "direction": "right"
-        },
-    },
-    {
-        "keys": [
-            "up"
-        ],
-        "command": "lsp_move_focus",
-        "args": {
-            "direction": "up"
-        },
-    },
-    {
-        "keys": [
-            "down"
-        ],
-        "command": "lsp_move_focus",
-        "args": {
-            "direction": "down"
-        },
-    },
-
-
     // To enable or change an existing key binding, copy it to the right view and uncomment, if needed.
     // To change the associated key press, edit the "keys" value.
 
@@ -282,5 +243,36 @@
         "command": "lsp_save",
         "args": {"async": true},
         "context": [{"key": "lsp.session_with_capability", "operand": "textDocumentSync.willSave | textDocumentSync.willSaveWaitUntil | codeActionProvider.codeActionKinds | documentFormattingProvider | documentRangeFormattingProvider"}]
+    },
+    // Navigate in Tree Views
+    {
+        "keys": ["left"],
+        "command": "lsp_handle_tree_view_action",
+        "args": {"action": "move_left"},
+        "context": [{"key": "lsp.tree_view_sheet_has_focus"}]
+    },
+    {
+        "keys": ["right"],
+        "command": "lsp_handle_tree_view_action",
+        "args": {"action": "move_right"},
+        "context": [{"key": "lsp.tree_view_sheet_has_focus"}]
+    },
+    {
+        "keys": ["up"],
+        "command": "lsp_handle_tree_view_action",
+        "args": {"action": "move_up"},
+        "context": [{"key": "lsp.tree_view_sheet_has_focus"}]
+    },
+    {
+        "keys": ["down"],
+        "command": "lsp_handle_tree_view_action",
+        "args": {"action": "move_down"},
+        "context": [{"key": "lsp.tree_view_sheet_has_focus"}]
+    },
+    {
+        "keys": ["escape"],
+        "command": "lsp_handle_tree_view_action",
+        "args": {"action": "close"},
+        "context": [{"key": "lsp.tree_view_sheet_has_focus"}]
     },
 ]

--- a/boot.py
+++ b/boot.py
@@ -299,13 +299,13 @@ class Listener(sublime_plugin.EventListener):
 class LspMoveFocusCommand(sublime_plugin.WindowCommand):
 
     def is_enabled(self) -> bool:
-        if wm := windows.lookup(self.window):
-            if (active_sheet := self.window.active_sheet()) and (sheet := wm.tree_view_sheets.get('Call Hierarchy')):
-                return sheet.id() == active_sheet.id()
+        if (active_sheet := self.window.active_sheet()) and (wm := windows.lookup(self.window)):
+            return active_sheet in wm.tree_view_sheets.values()
         return False
 
     def run(self, direction: Literal['down', 'up', 'left', 'right', 'close']) -> None:
-        if wm := windows.lookup(self.window):
-            if (active_sheet := self.window.active_sheet()) and (sheet := wm.tree_view_sheets.get('Call Hierarchy')):
-                if sheet.id() == active_sheet.id():
-                    sheet.navigate(direction)
+        if (
+            (active_sheet := self.window.active_sheet()) and (wm := windows.lookup(self.window))
+            and (sheet := next((sheet for sheet in wm.tree_view_sheets.values() if sheet == active_sheet), None))
+        ):
+            sheet.navigate(direction)

--- a/boot.py
+++ b/boot.py
@@ -296,3 +296,10 @@ class Listener(sublime_plugin.EventListener):
                 sublime.set_timeout_async(wm.update_diagnostics_panel_async)
             elif panel_manager.is_panel_open(PanelName.Log):
                 sublime.set_timeout(lambda: panel_manager.update_log_panel(scroll_to_selection=True))
+
+    def on_query_context(
+        self, view: sublime.View, key: str, operator: sublime.QueryOperator, operand: str, match_all: bool
+    ) -> bool | None:
+        if key == 'lsp.tree_view_sheet_has_focus':
+            return False
+        return None

--- a/boot.py
+++ b/boot.py
@@ -132,6 +132,7 @@ __all__ = (
     "LspHierarchyToggleCommand",
     "LspHoverCommand",
     "LspInlayHintClickCommand",
+    "LspMoveFocusCommand",
     "LspNextDiagnosticCommand",
     "LspOnDoubleClickCommand",
     "LspOpenLinkCommand",

--- a/boot.py
+++ b/boot.py
@@ -296,10 +296,3 @@ class Listener(sublime_plugin.EventListener):
                 sublime.set_timeout_async(wm.update_diagnostics_panel_async)
             elif panel_manager.is_panel_open(PanelName.Log):
                 sublime.set_timeout(lambda: panel_manager.update_log_panel(scroll_to_selection=True))
-
-    def on_query_context(
-        self, view: sublime.View, key: str, operator: sublime.QueryOperator, operand: str, match_all: bool
-    ) -> bool | None:
-        if key == 'lsp.tree_view_sheet_has_focus':
-            return False
-        return None

--- a/boot.py
+++ b/boot.py
@@ -36,6 +36,7 @@ from .plugin.core.transports import kill_all_subprocesses
 from .plugin.core.tree_view import LspActivateTreeItemCommand
 from .plugin.core.tree_view import LspCollapseTreeItemCommand
 from .plugin.core.tree_view import LspExpandTreeItemCommand
+from .plugin.core.tree_view import LspHandleTreeViewActionCommand
 from .plugin.core.views import LspRunTextCommandHelperCommand
 from .plugin.document_link import LspOpenLinkCommand
 from .plugin.documents import DocumentSyncListener
@@ -89,7 +90,6 @@ from .plugin.tooling import LspOnDoubleClickCommand
 from .plugin.tooling import LspParseVscodePackageJson
 from .plugin.tooling import LspTroubleshootServerCommand
 from typing import Any
-from typing import Literal
 import os
 import sublime
 import sublime_plugin
@@ -129,10 +129,10 @@ __all__ = (
     "LspFormatDocumentCommand",
     "LspFormatDocumentRangeCommand",
     "LspGotoDiagnosticCommand",
+    "LspHandleTreeViewActionCommand",
     "LspHierarchyToggleCommand",
     "LspHoverCommand",
     "LspInlayHintClickCommand",
-    "LspMoveFocusCommand",
     "LspNextDiagnosticCommand",
     "LspOnDoubleClickCommand",
     "LspOpenLinkCommand",
@@ -293,19 +293,3 @@ class Listener(sublime_plugin.EventListener):
                 sublime.set_timeout_async(wm.update_diagnostics_panel_async)
             elif panel_manager.is_panel_open(PanelName.Log):
                 sublime.set_timeout(lambda: panel_manager.update_log_panel(scroll_to_selection=True))
-
-
-# TODO: Added just for testing
-class LspMoveFocusCommand(sublime_plugin.WindowCommand):
-
-    def is_enabled(self) -> bool:
-        if (active_sheet := self.window.active_sheet()) and (wm := windows.lookup(self.window)):
-            return active_sheet in wm.tree_view_sheets.values()
-        return False
-
-    def run(self, direction: Literal['down', 'up', 'left', 'right', 'close']) -> None:
-        if (
-            (active_sheet := self.window.active_sheet()) and (wm := windows.lookup(self.window))
-            and (sheet := next((sheet for sheet in wm.tree_view_sheets.values() if sheet == active_sheet), None))
-        ):
-            sheet.navigate(direction)

--- a/boot.py
+++ b/boot.py
@@ -33,6 +33,7 @@ from .plugin.core.settings import unload_settings
 from .plugin.core.signature_help import LspSignatureHelpNavigateCommand
 from .plugin.core.signature_help import LspSignatureHelpShowCommand
 from .plugin.core.transports import kill_all_subprocesses
+from .plugin.core.tree_view import LspActivateTreeItemCommand
 from .plugin.core.tree_view import LspCollapseTreeItemCommand
 from .plugin.core.tree_view import LspExpandTreeItemCommand
 from .plugin.core.views import LspRunTextCommandHelperCommand
@@ -88,6 +89,7 @@ from .plugin.tooling import LspOnDoubleClickCommand
 from .plugin.tooling import LspParseVscodePackageJson
 from .plugin.tooling import LspTroubleshootServerCommand
 from typing import Any
+from typing import Literal
 import os
 import sublime
 import sublime_plugin
@@ -95,6 +97,7 @@ import sublime_plugin
 __all__ = (
     "DocumentSyncListener",
     "Listener",
+    "LspActivateTreeItemCommand",
     "LspApplyDocumentEditCommand",
     "LspApplyTextDocumentEditCommand",
     "LspApplyWorkspaceEditCommand",
@@ -289,3 +292,19 @@ class Listener(sublime_plugin.EventListener):
                 sublime.set_timeout_async(wm.update_diagnostics_panel_async)
             elif panel_manager.is_panel_open(PanelName.Log):
                 sublime.set_timeout(lambda: panel_manager.update_log_panel(scroll_to_selection=True))
+
+
+# TODO: Added just for testing
+class LspMoveFocusCommand(sublime_plugin.WindowCommand):
+
+    def is_enabled(self) -> bool:
+        if wm := windows.lookup(self.window):
+            if (active_sheet := self.window.active_sheet()) and (sheet := wm.tree_view_sheets.get('Call Hierarchy')):
+                return sheet.id() == active_sheet.id()
+        return False
+
+    def run(self, direction: Literal['down', 'up', 'left', 'right', 'close']) -> None:
+        if wm := windows.lookup(self.window):
+            if (active_sheet := self.window.active_sheet()) and (sheet := wm.tree_view_sheets.get('Call Hierarchy')):
+                if sheet.id() == active_sheet.id():
+                    sheet.navigate(direction)

--- a/plugin/core/tree_view.py
+++ b/plugin/core/tree_view.py
@@ -8,6 +8,8 @@ from abc import ABC
 from abc import abstractmethod
 from enum import IntEnum
 from functools import partial
+from typing import Any
+from typing import Literal
 from typing import TYPE_CHECKING
 from typing import TypeVar
 import html
@@ -48,7 +50,7 @@ class TreeItem:
         kind: SublimeKind = sublime.KIND_AMBIGUOUS,
         description: str = "",
         tooltip: str = "",
-        command_url: str = ""
+        action_command: tuple[str, dict[str, Any]] | None = None,
     ) -> None:
         self.label = label
         """ A human-readable string describing this item. """
@@ -58,13 +60,12 @@ class TreeItem:
         """ A human-readable string which is rendered less prominent. """
         self.tooltip = tooltip
         """ The tooltip text when you hover over this item. """
-        self.command_url = command_url
-        """ A HTML embeddable URL for a command that should be executed when the tree item label is clicked.
-        Use the sublime.command_url function to generate this URL. """
+        self.action_command = action_command
+        """ The command and its arguments to be executed when the tree item label is clicked. """
         self.collapsible_state = TreeItemCollapsibleState.COLLAPSED
         self.id = str(uuid.uuid4())
 
-    def html(self, sheet_name: str, indent_level: int) -> str:
+    def html(self, sheet_name: str, indent_level: int, is_active: bool = False) -> str:
         indent_html = f'<span style="padding-left: {indent_level}rem;">&nbsp;</span>'
         if self.collapsible_state == TreeItemCollapsibleState.COLLAPSED:
             disclosure_button_html = '<a class="disclosure-button" href="{}">▶</a>'.format(
@@ -79,14 +80,20 @@ class TreeItem:
             kind_class_name, self.kind[2], self.kind[1] or '&nbsp;')
         escaped_tooltip = html.escape(self.tooltip)
         escaped_label = html.escape(self.label)
-        if self.command_url and self.tooltip:
-            label_html = f'<a class="label" href="{self.command_url}" title="{escaped_tooltip}">{escaped_label}</a>'
-        elif self.command_url:
-            label_html = f'<a class="label" href="{self.command_url}">{escaped_label}</a>'
+        command_url = (
+            sublime.command_url('lsp_activate_tree_item', {'name': sheet_name, 'node_id': self.id})
+            if self.action_command else None
+        )
+        if command_url and self.tooltip:
+            label_html = f'<a class="label" href="{command_url}" title="{escaped_tooltip}">{escaped_label}</a>'
+        elif command_url:
+            label_html = f'<a class="label" href="{command_url}">{escaped_label}</a>'
         elif self.tooltip:
             label_html = f'<span class="label" title="{escaped_tooltip}">{escaped_label}</span>'
         else:
             label_html = f'<span class="label">{escaped_label}</span>'
+        if is_active:
+            label_html = f'<span class="active">{label_html}</span>'
         description_html = f'<span class="description">{html.escape(self.description)}</span>' if \
             self.description else ''
         content = indent_html + disclosure_button_html + icon_html + label_html + description_html
@@ -95,11 +102,12 @@ class TreeItem:
 
 class Node:
 
-    __slots__ = ('element', 'tree_item', 'indent_level', 'child_ids', 'is_resolved')
+    __slots__ = ('element', 'tree_item', 'parent_node_id', 'indent_level', 'child_ids', 'is_resolved')
 
-    def __init__(self, element: T, tree_item: TreeItem, indent_level: int = 0) -> None:
+    def __init__(self, element: T, tree_item: TreeItem, parent_node_id: str | None, indent_level: int = 0) -> None:
         self.element = element
         self.tree_item = tree_item
+        self.parent_node_id = parent_node_id
         self.indent_level = indent_level
         self.child_ids: list[str] = []
         self.is_resolved = False
@@ -127,6 +135,8 @@ class TreeViewSheet(sublime.HtmlSheet):
     def __init__(self, sheet_id: int, name: str, data_provider: TreeDataProvider, header: str = "") -> None:
         super().__init__(sheet_id)
         self.nodes: dict[str, Node] = {}
+        self.selected_node_id: str | None = None
+        self.ordered_node_ids: list[str] = []
         self.root_nodes: list[str] = []
         self.name = name
         self.data_provider = data_provider
@@ -152,9 +162,11 @@ class TreeViewSheet(sublime.HtmlSheet):
         for element in elements:
             tree_item = self.data_provider.get_tree_item(element)
             tree_item.collapsible_state = TreeItemCollapsibleState.EXPANDED
-            self.nodes[tree_item.id] = Node(element, tree_item)
+            self.nodes[tree_item.id] = Node(element, tree_item, parent_node_id=None)
             self.root_nodes.append(tree_item.id)
             promises.append(self.data_provider.get_children(element).then(partial(self._add_children, tree_item.id)))
+        if self.root_nodes:
+            self.selected_node_id = self.root_nodes[0]
         Promise.all(promises).then(lambda _: self._update_contents())
 
     def _add_children(self, node_id: str, elements: list[T]) -> None:
@@ -162,11 +174,52 @@ class TreeViewSheet(sublime.HtmlSheet):
         node = self.nodes[node_id]
         for element in elements:
             tree_item = self.data_provider.get_tree_item(element)
-            self.nodes[tree_item.id] = Node(element, tree_item, node.indent_level + 1)
+            self.nodes[tree_item.id] = Node(element, tree_item, node_id, node.indent_level + 1)
             node.child_ids.append(tree_item.id)
         if len(elements) == 0:
             node.tree_item.collapsible_state = TreeItemCollapsibleState.NONE
         node.is_resolved = True
+
+    def _resolve_children(self, node_id: str) -> None:
+        assert node_id in self.nodes
+        node = self.nodes[node_id]
+        self.data_provider.get_children(node.element) \
+            .then(partial(self._add_children, node_id)) \
+            .then(lambda _: self._update_contents())
+
+    def navigate(self, direction: Literal['up', 'right', 'down', 'left', 'close']) -> None:
+        if direction == 'close':
+            self.close()
+            return
+        if not self.selected_node_id or not (selected_node := self.nodes[self.selected_node_id]):
+            return
+        if direction == 'down':
+            current_index = self.ordered_node_ids.index(self.selected_node_id)
+            next_index = min(len(self.ordered_node_ids) - 1, current_index + 1)
+            if current_index == next_index:
+                return
+            next_node_id = self.ordered_node_ids[next_index]
+            self.activate_item(next_node_id)
+        elif direction == 'up':
+            current_index = self.ordered_node_ids.index(self.selected_node_id)
+            previous_index = max(0, current_index - 1)
+            if current_index == previous_index:
+                return
+            previous_node_id = self.ordered_node_ids[previous_index]
+            self.activate_item(previous_node_id)
+        elif direction == 'left':
+            if selected_node.tree_item.collapsible_state == TreeItemCollapsibleState.EXPANDED:
+                self.collapse_item(self.selected_node_id)
+            elif selected_node.parent_node_id and selected_node.tree_item.collapsible_state in {
+                TreeItemCollapsibleState.COLLAPSED,
+                TreeItemCollapsibleState.NONE
+            }:
+                self.activate_item(selected_node.parent_node_id)
+        elif direction == 'right':
+            if selected_node.tree_item.collapsible_state == TreeItemCollapsibleState.COLLAPSED:
+                self.expand_item(self.selected_node_id)
+        # TODO: reliable focus
+        sublime.set_timeout(lambda: sublime.active_window().focus_sheet(self), 300)
 
     def expand_item(self, node_id: str) -> None:
         assert node_id in self.nodes
@@ -175,14 +228,23 @@ class TreeViewSheet(sublime.HtmlSheet):
         if node.is_resolved:
             self._update_contents()
             return
-        self.data_provider.get_children(node.element) \
-            .then(partial(self._add_children, node_id)) \
-            .then(lambda _: self._update_contents())
+        self._resolve_children(node_id)
 
     def collapse_item(self, node_id: str) -> None:
         assert node_id in self.nodes
         self.nodes[node_id].tree_item.collapsible_state = TreeItemCollapsibleState.COLLAPSED
         self._update_contents()
+
+    def activate_item(self, node_id: str) -> None:
+        assert node_id in self.nodes
+        self.selected_node_id = node_id
+        node = self.nodes[node_id]
+        if node.is_resolved:
+            self._update_contents()
+        else:
+            self._resolve_children(node_id)
+        if action_command := node.tree_item.action_command:
+            sublime.active_window().run_command(*action_command)
 
     def _update_contents(self) -> None:
         contents = """
@@ -193,6 +255,15 @@ class TreeViewSheet(sublime.HtmlSheet):
             {}
             h3 a {{
                 text-decoration: none;
+            }}
+            kbd {{
+                background-color: color(var(--foreground) lightness(+ 5%));
+                border-radius: 0.25rem;
+                border: 1px solid color(var(--foreground) alpha(0.25));
+                color: var(--background);
+                font-size: 0.9rem;
+                padding: 0.05rem 0.25rem;
+                line-height: 0.8rem;
             }}
             .tree-view {{
                 padding: 0.5rem;
@@ -261,17 +332,34 @@ class TreeViewSheet(sublime.HtmlSheet):
                 color: color(var(--foreground) alpha(0.6));
                 padding-left: 0.5rem;
             }}
+            .active {{
+                background-color: color(var(--accent));
+            }}
         </style>
         <body id="lsp-tree-view" class="lsp_sheet">
             <h3>{}</h3>
+            <div class="description">use <kbd>↑</kbd> <kbd>↓</kbd> <kbd>←</kbd> <kbd>→</kbd> to move around</div>
             <div class="tree-view">{}</div>
         </body>
         """.format(css().sheets, self.header, "".join([self._subtree_html(root_id) for root_id in self.root_nodes]))
         self.set_contents(contents)
+        self._update_ordered_node_ids()
+
+    def _update_ordered_node_ids(self) -> None:
+        # Iterative to avoid recursion.
+        result: list[str] = []
+        stack = list(reversed(self.root_nodes))
+        while stack:
+            node_id = stack.pop()
+            node = self.nodes[node_id]
+            result.append(node_id)
+            if node.tree_item.collapsible_state == TreeItemCollapsibleState.EXPANDED:
+                stack.extend(reversed(node.child_ids))
+        self.ordered_node_ids = result
 
     def _subtree_html(self, node_id: str) -> str:
         node = self.nodes[node_id]
-        html = node.tree_item.html(self.name, node.indent_level)
+        html = node.tree_item.html(self.name, node.indent_level, node_id == self.selected_node_id)
         if node.tree_item.collapsible_state == TreeItemCollapsibleState.EXPANDED:
             html += "".join([self._subtree_html(child_id) for child_id in node.child_ids])
         return html
@@ -333,6 +421,16 @@ def toggle_tree_item(window: sublime.Window, name: str, node_id: str, expand: bo
         sheet.collapse_item(node_id)
 
 
+def activate_tree_item(window: sublime.Window, name: str, node_id: str) -> None:
+    wm = windows.lookup(window)
+    if not wm:
+        return
+    sheet = wm.tree_view_sheets.get(name)
+    if not sheet:
+        return
+    sheet.activate_item(node_id)
+
+
 class LspExpandTreeItemCommand(LspWindowCommand):
 
     def run(self, name: str, node_id: str) -> None:
@@ -343,3 +441,9 @@ class LspCollapseTreeItemCommand(LspWindowCommand):
 
     def run(self, name: str, node_id: str) -> None:
         toggle_tree_item(self.window, name, node_id, False)
+
+
+class LspActivateTreeItemCommand(LspWindowCommand):
+
+    def run(self, name: str, node_id: str) -> None:
+        activate_tree_item(self.window, name, node_id)

--- a/plugin/core/tree_view.py
+++ b/plugin/core/tree_view.py
@@ -66,7 +66,7 @@ class TreeItem:
         self.collapsible_state = TreeItemCollapsibleState.COLLAPSED
         self.id = str(uuid.uuid4())
 
-    def html(self, sheet_name: str, indent_level: int, is_active: bool = False) -> str:
+    def html(self, sheet_name: str, indent_level: int, *, has_focus: bool = False) -> str:
         indent_html = f'<span style="padding-left: {indent_level}rem;">&nbsp;</span>'
         if self.collapsible_state == TreeItemCollapsibleState.COLLAPSED:
             disclosure_button_html = '<a class="disclosure-button" href="{}">▶</a>'.format(
@@ -93,8 +93,8 @@ class TreeItem:
             label_html = f'<span class="label" title="{escaped_tooltip}">{escaped_label}</span>'
         else:
             label_html = f'<span class="label">{escaped_label}</span>'
-        if is_active:
-            label_html = f'<span class="active">{label_html}</span>'
+        if has_focus:
+            label_html = f'<span class="has-focus">{label_html}</span>'
         description_html = f'<span class="description">{html.escape(self.description)}</span>' if \
             self.description else ''
         content = indent_html + disclosure_button_html + icon_html + label_html + description_html
@@ -330,7 +330,7 @@ class TreeViewSheet(sublime.HtmlSheet):
                 color: color(var(--foreground) alpha(0.6));
                 padding-left: 0.5rem;
             }}
-            .active {{
+            .has-focus {{
                 background-color: color(var(--accent));
             }}
         </style>
@@ -356,7 +356,7 @@ class TreeViewSheet(sublime.HtmlSheet):
 
     def _subtree_html(self, node_id: str) -> str:
         node = self.nodes[node_id]
-        html = node.tree_item.html(self.name, node.indent_level, node_id == self.selected_node_id)
+        html = node.tree_item.html(self.name, node.indent_level, has_focus=node_id == self.selected_node_id)
         if node.tree_item.collapsible_state == TreeItemCollapsibleState.EXPANDED:
             html += "".join([self._subtree_html(child_id) for child_id in node.child_ids])
         return html

--- a/plugin/core/tree_view.py
+++ b/plugin/core/tree_view.py
@@ -440,11 +440,6 @@ class LspActivateTreeItemCommand(sublime_plugin.WindowCommand):
 
 class LspHandleTreeViewActionCommand(sublime_plugin.WindowCommand):
 
-    def is_enabled(self) -> bool:
-        if (active_sheet := self.window.active_sheet()) and (wm := windows.lookup(self.window)):
-            return active_sheet in wm.tree_view_sheets.values()
-        return False
-
     def run(self, action: TreeViewAction) -> None:
         if (
             (active_sheet := self.window.active_sheet()) and (wm := windows.lookup(self.window))

--- a/plugin/core/tree_view.py
+++ b/plugin/core/tree_view.py
@@ -331,7 +331,7 @@ class TreeViewSheet(sublime.HtmlSheet):
                 padding-left: 0.5rem;
             }}
             .has-focus {{
-                background-color: color(var(--accent));
+                background-color: color(var(--accent) alpha(0.3));
             }}
         </style>
         <body id="lsp-tree-view" class="lsp_sheet">

--- a/plugin/core/tree_view.py
+++ b/plugin/core/tree_view.py
@@ -200,14 +200,14 @@ class TreeViewSheet(sublime.HtmlSheet):
             if current_index == next_index:
                 return
             next_node_id = self.ordered_node_ids[next_index]
-            self.activate_item(next_node_id)
+            self.select_item(next_node_id)
         elif action == 'move_up':
             current_index = self.ordered_node_ids.index(self.selected_node_id)
             previous_index = max(0, current_index - 1)
             if current_index == previous_index:
                 return
             previous_node_id = self.ordered_node_ids[previous_index]
-            self.activate_item(previous_node_id)
+            self.select_item(previous_node_id)
         elif action == 'move_left':
             if selected_node.tree_item.collapsible_state == TreeItemCollapsibleState.EXPANDED:
                 self.collapse_item(self.selected_node_id)
@@ -215,10 +215,12 @@ class TreeViewSheet(sublime.HtmlSheet):
                 TreeItemCollapsibleState.COLLAPSED,
                 TreeItemCollapsibleState.NONE
             }:
-                self.activate_item(selected_node.parent_node_id)
+                self.select_item(selected_node.parent_node_id)
         elif action == 'move_right':
             if selected_node.tree_item.collapsible_state == TreeItemCollapsibleState.COLLAPSED:
                 self.expand_item(self.selected_node_id)
+        elif action == 'activate':
+            self.activate_item(self.selected_node_id)
 
     def expand_item(self, node_id: str) -> None:
         assert node_id in self.nodes
@@ -234,7 +236,7 @@ class TreeViewSheet(sublime.HtmlSheet):
         self.nodes[node_id].tree_item.collapsible_state = TreeItemCollapsibleState.COLLAPSED
         self._update_contents()
 
-    def activate_item(self, node_id: str) -> None:
+    def select_item(self, node_id: str) -> None:
         assert node_id in self.nodes
         self.selected_node_id = node_id
         node = self.nodes[node_id]
@@ -242,6 +244,12 @@ class TreeViewSheet(sublime.HtmlSheet):
             self._update_contents()
         else:
             self._resolve_children(node_id)
+
+    def activate_item(self, node_id: str) -> None:
+        self.select_item(node_id)
+        assert node_id in self.nodes
+        self.selected_node_id = node_id
+        node = self.nodes[node_id]
         if action_command := node.tree_item.action_command:
             sublime.active_window().run_command(*action_command)
 

--- a/plugin/core/tree_view.py
+++ b/plugin/core/tree_view.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from .css import css
 from .promise import Promise
-from .registry import LspWindowCommand
 from .registry import windows
 from abc import ABC
 from abc import abstractmethod
@@ -15,6 +14,7 @@ from typing import TypeVar
 import html
 import sublime
 import sublime_api  # pyright: ignore[reportMissingImports]
+import sublime_plugin
 import uuid
 
 if TYPE_CHECKING:
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 # pyright: reportInvalidTypeVarUse=false
 T = TypeVar('T')
 
+TreeViewAction = Literal['move_up', 'move_right', 'move_down', 'move_left', 'close', 'activate']
 
 KIND_CLASS_NAMES: dict[int, str] = {
     sublime.KindId.KEYWORD: 'kind kind_keyword',
@@ -187,27 +188,27 @@ class TreeViewSheet(sublime.HtmlSheet):
             .then(partial(self._add_children, node_id)) \
             .then(lambda _: self._update_contents())
 
-    def navigate(self, direction: Literal['up', 'right', 'down', 'left', 'close']) -> None:
-        if direction == 'close':
+    def handle_action(self, action: TreeViewAction) -> None:
+        if action == 'close':
             self.close()
             return
         if not self.selected_node_id or not (selected_node := self.nodes[self.selected_node_id]):
             return
-        if direction == 'down':
+        if action == 'move_down':
             current_index = self.ordered_node_ids.index(self.selected_node_id)
             next_index = min(len(self.ordered_node_ids) - 1, current_index + 1)
             if current_index == next_index:
                 return
             next_node_id = self.ordered_node_ids[next_index]
             self.activate_item(next_node_id)
-        elif direction == 'up':
+        elif action == 'move_up':
             current_index = self.ordered_node_ids.index(self.selected_node_id)
             previous_index = max(0, current_index - 1)
             if current_index == previous_index:
                 return
             previous_node_id = self.ordered_node_ids[previous_index]
             self.activate_item(previous_node_id)
-        elif direction == 'left':
+        elif action == 'move_left':
             if selected_node.tree_item.collapsible_state == TreeItemCollapsibleState.EXPANDED:
                 self.collapse_item(self.selected_node_id)
             elif selected_node.parent_node_id and selected_node.tree_item.collapsible_state in {
@@ -215,11 +216,9 @@ class TreeViewSheet(sublime.HtmlSheet):
                 TreeItemCollapsibleState.NONE
             }:
                 self.activate_item(selected_node.parent_node_id)
-        elif direction == 'right':
+        elif action == 'move_right':
             if selected_node.tree_item.collapsible_state == TreeItemCollapsibleState.COLLAPSED:
                 self.expand_item(self.selected_node_id)
-        # TODO: reliable focus
-        sublime.set_timeout(lambda: sublime.active_window().focus_sheet(self), 300)
 
     def expand_item(self, node_id: str) -> None:
         assert node_id in self.nodes
@@ -255,15 +254,6 @@ class TreeViewSheet(sublime.HtmlSheet):
             {}
             h3 a {{
                 text-decoration: none;
-            }}
-            kbd {{
-                background-color: color(var(--foreground) lightness(+ 5%));
-                border-radius: 0.25rem;
-                border: 1px solid color(var(--foreground) alpha(0.25));
-                color: var(--background);
-                font-size: 0.9rem;
-                padding: 0.05rem 0.25rem;
-                line-height: 0.8rem;
             }}
             .tree-view {{
                 padding: 0.5rem;
@@ -338,7 +328,6 @@ class TreeViewSheet(sublime.HtmlSheet):
         </style>
         <body id="lsp-tree-view" class="lsp_sheet">
             <h3>{}</h3>
-            <div class="description">use <kbd>↑</kbd> <kbd>↓</kbd> <kbd>←</kbd> <kbd>→</kbd> to move around</div>
             <div class="tree-view">{}</div>
         </body>
         """.format(css().sheets, self.header, "".join([self._subtree_html(root_id) for root_id in self.root_nodes]))
@@ -431,19 +420,34 @@ def activate_tree_item(window: sublime.Window, name: str, node_id: str) -> None:
     sheet.activate_item(node_id)
 
 
-class LspExpandTreeItemCommand(LspWindowCommand):
+class LspExpandTreeItemCommand(sublime_plugin.WindowCommand):
 
     def run(self, name: str, node_id: str) -> None:
         toggle_tree_item(self.window, name, node_id, True)
 
 
-class LspCollapseTreeItemCommand(LspWindowCommand):
+class LspCollapseTreeItemCommand(sublime_plugin.WindowCommand):
 
     def run(self, name: str, node_id: str) -> None:
         toggle_tree_item(self.window, name, node_id, False)
 
 
-class LspActivateTreeItemCommand(LspWindowCommand):
+class LspActivateTreeItemCommand(sublime_plugin.WindowCommand):
 
     def run(self, name: str, node_id: str) -> None:
         activate_tree_item(self.window, name, node_id)
+
+
+class LspHandleTreeViewActionCommand(sublime_plugin.WindowCommand):
+
+    def is_enabled(self) -> bool:
+        if (active_sheet := self.window.active_sheet()) and (wm := windows.lookup(self.window)):
+            return active_sheet in wm.tree_view_sheets.values()
+        return False
+
+    def run(self, action: TreeViewAction) -> None:
+        if (
+            (active_sheet := self.window.active_sheet()) and (wm := windows.lookup(self.window))
+            and (sheet := next((sheet for sheet in wm.tree_view_sheets.values() if sheet == active_sheet), None))
+        ):
+            sheet.handle_action(action)

--- a/plugin/core/tree_view.py
+++ b/plugin/core/tree_view.py
@@ -406,26 +406,11 @@ def new_tree_view_sheet(
 
 
 def toggle_tree_item(window: sublime.Window, name: str, node_id: str, expand: bool) -> None:
-    wm = windows.lookup(window)
-    if not wm:
-        return
-    sheet = wm.tree_view_sheets.get(name)
-    if not sheet:
-        return
-    if expand:
-        sheet.expand_item(node_id)
-    else:
-        sheet.collapse_item(node_id)
-
-
-def activate_tree_item(window: sublime.Window, name: str, node_id: str) -> None:
-    wm = windows.lookup(window)
-    if not wm:
-        return
-    sheet = wm.tree_view_sheets.get(name)
-    if not sheet:
-        return
-    sheet.activate_item(node_id)
+    if (wm := windows.lookup(window)) and (sheet := wm.tree_view_sheets.get(name)):
+        if expand:
+            sheet.expand_item(node_id)
+        else:
+            sheet.collapse_item(node_id)
 
 
 class LspExpandTreeItemCommand(sublime_plugin.WindowCommand):
@@ -443,7 +428,8 @@ class LspCollapseTreeItemCommand(sublime_plugin.WindowCommand):
 class LspActivateTreeItemCommand(sublime_plugin.WindowCommand):
 
     def run(self, name: str, node_id: str) -> None:
-        activate_tree_item(self.window, name, node_id)
+        if (wm := windows.lookup(self.window)) and (sheet := wm.tree_view_sheets.get(name)):
+            sheet.activate_item(node_id)
 
 
 class LspHandleTreeViewActionCommand(sublime_plugin.WindowCommand):

--- a/plugin/hierarchy.py
+++ b/plugin/hierarchy.py
@@ -69,22 +69,21 @@ class HierarchyDataProvider(TreeDataProvider):
     def get_tree_item(self, element: HierarchyItemWrapper) -> TreeItem:
         item = element['item']
         selection_range = element['selectionRange']
-        command_url = sublime.command_url('lsp_open_location', {
-            'location': {
-                'targetUri': item['uri'],
-                'targetRange': item['range'],
-                'targetSelectionRange': selection_range
-            },
-            'session_name': self.session_name,
-            'flags': sublime.NewFileFlags.ADD_TO_SELECTION | sublime.NewFileFlags.SEMI_TRANSIENT | sublime.NewFileFlags.CLEAR_TO_RIGHT  # noqa: E501
-        })
         path = simple_path(self.weaksession(), item['uri'])
         return TreeItem(
             item['name'],
             kind=SYMBOL_KINDS.get(item['kind'], sublime.KIND_AMBIGUOUS),
             description=item.get('detail', ''),
             tooltip="{}:{}".format(path, item['selectionRange']['start']['line'] + 1),
-            command_url=command_url
+            action_command=('lsp_open_location', {
+                'location': {
+                    'targetUri': item['uri'],
+                    'targetRange': item['range'],
+                    'targetSelectionRange': selection_range
+                },
+                'session_name': self.session_name,
+                'flags': sublime.NewFileFlags.ADD_TO_SELECTION | sublime.NewFileFlags.SEMI_TRANSIENT | sublime.NewFileFlags.CLEAR_TO_RIGHT  # noqa: E501
+            })
         )
 
 


### PR DESCRIPTION
The idea: implement focus handling in tree view (used by call hierarchy) so that it's possible to navigate quickly using keyboard. I kinda want this functionality for another use case that doesn't exist yet (navigating symbol list) but it would be nice to have for call hierarchy also.

Problem with implementing keyboard navigation for call hierarchy is that clicking a caller focuses another view which is interfering with being able to navigate quickly. This is not a solved problem and it means that supporting keyboard navigation in it might not be feasible (though I haven't thought hard enough about it yet). That said, supporting focus state would be useful anyway.

I've included some keybindings and a command for navigating using keyboard for testing but those are not meant to be integrated in their current form, most likely. This PR mostly just concerns adding focus state. The keyboard navigation is what it allows to build on top of that but this PR is not really meant to add that, it's here just to be able to test the focus state.

https://github.com/user-attachments/assets/eec1ece7-821b-4a65-a018-94ccfd6fb08a

