### PR TITLE
Allow pylsp and pyrefly to work with this repository

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,3 +150,12 @@ ignore = [
     "TRY003",  # https://docs.astral.sh/ruff/rules/raise-vanilla-args/
     "TRY301",  # https://docs.astral.sh/ruff/rules/raise-within-try/
 ]
+
+[tool.pyrefly]
+python-version = "3.8.0"
+site-package-path = ["./stubs"]
+infer-with-first-use = false
+
+[tool.pyrefly.errors]
+bad-override = "ignore"
+missing-source = "ignore"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[pycodestyle]
-max_line_length = 120
-max_doc_length = 120

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[pycodestyle]
+max_line_length = 120
+max_doc_length = 120


### PR DESCRIPTION
This adds a few lines of configuration so that:

* pylsp does not complain about line length being >79 chars
* pyrefly works