### PR TITLE
Fix deadlock on unloading LSP module

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -197,8 +197,7 @@ def _register_all_plugins() -> None:
 
 def _unregister_all_plugins() -> None:
     g_plugins.clear()
-    client_configs.external.clear()
-    client_configs.all.clear()
+    client_configs.remove_all_configs()
 
 
 def plugin_loaded() -> None:
@@ -220,6 +219,10 @@ def plugin_loaded() -> None:
 def plugin_unloaded() -> None:
     _unregister_all_plugins()
     windows.disable()
+    for listeners in sublime_plugin.view_event_listeners.values():
+        for listener in listeners:
+            if isinstance(listener, DocumentSyncListener):
+                listener.before_destroy()
     unload_settings()
 
 

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -92,6 +92,7 @@ class ClientConfigs:
         names = list(self.all.keys())
         for name in names:
             self.remove_external_config(name, notify_listener=False)
+        self.all.clear()
 
     def _update_external_config(self, name: str, settings_store: SettingsStore) -> None:
         try:

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -33,8 +33,8 @@ class ClientConfigs:
 
     def __init__(self) -> None:
         self.all: dict[str, ClientConfig] = {}
-        self.external: dict[str, ClientConfig] = {}
-        self.external_settings_registrations: dict[str, SettingsRegistration] = {}
+        self._external: dict[str, ClientConfig] = {}
+        self._external_settings_registrations: dict[str, SettingsRegistration] = {}
         self._listener: LspSettingsChangeListener | None = None
         self._clients_hash: int | None = None
 
@@ -56,17 +56,17 @@ class ClientConfigs:
         self._notify_clients_listener()
 
     def add_external_config(self, name: str, settings_path: str, notify_listener: bool) -> bool:
-        if name in self.external:
+        if name in self._external:
             return False
         settings = sublime.load_settings(basename(settings_path))
         settings_store = SettingsStore(settings, settings_path)
         config = ClientConfig.from_sublime_settings(name, settings_store)
         registration = SettingsRegistration(settings, partial(self._update_external_config, name, settings_store))
-        self.external_settings_registrations[name] = registration
-        self.external[name] = config
+        self._external_settings_registrations[name] = registration
+        self._external[name] = config
         self.all[name] = config
         if notify_listener:
-            size = len(self.external)
+            size = len(self._external)
             # A debounced call is necessary here because of the following problem.
             # When Sublime Text starts, it loads plugins in alphabetical order.
             # Each plugin is loaded 100 milliseconds after the previous plugin.
@@ -78,15 +78,20 @@ class ClientConfigs:
             # That causes many calls to WindowConfigManager.match_view, which is relatively speaking an expensive
             # operation. To ensure that this dance is done only once, we delay notifying the WindowConfigManager until
             # all plugins have done their `register_plugin` call.
-            debounced(lambda: self._notify_clients_listener(name), 200, lambda: len(self.external) == size)
+            debounced(lambda: self._notify_clients_listener(name), 200, lambda: len(self._external) == size)
         return True
 
-    def remove_external_config(self, name: str) -> None:
-        if registration := self.external_settings_registrations.pop(name, None):
+    def remove_external_config(self, name: str, *, notify_listener: bool = True) -> None:
+        if registration := self._external_settings_registrations.pop(name, None):
             registration.unregister()
-        self.external.pop(name, None)
-        if self.all.pop(name, None):
+        self._external.pop(name, None)
+        if self.all.pop(name, None) and notify_listener:
             self._notify_clients_listener()
+
+    def remove_all_configs(self) -> None:
+        names = list(self.all.keys())
+        for name in names:
+            self.remove_external_config(name, notify_listener=False)
 
     def _update_external_config(self, name: str, settings_store: SettingsStore) -> None:
         try:
@@ -95,7 +100,7 @@ class ClientConfigs:
             # The plugin is about to be disabled (for example by Package Control for an upgrade), let unregister_plugin
             # handle this
             return
-        self.external[name] = config
+        self._external[name] = config
         self.update_config(name, config)
 
     def update_configs(self) -> None:
@@ -113,7 +118,7 @@ class ClientConfigs:
             clients.update(_configs_registration.settings.to_dict())
         self.all.clear()
         self.all.update({name: ClientConfig.from_dict(name, d) for name, d in clients.get().items()})
-        self.all.update(self.external)
+        self.all.update(self._external)
         debug("enabled configs:", ", ".join(sorted(c.name for c in self.all.values() if c.enabled)))
         debug("disabled configs:", ", ".join(sorted(c.name for c in self.all.values() if not c.enabled)))
         self._notify_clients_listener()
@@ -125,7 +130,7 @@ class ClientConfigs:
     def _set_enabled(self, config_name: str, is_enabled: bool) -> None:
         from ..api import get_plugin
         if get_plugin(config_name):
-            config = self.external[config_name]
+            config = self._external[config_name]
             config.enabled = is_enabled
             return
         settings = sublime.load_settings(SERVER_CONFIGS_FILENAME)

--- a/plugin/documents.py
+++ b/plugin/documents.py
@@ -259,6 +259,11 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         # But this has to run on the async thread again
         sublime.set_timeout_async(self.on_activated_async)
 
+    def before_destroy(self) -> None:
+        self._cleanup()
+        self._registration.unregister()
+        self._closed = True
+
     # --- Implements AbstractViewListener ------------------------------------------------------------------------------
 
     def on_post_move_window_async(self) -> None:
@@ -517,9 +522,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener, AbstractViewListene
         if self._registered and self._manager:
             manager = self._manager
             sublime.set_timeout_async(lambda: manager.unregister_listener_async(self))
-        self._cleanup()
-        self._registration.unregister()
-        self._closed = True
+        self.before_destroy()
 
     def on_query_context(self, key: str, operator: int, operand: Any, match_all: bool) -> bool | None:
         # You can filter key bindings by the precense of a provider,


### PR DESCRIPTION
On unloading LSP module (when saving `LSP.boot`, for example), ST re-creates all `ViewEventListener`s referenced from that module. That should result in old instances being garbage collected but in our case `DocumentSyncListener` was not deleted because `settings.add_on_change` listener added in `DocumentSyncListener.__init__` was not unregistered so it held a strong reference to `DocumentSyncListener`. That resulted in a deadlock in some conditions (related bug report: https://github.com/sublimehq/sublime_text/issues/6868).

Go through all view listeners on LSP's `plugin_unload` and call our `DocumentSyncListener.before_destroy()` so that the settings listener is unregistered which then allows the instance to be GCed.

Also go through `ClientConfigs`' newly added `remove_all_configs()` to unregister settings listeners for removed configs instead of just clearing internal lists.