### PR TITLE
Trigger session start on adding the plugin

### DIFF
--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -153,7 +153,7 @@ class WindowConfigManager:
             if changed := changes['settings_changed']:
                 for listener in self._change_listeners:
                     listener.on_server_settings_changed(changed)
-            if changed := changes['root_changed'] + changes['removed']:
+            if changed := changes['root_changed'] + changes['removed'] + changes['added']:
                 for listener in self._change_listeners:
                     listener.on_configs_changed(changed)
 

--- a/tests/test_configurations.py
+++ b/tests/test_configurations.py
@@ -167,7 +167,7 @@ class WindowConfigManagerTests(ViewTestCase):
         manager.add_change_listener(change_listener)
         global_configs[TEST_CONFIG.name] = TEST_CONFIG
         manager.update(TEST_CONFIG.name)
-        change_listener.on_configs_changed.assert_not_called()
+        change_listener.on_configs_changed.assert_called_once_with([TEST_CONFIG])
         change_listener.on_server_settings_changed.assert_not_called()
         self.assertIn(TEST_CONFIG.name, manager.all)
 
@@ -282,7 +282,7 @@ class WindowConfigManagerTests(ViewTestCase):
             }
         }
         manager.update()
-        change_listener.on_configs_changed.assert_not_called()
+        change_listener.on_configs_changed.assert_called_once_with([manager.all[PROJECT_TEST_CONFIG_NAME]])
         change_listener.on_server_settings_changed.assert_not_called()
         self.assertIn(PROJECT_TEST_CONFIG_NAME, manager.all)
 


### PR DESCRIPTION
Fix issue where re-enabling LSP-ruff didn't trigger session start. We have to trigger [on_configs_changed](https://github.com/sublimelsp/LSP/blob/914e76d1035f4f2b1478c6af6ccf74126f39652a/plugin/core/windows.py#L590-L592).

Fixes #2899