### PR TITLE
fix: server starts in wrong dir

### DIFF
--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -66,6 +66,7 @@ from weakref import ref
 from weakref import WeakSet
 import functools
 import json
+import os
 import sublime
 import threading
 
@@ -295,7 +296,11 @@ class WindowManager(Manager, WindowConfigChangeListener, ViewStatusHandler):
             workspace_folders = sorted_workspace_folders(self._workspace.folders, file_path)
             plugin_class = get_plugin(config.name)
             variables = extract_variables(self._window)
-            cwd = workspace_folders[0].path if workspace_folders else None
+            cwd = (
+                workspace_folders[0].path
+                if workspace_folders
+                else (os.path.dirname(file_path) if file_path else None)
+            )
             context = OnPreStartContext(config, variables, initiating_view, cwd, workspace_folders)
             if plugin_class:
                 if issubclass(plugin_class, LspPlugin):


### PR DESCRIPTION
Fix mentioned in sublimelsp/LSP-ty#60.

For `LSP-ty` and `LSP-ruff`. If open folder from ST menu or start subl . in file explorer - servers starts in working/project dir:
`LSP: starting  ['C:\\Users\\...\\LSP-ty\\v0.0.50\\ty.exe', 'server'] in D:\working_dir`

If open file (eg. double click in file explorer or Open file from ST menu) - servers starts in installation dir of ST:
`LSP: starting ['C:\\Users\\...\\LSP-ty\\v0.0.50\\ty.exe', 'server'] in C:\Program Files\Sublime Text`
The server is expected to run in the directory of the file being edited for full functionality.
If the server is started in the wrong directory, not all functions will work (eg. `rename` or `completeFunctionParentheses`).

Maybe the same fix is ​​needed for plugin/tooling.py?