### PR TITLE
Fix return default on non-existing key

### DIFF
--- a/plugin/core/collections.py
+++ b/plugin/core/collections.py
@@ -55,8 +55,8 @@ class DottedDict:
         current: Any = self._d
         keys = path.split('.')
         for key in keys:
-            if isinstance(current, dict):
-                current = current.get(key)
+            if isinstance(current, dict) and key in current:
+                current = current[key]
             else:
                 return default
         return current


### PR DESCRIPTION
Fixes https://github.com/sublimelsp/LSP-rust-analyzer/issues/218

Feel free to edit as require for style/lint.

I left the `current = current.get(key)` alone as I am not sure if changing that to `current = current[key]` would be considered as `unrelated changes`.

This keep the return None if the value is actually an None value instead of replacing with default as per previous function, pre-https://github.com/sublimelsp/LSP/commit/7981a132ce889cfa0967372805b6909483a3c064