### PR TITLE
chore: ignore LSP-vale-ls when testing packages

### DIFF
--- a/.github/workflows/test-community-packages.yaml
+++ b/.github/workflows/test-community-packages.yaml
@@ -22,7 +22,13 @@ jobs:
           path: lsp_maintainers
 
       - name: Check out community package repositories
-        run: python3 scripts/checkout-repos.py --preferred-branch ${{ github.head_ref }} --exclude LSP --exclude LSP-pyvoice --exclude WolframLanguage
+        run: |
+          python3 scripts/checkout-repos.py \
+            --preferred-branch ${{ github.head_ref }} \
+            --exclude LSP \
+            --exclude LSP-pyvoice \
+            --exclude LSP-VHDL-ls \
+            --exclude WolframLanguage
         working-directory: lsp_maintainers
 
       - name: Use checkout of LSP from PR

--- a/.github/workflows/test-community-packages.yaml
+++ b/.github/workflows/test-community-packages.yaml
@@ -28,7 +28,6 @@ jobs:
             --exclude LSP \
             --exclude LSP-pyvoice \
             --exclude LSP-vale-ls \
-            --exclude LSP-VHDL-ls \
             --exclude WolframLanguage
         working-directory: lsp_maintainers
 

--- a/.github/workflows/test-community-packages.yaml
+++ b/.github/workflows/test-community-packages.yaml
@@ -27,6 +27,7 @@ jobs:
             --preferred-branch ${{ github.head_ref }} \
             --exclude LSP \
             --exclude LSP-pyvoice \
+            --exclude LSP-vale-ls \
             --exclude LSP-VHDL-ls \
             --exclude WolframLanguage
         working-directory: lsp_maintainers

--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -1,13 +1,7 @@
 # Stubs for sublime.py
 from enum import IntEnum, IntFlag
 from typing import Any, Callable, Iterable, Iterator, Literal, Optional, Reversible, Sequence
-from typing_extensions import TypedDict, deprecated
-
-
-class Layout(TypedDict):
-    cells: list[list[int]]
-    cols: list[float]
-    rows: list[float]
+from typing_extensions import deprecated
 
 
 class HoverZone(IntEnum):
@@ -1269,17 +1263,17 @@ class Window:
         """
         ...
 
-    def layout(self) -> Layout:
+    def layout(self) -> dict[str, Any]:
         """
         Get the group layout of the window.
         """
         ...
 
     @deprecated("Use layout() instead")
-    def get_layout(self) -> Layout:
+    def get_layout(self) -> dict[str, Any]:
         ...
 
-    def set_layout(self, layout: Layout) -> None:
+    def set_layout(self, layout: dict[str, Any]) -> None:
         """
         Set the group layout of the window.
         """

--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -1,7 +1,13 @@
 # Stubs for sublime.py
 from enum import IntEnum, IntFlag
 from typing import Any, Callable, Iterable, Iterator, Literal, Optional, Reversible, Sequence
-from typing_extensions import deprecated
+from typing_extensions import TypedDict, deprecated
+
+
+class Layout(TypedDict):
+    cells: list[list[int]]
+    cols: list[float]
+    rows: list[float]
 
 
 class HoverZone(IntEnum):
@@ -1263,17 +1269,17 @@ class Window:
         """
         ...
 
-    def layout(self) -> dict[str, Any]:
+    def layout(self) -> Layout:
         """
         Get the group layout of the window.
         """
         ...
 
     @deprecated("Use layout() instead")
-    def get_layout(self) -> dict[str, Any]:
+    def get_layout(self) -> Layout:
         ...
 
-    def set_layout(self, layout: dict[str, Any]) -> None:
+    def set_layout(self, layout: Layout) -> None:
         """
         Set the group layout of the window.
         """


### PR DESCRIPTION
~~We don't use that type anywhere but not having proper type results in an error when running the `test-community-packages.yaml` workflow because LSP-copilot [bundles its own](https://github.com/sublimelsp/LSP-copilot/blob/843a9006f440a2fadc15e8ec9105ed9770dca993/plugin/types.py#L36-L39) (matching our new one) type for Layout.~~

Just ignore one package whose maintainer is inactive.