### PR TITLE
chore: ignore LSP-gnols when testing packages

### DIFF
--- a/.github/workflows/test-community-packages.yaml
+++ b/.github/workflows/test-community-packages.yaml
@@ -26,6 +26,7 @@ jobs:
           python3 scripts/checkout-repos.py \
             --preferred-branch ${{ github.head_ref }} \
             --exclude LSP \
+            --exclude LSP-gnols \
             --exclude LSP-pyvoice \
             --exclude LSP-vale-ls \
             --exclude WolframLanguage


### PR DESCRIPTION
ignore [LSP-gnols](https://github.com/gno-playground/LSP-gnols) - not maintained, doesn't even opt-in to python 3.8.