### PR TITLE
fix tree item text indent when no kind

### DIFF
--- a/plugin/core/tree_view.py
+++ b/plugin/core/tree_view.py
@@ -288,7 +288,8 @@ class TreeViewSheet(sublime.HtmlSheet):
                 margin-right: 6px;
             }}
             .kind_ambiguous {{
-                display: none;
+                margin-left: 0;
+                width: 0;
             }}
             .kind_keyword {{
                 background-color: color(var(--pinkish) a(0.2));


### PR DESCRIPTION
When no kind specified, the spacing between the arrow and the text was too small.

### Before

<img width="303" height="229" alt="Screenshot 2026-07-02 at 22 00 43" src="https://github.com/user-attachments/assets/b9d571aa-5188-47c7-b9b5-d43d666d31c0" />

### After

<img width="282" height="225" alt="Screenshot 2026-07-02 at 22 01 20" src="https://github.com/user-attachments/assets/b771f0de-04a3-438a-96f1-45062d997a6d" />
