### PR TITLE
Fix workspace/textDocumentContent for roslyn-language-server

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1498,7 +1498,9 @@ class Session(APIHandler, TransportCallbacks):
             view = self.window.new_file(flags)
             view.set_scratch(True)
             return Promise.resolve(view)
-        if scheme in self.get_capability('textDocumentContentProvider.schemes', []):
+        if scheme in self.get_capability('workspace.textDocumentContent.schemes', []) or scheme in self.get_capability(
+            'textDocumentContentProvider.schemes', []
+        ):
             return self.send_request_task(Request('workspace/textDocumentContent', {'uri': uri})) \
                 .then(lambda response: self._on_text_document_content_async(response, uri, flags, group)) \
                 .then(lambda view: self._on_view_for_uri_opened(view, uri, r) if view else None)


### PR DESCRIPTION
The roslyn-language-server puts the schemes in the capabilty path `workspace.textDocumentContent.schemes`. It does that on this line:

https://github.com/dotnet/roslyn/blob/83ca1a6465bb861e28a51cdbb4b56074b69cb5eb/src/LanguageServer/Protocol/DefaultCapabilitiesProvider.cs#L152

Triggering `workspace/textDocumentContent` is differs from JETLS. You need to have something called auto-generated-source. I'm fuzzy on the details as an LLM has generated this project for me.

In any case, in this zip:

[hello-world.zip](https://github.com/user-attachments/files/29711092/hello-world.zip)

is a complete C# (.NET 10) "hello-world" project that can trigger the request. In the zip is a Program.cs file with a single line:

```cs
Console.WriteLine(HelloWorld.Generated.GetMessage());
```

When you use "Go To Definition" on the `GetMessage` method, then that will trigger the `workspace/textDocumentContent` request, because roslyn-language-server sends back a URI for that definition with the scheme:

```
roslyn-source-generated
```

Sample log lines from LSP:

```
:: [18:26:49.006] --> roslyn textDocument/definition (47): {'textDocument': {'uri': 'file:///tmp/opencode/hello-world/HelloWorld.App/Program.cs'}, 'position': {'line': 0, 'character': 43}, 'workDoneToken': '$ublime-work-done-progress-47'}
:: [18:26:49.034] <<< roslyn (47) (duration: 27ms): [{'uri': 'roslyn-source-generated://2c853685-dcd9-4856-a501-3d0e82cdbbe9/HelloWorld.g.cs?documentId=9af8a26e-b63e-6365-f8a2-2b0b340f14a2&hintName=HelloWorld.g.cs&assemblyName=HelloWorld.Generator&assemblyVersion=1.0.0.0&typeName=HelloWorld.HelloWorldGenerator&assemblyPath=%2Ftmp%2Fopencode%2Fhello-world%2FHelloWorld.Generator%2Fbin%2FDebug%2Fnetstandard2.0%2FHelloWorld.Generator.dll', 'range': {'start': {'line': 4, 'character': 29}, 'end': {'line': 4, 'character': 39}}}]
:: [18:26:49.035] --> roslyn workspace/textDocumentContent (48): {'uri': 'roslyn-source-generated://2c853685-dcd9-4856-a501-3d0e82cdbbe9/HelloWorld.g.cs?documentId=9af8a26e-b63e-6365-f8a2-2b0b340f14a2&hintName=HelloWorld.g.cs&assemblyName=HelloWorld.Generator&assemblyVersion=1.0.0.0&typeName=HelloWorld.HelloWorldGenerator&assemblyPath=%2Ftmp%2Fopencode%2Fhello-world%2FHelloWorld.Generator%2Fbin%2FDebug%2Fnetstandard2.0%2FHelloWorld.Generator.dll'}
:: [18:26:49.041] <<< roslyn (48) (duration: 6ms): {'text': 'namespace HelloWorld\n{\n    internal static class Generated\n    {\n        public static string GetMessage() => "Hello from source generator!";\n    }\n}'}
```

My client config was:

```json
    "roslyn": {
        "enabled": true,
        "command": [
            "/home/raoul/.dotnet/tools/roslyn-language-server",
            "--logLevel",
            "Warning",
            "--autoLoadProjects",
            "--stdio"
        ],
        "selector": "source.cs"
    },
```

Server was installed with:

```
dotnet tool install --global roslyn-language-server --prerelease
```

(and requires .NET 10)