### PR TITLE
Properly fix wrong capability name for textDocumentContent provider

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -1498,7 +1498,7 @@ class Session(APIHandler, TransportCallbacks):
             view = self.window.new_file(flags)
             view.set_scratch(True)
             return Promise.resolve(view)
-        if scheme in self.get_capability('textDocumentContentProvider.schemes', []):
+        if scheme in self.get_capability('workspace.textDocumentContent.schemes', []):
             return self.send_request_task(Request('workspace/textDocumentContent', {'uri': uri})) \
                 .then(lambda response: self._on_text_document_content_async(response, uri, flags, group)) \
                 .then(lambda view: self._on_view_for_uri_opened(view, uri, r) if view else None)

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -546,6 +546,7 @@ _METHOD_TO_CAPABILITY_EXCEPTIONS: dict[str, tuple[str, str | None]] = {
     'workspace/didChangeConfiguration': ('workspace.didChangeConfiguration', None),
     'workspace/didChangeWorkspaceFolders': ('workspace.workspaceFolders',
                                             'workspace.workspaceFolders.changeNotifications'),
+    'workspace/textDocumentContent': ('workspace.textDocumentContent', None),
     'textDocument/didOpen': ('textDocumentSync.didOpen', None),
     'textDocument/didClose': ('textDocumentSync.didClose', None),
     'textDocument/didChange': ('textDocumentSync.change', None),


### PR DESCRIPTION
... continuing from #2977 

Revert https://github.com/sublimelsp/LSP/commit/c63e4b2d77157aa888d51a56129d5df1f707b0de, which was the wrong way to "fix" it for dynamic registration, and add the correct name to the capability path exceptions map instead.

Tested and confirmed to work with JETLS.