### PR TITLE
chore: add integration test for workspace/textDocumentContent

### DIFF
--- a/tests/server.py
+++ b/tests/server.py
@@ -18,7 +18,6 @@ Tests can await this request to make sure that they receive notification before 
 resumes (since response to request will arrive after requested notification).
 
 To make the server do a request when running a Command, send the $test/setupCommandAction request.
-
 """
 from __future__ import annotations
 

--- a/tests/server.py
+++ b/tests/server.py
@@ -17,6 +17,8 @@ with expected notification method in params['method'] and params in params['para
 Tests can await this request to make sure that they receive notification before code
 resumes (since response to request will arrive after requested notification).
 
+To make the server do a request when running a Command, send the $test/setupCommandAction request.
+
 """
 from __future__ import annotations
 
@@ -174,6 +176,7 @@ class Session:
         self._responses: list[tuple[str, PayloadLike]] = []
         self._received: dict[str, PayloadLike] = {}
         self._received_cv = asyncio.Condition()
+        self._command_actions: dict[str, PayloadLike] = {}
 
         self._install_handlers()
 
@@ -323,6 +326,7 @@ class Session:
 
     def _install_handlers(self) -> None:
         self._on_request("initialize", self._initialize)
+        self._on_request("workspace/executeCommand", self._execute_command)
         self._on_request("shutdown", self._shutdown)
         self._on_notification("exit", self._on_exit)
 
@@ -330,6 +334,8 @@ class Session:
         self._on_request("$test/fakeRequest", self._fake_request)
         self._on_request("$test/sendNotification", self._send_notification)
         self._on_request("$test/setResponses", self._set_responses)
+        self._on_request("$test/getAndClearUnusedMockResponses", self._get_and_clear_unused_mock_responses)
+        self._on_request("$test/setupCommandAction", self._setup_command_action)
         self._on_notification("$test/setResponse", self._on_set_response)
 
     async def _on_set_response(self, params: PayloadLike) -> None:
@@ -346,6 +352,42 @@ class Session:
 
         self._responses.extend([(param['method'], param['response']) for param in params])
         return None
+
+    async def _get_and_clear_unused_mock_responses(self, params: PayloadLike) -> PayloadLike:
+        responses = list(self._responses)
+        command_actions = dict(self._command_actions)
+        self._responses = []
+        self._command_actions = {}
+        return {"responses": responses, "commandActions": command_actions}
+
+    async def _execute_command(self, params: PayloadLike) -> PayloadLike:
+        if not isinstance(params, dict):
+            raise Error(ErrorCode.InvalidParams, "expected params to be a dictionary")
+        command_name = params.get("command")
+        if command_name is None:
+            raise Error(ErrorCode.InvalidParams, 'expected "command" key')
+        action = self._command_actions.pop(command_name, None)
+        if isinstance(action, dict):
+            request_method = action.get("method")
+            if not isinstance(request_method, str):
+                raise Error(ErrorCode.InvalidParams, 'expected action to have a "method" key')
+            return await self.request(request_method, action.get("params"))
+        mocked = self._get_mocked_response("workspace/executeCommand")
+        if not isinstance(mocked, bool):
+            return mocked
+        return None
+
+    async def _setup_command_action(self, params: PayloadLike) -> PayloadLike:
+        if not isinstance(params, dict):
+            raise Error(ErrorCode.InvalidParams, 'params must be a dict')
+        command_name = params.pop("commandName")
+        if command_name in self._command_actions:
+            raise Error(ErrorCode.InvalidParams, f"command action for command \"{command_name}\" is already set up")
+        if "method" not in params:
+            raise Error(ErrorCode.InvalidParams, 'params must contain a "method" key')
+        if "params" not in params:
+            raise Error(ErrorCode.InvalidParams, 'params msut contain a "params" key')
+        self._command_actions[command_name] = params
 
     async def _send_notification(self, params: PayloadLike) -> PayloadLike:
         method, payload = self._validate_request_params(params)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -20,6 +20,7 @@ import sublime
 if TYPE_CHECKING:
     from collections.abc import Generator
     from LSP.plugin.core.promise import Promise
+    from LSP.protocol import LSPObject
 
 CI = any(key in environ for key in ("TRAVIS", "CI", "GITHUB_ACTIONS"))
 
@@ -257,6 +258,37 @@ class TextDocumentTestCase(DeferrableTestCase):
 
         payload = [{"method": method, "response": responses} for method, responses in responses]
         self.session.send_request(Request("$test/setResponses", payload), handler, error_handler)
+        yield from self.await_promise(promise)
+
+    def mock_command_action(self, command_name: str, action: LSPObject) -> Generator:
+        """
+        Make the fake server send a request when workspace/executeCommand is received.
+
+        The action must have a "method" key and a "params" key.
+
+        Examples:
+            await self.mock_command_action("myCommand", {
+                "method": "window/showDocument",
+                "params": {"uri": "file:///test.txt", "takeFocus": True}
+            })
+            await self.mock_command_action("rename", {
+                "method": "workspace/applyEdit",
+                "params": {"edit": {"changes": {...}}}
+            })
+        """
+        assert self.session
+        promise = YieldPromise()
+
+        def handler(params: Any) -> None:
+            promise.fulfill(params)
+
+        def error_handler(params: Any) -> None:
+            print("Got error:", params, "awaiting timeout :(")
+
+        self.session.send_request(Request("$test/setupCommandAction", {
+            "commandName": command_name,
+            **action
+        }), handler, error_handler)
         yield from self.await_promise(promise)
 
     def await_client_notification(self, method: str, params: Any = None) -> Generator:

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -20,7 +20,8 @@ import sublime
 if TYPE_CHECKING:
     from collections.abc import Generator
     from LSP.plugin.core.promise import Promise
-    from LSP.protocol import LSPObject
+    from LSP.plugin.core.protocol import ServerRequest
+
 
 CI = any(key in environ for key in ("TRAVIS", "CI", "GITHUB_ACTIONS"))
 
@@ -260,11 +261,9 @@ class TextDocumentTestCase(DeferrableTestCase):
         self.session.send_request(Request("$test/setResponses", payload), handler, error_handler)
         yield from self.await_promise(promise)
 
-    def mock_command_action(self, command_name: str, action: LSPObject) -> Generator:
+    def mock_command_action(self, command_name: str, action: ServerRequest) -> Generator:
         """
         Make the fake server send a request when workspace/executeCommand is received.
-
-        The action must have a "method" key and a "params" key.
 
         Examples:
             await self.mock_command_action("myCommand", {

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -261,16 +261,16 @@ class TextDocumentTestCase(DeferrableTestCase):
         self.session.send_request(Request("$test/setResponses", payload), handler, error_handler)
         yield from self.await_promise(promise)
 
-    def mock_command_action(self, command_name: str, action: ServerRequest) -> Generator:
+    def set_command_response_action(self, command_name: str, action: ServerRequest) -> Generator:
         """
         Make the fake server send a request when workspace/executeCommand is received.
 
         Examples:
-            await self.mock_command_action("myCommand", {
+            yield from self.set_command_response_action("myCommand", {
                 "method": "window/showDocument",
                 "params": {"uri": "file:///test.txt", "takeFocus": True}
             })
-            await self.mock_command_action("rename", {
+            yield from self.set_command_response_action("rename", {
                 "method": "workspace/applyEdit",
                 "params": {"edit": {"changes": {...}}}
             })

--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -29,6 +29,9 @@ basic_responses = {
             'workspace': {
                 'workspaceFolders': {
                     'supported': True
+                },
+                'textDocumentContent': {
+                    'schemes': ['r2d2']
                 }
             }
         }

--- a/tests/test_single_document.py
+++ b/tests/test_single_document.py
@@ -333,6 +333,27 @@ class SingleDocumentTestCase(TextDocumentTestCase):
         yield from self.await_message("workspace/executeCommand")
         self.assertEqual(promise.result(), {"canReturnAnythingHere": "asdf"})
 
+    def test_complex_request_chain_with_command(self) -> Generator:
+        # Setup mocks.
+        yield from self.mock_command_action(
+            "fooooobar",
+            {"method": "window/showDocument", "params": {"uri": "r2d2:some-decompiled-file-from-a-jar-or-dll"}},
+        )
+        self.set_response("workspace/textDocumentContent", {"text": "hello world"})
+        promise = YieldPromise()
+        sublime.set_timeout_async(
+            lambda: self.session.execute_command(
+                {"command": "fooooobar", "arguments": ["doesnt", "matter"]},
+                progress=False,
+                view=self.view,
+            ).then(promise.fulfill)
+        )
+        yield from self.await_promise(promise)
+        # Assert that some methods have been called.
+        params = yield from self.await_message("workspace/textDocumentContent")
+        self.assertEqual(params, {"uri": "r2d2:some-decompiled-file-from-a-jar-or-dll"})
+        self.assertEqual(promise.result(), {"success": True})
+
     def test_progress(self) -> Generator:
         request = Request("foobar", {"hello": "world"}, self.view, progress=True)
         self.set_response("foobar", {"general": "kenobi"})

--- a/tests/test_single_document.py
+++ b/tests/test_single_document.py
@@ -335,7 +335,7 @@ class SingleDocumentTestCase(TextDocumentTestCase):
 
     def test_complex_request_chain_with_command(self) -> Generator:
         # Setup mocks.
-        yield from self.mock_command_action(
+        yield from self.set_command_response_action(
             "fooooobar",
             {"method": "window/showDocument", "params": {"uri": "r2d2:some-decompiled-file-from-a-jar-or-dll"}},
         )


### PR DESCRIPTION
This teaches our fake server in tests/server.py to execute a server->client request when receiving a command. With this, we can set up an integration test that makes the fake server do a `window/showDocument` request when receiving a `workspace/executeCommand` request. In turn, that will then cause the client to make a `workspace/textDocumentContent` request.

So the request flow is:

1. Client->Server: `workspace/executeCommand`
2. Server->Client: `window/showDocument`
3. Client->Server: `workspace/textDocumentContent`
4. server resolves `workspace/textDocumentContent`
5. client resolves `window/showDocument`
6. server resolves `workspace/executeCommand`

I also ported along the `$test/getAndClearUnusedMockResponses` method, but that remains unused for now.