### PR TITLE
Add optional argument severity_level for diagnostics navigation

### DIFF
--- a/docs/src/keyboard_shortcuts.md
+++ b/docs/src/keyboard_shortcuts.md
@@ -66,15 +66,15 @@ Below is a list of supported commands and the corresponding keyboard shortcut (i
 | Format Selection | unbound | `lsp_format_document_range`
 | Goto Declaration | unbound | `lsp_symbol_declaration`
 | Goto Definition | unbound<br>suggested: <kbd>F12</kbd> | `lsp_symbol_definition`
-| Goto Diagnostic | unbound<br>suggested: <kbd>F8</kbd> | `lsp_goto_diagnostic`<br>Supports optional argument `"severity_level"` for the severity level of included diagnostics: 1 (error), 2 (warning), 3 (information), 4 (hint). Uses the `"show_diagnostics_severity_level"` setting if not provided.
 | Goto Implementation | unbound | `lsp_symbol_implementation`
 | Goto Symbol in Project | unbound<br>suggested: <kbd>Ctrl</kbd> <kbd>Shift</kbd> <kbd>R</kbd> | `lsp_workspace_symbols`
 | Goto Symbol | unbound<br>suggested: <kbd>Ctrl</kbd> <kbd>R</kbd> | `lsp_document_symbols`
 | Goto Type Definition | unbound | `lsp_symbol_type_definition`
-| Hover Popup | unbound | `lsp_hover`
-| Insert/Replace Completions | <kbd>Alt</kbd> <kbd>Enter</kbd> | `lsp_commit_completion_with_opposite_insert_mode`
+| Goto Diagnostic | unbound<br>suggested: <kbd>F8</kbd> | `lsp_goto_diagnostic`<br>Supports optional argument `"severity_level"` for the severity level of included diagnostics: 1 (error), 2 (warning), 3 (information), 4 (hint). Uses the `"show_diagnostics_severity_level"` setting if not provided.
 | Next Diagnostic | unbound | `lsp_next_diagnostic`<br>Supports optional argument `"severity_level"`
 | Previous Diagnostic | unbound | `lsp_prev_diagnostic`<br>Supports optional argument `"severity_level"`
+| Hover Popup | unbound | `lsp_hover`
+| Insert/Replace Completions | <kbd>Alt</kbd> <kbd>Enter</kbd> | `lsp_commit_completion_with_opposite_insert_mode`
 | Rename | unbound | `lsp_symbol_rename`
 | Restart Server | unbound | `lsp_restart_server`
 | Run Code Action | unbound | `lsp_code_actions`

--- a/docs/src/keyboard_shortcuts.md
+++ b/docs/src/keyboard_shortcuts.md
@@ -73,8 +73,8 @@ Below is a list of supported commands and the corresponding keyboard shortcut (i
 | Goto Type Definition | unbound | `lsp_symbol_type_definition`
 | Hover Popup | unbound | `lsp_hover`
 | Insert/Replace Completions | <kbd>Alt</kbd> <kbd>Enter</kbd> | `lsp_commit_completion_with_opposite_insert_mode`
-| Next Diagnostic | unbound | `lsp_next_diagnostic`
-| Previous Diagnostic | unbound | `lsp_prev_diagnostic`
+| Next Diagnostic | unbound | `lsp_next_diagnostic`<br>Supports optional argument `"severity_level"`
+| Previous Diagnostic | unbound | `lsp_prev_diagnostic`<br>Supports optional argument `"severity_level"`
 | Rename | unbound | `lsp_symbol_rename`
 | Restart Server | unbound | `lsp_restart_server`
 | Run Code Action | unbound | `lsp_code_actions`

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from .settings import userprefs
 from .views import first_selection_region
 from .views import get_uri_and_position_from_location
 from .views import MissingUriError
@@ -256,7 +257,9 @@ class LspCheckApplicableCommand(sublime_plugin.TextCommand):
             wm.recheck_is_applicable_async(self.view, session_name)
 
 
-def navigate_diagnostics(view: sublime.View, point: int | None, forward: bool = True) -> None:
+def navigate_diagnostics(
+    view: sublime.View, point: int | None, severity_level: int | None, *, forward: bool = True
+) -> None:
     try:
         uri = uri_from_view(view)
     except MissingUriError:
@@ -264,9 +267,11 @@ def navigate_diagnostics(view: sublime.View, point: int | None, forward: bool = 
     wm = windows.lookup(view.window())
     if not wm:
         return
+    if severity_level is None:
+        severity_level = userprefs().show_diagnostics_severity_level
     diagnostics: list[Diagnostic] = []
     for session in wm.get_sessions():
-        diagnostics.extend(session.diagnostics.get_diagnostics_for_uri(uri))
+        diagnostics.extend(session.diagnostics.get_diagnostics_for_uri(uri, severity_level))
     if not diagnostics:
         return
     # Sort diagnostics by location
@@ -297,8 +302,8 @@ def _show_diagnostic_popup(view: sublime.View, point: int) -> None:
 
 class LspNextDiagnosticCommand(LspTextCommand):
 
-    def run(self, edit: sublime.Edit, point: int | None = None) -> None:
-        navigate_diagnostics(self.view, point, forward=True)
+    def run(self, edit: sublime.Edit, point: int | None = None, severity_level: int | None = None) -> None:
+        navigate_diagnostics(self.view, point, severity_level, forward=True)
 
     def want_event(self) -> bool:
         return False
@@ -306,8 +311,8 @@ class LspNextDiagnosticCommand(LspTextCommand):
 
 class LspPrevDiagnosticCommand(LspTextCommand):
 
-    def run(self, edit: sublime.Edit, point: int | None = None) -> None:
-        navigate_diagnostics(self.view, point, forward=False)
+    def run(self, edit: sublime.Edit, point: int | None = None, severity_level: int | None = None) -> None:
+        navigate_diagnostics(self.view, point, severity_level, forward=False)
 
     def want_event(self) -> bool:
         return False


### PR DESCRIPTION
Closes #2983

Align the behavior of the jump to next/previous diagnostic commands with the "Goto Diagnostic" quick panel (only jumps to visible diagnostics by default).