### PR TITLE
feat: show progress when requesting code actions manually

### DIFF
--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -528,7 +528,7 @@ class LspMenuActionCommand(LspWindowCommand, ABC):
         if not view:
             return
         if (region := self._get_region(event)) is not None:
-            actions_manager.request_for_region_async(view, region, [], MENU_ACTIONS_KINDS, manual=True, progress=True)
+            actions_manager.request_for_region_async(view, region, [], MENU_ACTIONS_KINDS, manual=True)
 
 
 class LspRefactorCommand(LspMenuActionCommand):

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -98,7 +98,9 @@ class CodeActionsManager:
         region: sublime.Region,
         session_buffer_diagnostics: list[tuple[SessionBufferProtocol, list[Diagnostic]]],
         only_kinds: list[str | CodeActionKind] | None = None,
+        *,
         manual: bool = False,
+        progress: bool = False,
     ) -> Promise[list[CodeActionsByConfigName]]:
         """
         Requests code actions with provided diagnostics and specified region. If there are
@@ -129,7 +131,7 @@ class CodeActionsManager:
                     diagnostics = diags
                     break
             params = text_document_code_action_params(view, region, diagnostics, only_kinds, manual)
-            return Request.codeAction(params, view)
+            return Request.codeAction(params, view, progress=progress)
 
         def response_filter(sb: SessionBufferProtocol, actions: list[CodeActionOrCommand]) -> list[CodeActionOrCommand]:
             # Filter out non "quickfix" code actions unless "only_kinds" is provided.
@@ -397,9 +399,9 @@ class LspCodeActionsCommand(LspTextCommand):
         if not listener:
             return
         session_buffer_diagnostics = listener.get_diagnostics_async(region)
-        actions_manager \
-            .request_for_region_async(view, region, session_buffer_diagnostics, only_kinds, manual=True) \
-            .then(lambda actions: sublime.set_timeout(lambda: self._handle_code_actions(actions)))
+        actions_manager.request_for_region_async(
+            view, region, session_buffer_diagnostics, only_kinds, manual=True, progress=True
+        ).then(lambda actions: sublime.set_timeout(lambda: self._handle_code_actions(actions)))
 
     def _handle_code_actions(self, response: list[CodeActionsByConfigName], run_first: bool = False) -> None:
         # Flatten response to a list of (config_name, code_action) tuples.
@@ -526,7 +528,7 @@ class LspMenuActionCommand(LspWindowCommand, ABC):
         if not view:
             return
         if (region := self._get_region(event)) is not None:
-            actions_manager.request_for_region_async(view, region, [], MENU_ACTIONS_KINDS, True)
+            actions_manager.request_for_region_async(view, region, [], MENU_ACTIONS_KINDS, manual=True, progress=True)
 
 
 class LspRefactorCommand(LspMenuActionCommand):

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -85,9 +85,9 @@ class Request(Generic[P, R]):
 
     @classmethod
     def codeAction(
-        cls, params: CodeActionParams, view: sublime.View
+        cls, params: CodeActionParams, view: sublime.View, progress: bool = False
     ) -> Request[CodeActionParams, list[Command | CodeAction] | None]:
-        return Request("textDocument/codeAction", params, view)
+        return Request("textDocument/codeAction", params, view, progress=progress)
 
     @classmethod
     def documentColor(

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -840,7 +840,9 @@ class SessionBufferProtocol(Protocol):
         region: sublime.Region,
         diagnostics: list[Diagnostic],
         kinds: list[str | CodeActionKind] | None = ...,
-        trigger_kind: CodeActionTriggerKind = ...
+        trigger_kind: CodeActionTriggerKind = ...,
+        *,
+        progress: bool = False,
     ) -> Promise[list[Command | CodeAction] | Error | None]:
         ...
 

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -1001,7 +1001,9 @@ class SessionBuffer:
         region: sublime.Region,
         diagnostics: list[Diagnostic],
         kinds: list[str | CodeActionKind] | None = None,
-        trigger_kind: CodeActionTriggerKind = CodeActionTriggerKind.Automatic
+        trigger_kind: CodeActionTriggerKind = CodeActionTriggerKind.Automatic,
+        *,
+        progress: bool = False,
     ) -> Promise[list[Command | CodeAction] | Error | None]:
         context: CodeActionContext = {
             'diagnostics': diagnostics,
@@ -1014,7 +1016,7 @@ class SessionBuffer:
             'range': region_to_range(view, region),
             'context': context
         }
-        request = Request.codeAction(params, view)
+        request = Request.codeAction(params, view, progress=progress)
         return self.session.send_request_task(request)
 
     # --- textDocument/codeLens ----------------------------------------------------------------------------------------


### PR DESCRIPTION
Some servers take quite some time to return code actions (JETLS for example takes ~2 seconds for me).

When requesting such code actions from the command palette, it can be a little confusing to understand what is happening, as there is no feedback given when the code action results take ~2 seconds to compute.

This change shows the usual progress notification in the status bar when it's taking more than 200ms.