### PR TITLE
docs: add syntax_map to roslyn-language-server configuration

### DIFF
--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -81,7 +81,10 @@ Follow installation instructions on [LSP-clangd](https://github.com/sublimelsp/L
                 "--autoLoadProjects",
                 "--stdio"
             ],
-            "selector": "source.cs"
+            "selector": "source.cs",
+            "syntax_map": {
+                "roslyn-source-generated": "C#.sublime-syntax"
+            }
         }
     }
     ```


### PR DESCRIPTION
as [mentioned here](https://github.com/sublimelsp/LSP/pull/2977#issue-4821128777), roslyn-language-server may return URIs with scheme `roslyn-source-generated`. These just contain C\# content.