### PR TITLE
chore: make the 'P' type var contravariant

### DIFF
--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -5,6 +5,7 @@ from ...protocol import *  # For backward compatibility with LSP packages.  # no
 from functools import total_ordering
 from typing import Any
 from typing import Callable
+from typing import final
 from typing import Generic
 from typing import List
 from typing import Literal
@@ -22,7 +23,7 @@ if TYPE_CHECKING:
 INT_MAX = 2**31 - 1
 UINT_MAX = INT_MAX
 
-P = TypeVar('P', bound=LSPAny)
+P_contra = TypeVar('P_contra', bound=LSPAny, contravariant=True)
 R = TypeVar('R', bound=LSPAny)
 
 
@@ -49,14 +50,14 @@ class NotificationMessage(TypedDict):
 JSONRPCMessage = Union[RequestMessage, ResponseMessage, NotificationMessage]
 
 
-class Request(Generic[P, R]):
+class Request(Generic[P_contra, R]):
 
     __slots__ = ('method', 'params', 'view', 'progress', 'on_partial_result')
 
     def __init__(
         self,
         method: str,
-        params: P = None,
+        params: P_contra = None,
         view: sublime.View | None = None,
         progress: bool = False,
         on_partial_result: Callable[[R], None] | None = None,
@@ -297,33 +298,43 @@ class Error(Exception):
 
     def __init__(self, code: int, message: str, data: Any = None) -> None:
         super().__init__(message)
-        self.code = code
-        self.data = data
+        self._code = code
+        self._data = data
+
+    @property
+    def code(self) -> int:
+        return self._code
+
+    @property
+    def data(self) -> Any:
+        return self._data
 
     @classmethod
     def from_lsp(cls, params: ResponseError) -> Error:
         return Error(params["code"], params["message"], params.get("data"))
 
+    @final
     def to_lsp(self) -> ResponseError:
-        result: ResponseError = {"code": self.code, "message": super().__str__()}
-        if self.data:
-            result["data"] = self.data
+        result: ResponseError = {"code": self._code, "message": super().__str__()}
+        if self._data:
+            result["data"] = self._data
         return result
 
+    @final
     def __str__(self) -> str:
-        return f"{super().__str__()} ({self.code})"
+        return f"{super().__str__()} ({self._code})"
 
     @classmethod
     def from_exception(cls, ex: Exception) -> Error:
         return Error(ErrorCodes.InternalError, str(ex))
 
 
-class Response(Generic[P]):
+class Response(Generic[R]):
 
     __slots__ = ('request_id', 'result', 'post_response_callback')
 
     def __init__(
-        self, request_id: str | int, result: P, post_response_callback: PostResponseCallback | None = None
+        self, request_id: str | int, result: R, post_response_callback: PostResponseCallback | None = None
     ) -> None:
         self.request_id = request_id
         self.result = result
@@ -337,11 +348,11 @@ class Response(Generic[P]):
         }
 
 
-class Notification(Generic[P]):
+class Notification(Generic[P_contra]):
 
     __slots__ = ('method', 'params')
 
-    def __init__(self, method: str, params: P = None) -> None:
+    def __init__(self, method: str, params: P_contra = None) -> None:
         self.method = method
         self.params = params
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -132,7 +132,9 @@ from .protocol import ClientResponse
 from .protocol import Error
 from .protocol import JSONRPCMessage
 from .protocol import Notification
+from .protocol import P_contra
 from .protocol import Point
+from .protocol import R
 from .protocol import Request
 from .protocol import ResolvedCodeLens
 from .protocol import Response
@@ -182,7 +184,6 @@ from typing import Literal
 from typing import overload
 from typing import Protocol
 from typing import TYPE_CHECKING
-from typing import TypeVar
 from typing import Union
 from typing_extensions import TypeAlias
 from typing_extensions import TypeGuard
@@ -201,8 +202,6 @@ if TYPE_CHECKING:
 
 
 InitCallback: TypeAlias = Callable[['Session', bool], None]
-P = TypeVar('P', bound=LSPAny)
-R = TypeVar('R', bound=LSPAny)
 
 
 class ViewStateActions(IntFlag):
@@ -2481,7 +2480,7 @@ class Session(APIHandler, TransportCallbacks):
 
     def send_request_async(
             self,
-            request: Request[P, R],
+            request: Request[P_contra, R],
             on_result: Callable[[R], None],
             on_error: Callable[[ResponseError], None] | None = None
     ) -> int:
@@ -2500,27 +2499,27 @@ class Session(APIHandler, TransportCallbacks):
         elif self._plugin:
             client_request = cast('ClientRequest', cast('object', {'method': request.method, 'params': request.params}))
             self._plugin.on_pre_send_request_async(client_request, request.view)
-            request.params = cast('P', client_request['params'])
+            request.params = cast('P_contra', client_request['params'])
         self._logger.outgoing_request(request_id, request.method, request.params)
         self.send_payload(request.to_payload(request_id))
         return request_id
 
     def send_request(
             self,
-            request: Request[P, R],
+            request: Request[P_contra, R],
             on_result: Callable[[R], None],
             on_error: Callable[[ResponseError], None] | None = None,
     ) -> None:
         """You can call this method from any thread. Callbacks will run in Sublime's worker thread."""
         sublime.set_timeout_async(partial(self.send_request_async, request, on_result, on_error))
 
-    def send_request_task(self, request: Request[P, R]) -> Promise[R | Error]:
+    def send_request_task(self, request: Request[P_contra, R]) -> Promise[R | Error]:
         task: PackagedTask[Any] = Promise.packaged_task()
         promise, resolver = task
         self.send_request_async(request, resolver, lambda x: resolver(Error.from_lsp(x)))
         return promise
 
-    def send_request_task_2(self, request: Request[P, R]) -> tuple[Promise[R | Error], int]:
+    def send_request_task_2(self, request: Request[P_contra, R]) -> tuple[Promise[R | Error], int]:
         task: PackagedTask[R | Error] = Promise.packaged_task()
         promise, resolver = task
         request_id = self.send_request_async(request, resolver, lambda x: resolver(Error.from_lsp(x)))
@@ -2534,18 +2533,18 @@ class Session(APIHandler, TransportCallbacks):
             self._invoke_views(request, "on_request_canceled_async", request_id)
             self._response_handlers[request_id] = (request, lambda *args: None, lambda *args: None)
 
-    def send_notification(self, notification: Notification[P]) -> None:
+    def send_notification(self, notification: Notification[P_contra]) -> None:
         if self._plugin and isinstance(self._plugin, AbstractPlugin):
             self._plugin.on_pre_send_notification_async(notification)
         elif self._plugin:
             client_notification = cast('ClientNotification',
                                        cast('object', {'method': notification.method, 'params': notification.params}))
             self._plugin.on_pre_send_notification_async(client_notification)
-            notification.params = cast('P', client_notification['params'])
+            notification.params = cast('P_contra', client_notification['params'])
         self._logger.outgoing_notification(notification.method, notification.params)
         self.send_payload(notification.to_payload())
 
-    def send_response(self, response: Response[P]) -> None:
+    def send_response(self, response: Response[R]) -> None:
         self._logger.outgoing_response(response.request_id, response.result)
         self.send_payload(response.to_payload())
         if response.post_response_callback:


### PR DESCRIPTION
(I'm porting some self-contained bits from the feat/asyncio branch so that PR becomes a bit smaller.)

It's used as a type var for function arguments. This will allow for constructs like defining a function `foo` that takes a union of request types:

def foo(r: Request[A, X] | Request[B, X]) -> X:
    ...

The foo function takes either an object of type `Request[A,X]` or an object of type `Request[B,X]` and in both cases will return an object of type `X`.