### PR TITLE
Add Svelte language identifier

### DIFF
--- a/plugin/core/constants.py
+++ b/plugin/core/constants.py
@@ -313,6 +313,7 @@ LANGUAGE_IDENTIFIERS: dict[str, str] = {
     "text.html.markdown.rmarkdown": LanguageKind.R,  # https://github.com/REditorSupport/sublime-ide-r
     "text.html.rails": "erb",
     "text.html.vue": "vue",
+    "text.html.svelte": "svelte",
     "text.jinja": LanguageKind.HTML,  # https://github.com/Sublime-Instincts/BetterJinja
     "text.plain": "plaintext",
     "text.plist": LanguageKind.XML,  # https://bitbucket.org/fschwehn/sublime_plist

--- a/plugin/core/constants.py
+++ b/plugin/core/constants.py
@@ -312,8 +312,8 @@ LANGUAGE_IDENTIFIERS: dict[str, str] = {
     "text.html.markdown": LanguageKind.Markdown,
     "text.html.markdown.rmarkdown": LanguageKind.R,  # https://github.com/REditorSupport/sublime-ide-r
     "text.html.rails": "erb",
-    "text.html.vue": "vue",
     "text.html.svelte": "svelte",
+    "text.html.vue": "vue",
     "text.jinja": LanguageKind.HTML,  # https://github.com/Sublime-Instincts/BetterJinja
     "text.plain": "plaintext",
     "text.plist": LanguageKind.XML,  # https://bitbucket.org/fschwehn/sublime_plist


### PR DESCRIPTION
Adding this language identifier is necessary for Biome to work with Svelte files correctly.

See: https://github.com/sublimelsp/LSP-biome/issues/92
