### PR TITLE
Make LspTextCommand inherit from sublime_aio.ViewCommand

### DIFF
--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -353,9 +353,8 @@ class LspCodeActionsCommand(LspTextCommand):
             return self.is_enabled(event, point)
         return True
 
-    def run(
+    async def run(
         self,
-        edit: sublime.Edit,
         event: dict | None = None,
         only_kinds: list[str | CodeActionKind] | None = None,
         code_actions_by_config: list[CodeActionsByConfigName] | None = None
@@ -363,9 +362,6 @@ class LspCodeActionsCommand(LspTextCommand):
         if code_actions_by_config:
             self._handle_code_actions(code_actions_by_config, run_first=True)
             return
-        run_coroutine(self._run(only_kinds))
-
-    async def _run(self, only_kinds: list[str | CodeActionKind] | None = None) -> None:
         view = self.view
         region = first_selection_region(view)
         if region is None:
@@ -465,10 +461,7 @@ class LspMenuActionCommand(LspWindowCommand, ABC):
     def want_event(self) -> bool:
         return True
 
-    def run(self, index: int, event: dict | None = None) -> None:
-        run_coroutine(self._run(index, event))
-
-    async def _run(self, index: int, event: dict | None) -> None:
+    async def run(self, index: int, event: dict | None = None) -> None:
         if self._is_cache_valid(event):
             config_name, action = self.actions_cache[index]
             if session := self.session_by_name(config_name):

--- a/plugin/code_lens.py
+++ b/plugin/code_lens.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from .core.aio import run_coroutine
 from .core.constants import CODE_LENS_ENABLED_KEY
 from .core.protocol import Error
 from .core.protocol import Request
@@ -128,12 +127,9 @@ class LspToggleCodeLensesCommand(LspWindowCommand):
     def is_checked(self) -> bool:
         return self.are_enabled(self.window)
 
-    def run(self) -> None:
+    async def run(self) -> None:
         enable = not self.is_checked()
         self.window.settings().set(CODE_LENS_ENABLED_KEY, enable)
-        run_coroutine(self._update_views(enable))
-
-    async def _update_views(self, enable: bool) -> None:
         window_manager = windows.lookup(self.window)
         if not window_manager:
             return

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -267,10 +267,7 @@ class QueryCompletionsTask:
 
 class LspResolveDocsCommand(LspTextCommand):
 
-    def run(self, edit: sublime.Edit, index: int, session_name: str, event: dict | None = None) -> None:
-        run_coroutine(self._run(index, session_name, event))
-
-    async def _run(self, index: int, session_name: str, event: dict | None = None) -> None:
+    async def run(self, index: int, session_name: str, event: dict | None = None) -> None:
         items, item_defaults = LspSelectCompletionCommand.completions[session_name]
         item = completion_with_defaults(items[index], item_defaults)
         language_map: MarkdownLangMap | None = None

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -15,7 +15,7 @@ from typing import Iterable
 from typing import TYPE_CHECKING
 import operator
 import sublime
-import sublime_plugin
+import sublime_aio
 
 if TYPE_CHECKING:
     from ...protocol import Diagnostic
@@ -52,7 +52,7 @@ def get_position(view: sublime.View, event: dict | None = None, point: int | Non
         return None
 
 
-class LspWindowCommand(sublime_plugin.WindowCommand):
+class LspWindowCommand(sublime_aio.WindowCommand):
     """
     Inherit from this class to define requests which are not bound to a particular view. This allows to run requests
     for example from links in HtmlSheets or when an unrelated file has focus.
@@ -115,7 +115,7 @@ class LspWindowCommand(sublime_plugin.WindowCommand):
         return windows.lookup(self.window)
 
 
-class LspTextCommand(sublime_plugin.TextCommand):
+class LspTextCommand(sublime_aio.ViewCommand):
     """
     Inherit from this class to define your requests that should be triggered via the command palette and/or a
     keybinding.
@@ -188,7 +188,7 @@ class LspTextCommand(sublime_plugin.TextCommand):
 class LspOpenLocationCommand(LspWindowCommand):
     """A command to be used by third-party ST packages that need to open an URI with some abstract scheme."""
 
-    def run(
+    async def run(
         self,
         location: Location | LocationLink,
         session_name: str | None = None,
@@ -202,19 +202,14 @@ class LspOpenLocationCommand(LspWindowCommand):
                     flags |= sublime.NewFileFlags.ADD_TO_SELECTION | sublime.NewFileFlags.SEMI_TRANSIENT | sublime.NewFileFlags.CLEAR_TO_RIGHT  # noqa: E501
                 elif 'shift' in modifier_keys:
                     flags |= sublime.NewFileFlags.ADD_TO_SELECTION | sublime.NewFileFlags.SEMI_TRANSIENT
-        run_coroutine(self._run(location, session_name, flags, group))
-
-    def want_event(self) -> bool:
-        return True
-
-    async def _run(
-        self, location: Location | LocationLink, session_name: str | None, flags: sublime.NewFileFlags, group: int
-    ) -> None:
         if session := self.session_by_name(session_name) if session_name else self.session():
             if not await session.open_location(location, flags, group):
                 uri, _ = get_uri_and_position_from_location(location)
                 message = f"Failed to open {uri}"
                 sublime.status_message(message)
+
+    def want_event(self) -> bool:
+        return True
 
 
 class LspRestartServerCommand(LspTextCommand):
@@ -241,12 +236,9 @@ class LspRestartServerCommand(LspTextCommand):
         run_coroutine(wm.restart_sessions([self._config_names[index]]))
 
 
-class LspCheckApplicableCommand(sublime_plugin.TextCommand):
+class LspCheckApplicableCommand(sublime_aio.ViewCommand):
 
-    def run(self, edit: sublime.Edit, session_name: str) -> None:
-        run_coroutine(self._run(session_name))
-
-    async def _run(self, session_name: str) -> None:
+    async def run(self, session_name: str) -> None:
         if wm := windows.lookup(self.view.window()):
             await wm.recheck_is_applicable(self.view, session_name)
 

--- a/plugin/document_link.py
+++ b/plugin/document_link.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from .core.aio import run_coroutine
 from .core.logging import exception_log
 from .core.open import open_file_uri
 from .core.open import open_in_browser
@@ -17,7 +16,6 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from ..protocol import URI
     from .core.sessions import Session
-    import sublime
 
 
 class LspOpenLinkCommand(LspTextCommand):
@@ -35,10 +33,7 @@ class LspOpenLinkCommand(LspTextCommand):
             return False
         return True
 
-    def run(self, edit: sublime.Edit, event: dict | None = None, point: int | None = None) -> None:
-        run_coroutine(self._run(event, point))
-
-    async def _run(self, event: dict | None, point: int | None) -> None:
+    async def run(self, event: dict | None = None, point: int | None = None) -> None:
         if (position := get_position(self.view, event, point)) is not None:
             if session := self.best_session(self.capability, position):
                 response = await session.request(

--- a/plugin/edit.py
+++ b/plugin/edit.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from .core.aio import run_coroutine
 from .core.constants import ChangeEventAction
 from .core.edit import is_snippet_text_edit
 from .core.edit import parse_lsp_position
@@ -93,12 +92,7 @@ def temporary_setting(settings: sublime.Settings, key: str, val: Any) -> Generat
 
 class LspApplyWorkspaceEditCommand(LspWindowCommand):
 
-    def run(
-        self, session_name: str, edit: WorkspaceEdit, label: str | None = None, is_refactoring: bool = False
-    ) -> None:
-        run_coroutine(self._run(session_name, edit, label, is_refactoring))
-
-    async def _run(
+    async def run(
         self, session_name: str, edit: WorkspaceEdit, label: str | None = None, is_refactoring: bool = False
     ) -> None:
         if session := self.session_by_name(session_name):

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-from .core.aio import run_coroutine
 from .core.logging import debug
 from .core.protocol import Error
-from .core.protocol import LSPAny
 from .core.registry import LspTextCommand
 from .core.views import first_selection_region
 from .core.views import offset_to_point
@@ -18,14 +16,12 @@ import sublime
 
 if TYPE_CHECKING:
     from ..protocol import ExecuteCommandParams
-    from .core.sessions import Session
 
 
 class LspExecuteCommand(LspTextCommand):
     """Helper command for triggering workspace/executeCommand requests."""
 
-    def run(self,
-            edit: sublime.Edit,
+    async def run(self,
             command_name: str | None = None,
             command_args: list[Any] | None = None,
             session_name: str | None = None,
@@ -35,14 +31,11 @@ class LspExecuteCommand(LspTextCommand):
             params: ExecuteCommandParams = {"command": command_name}
             if command_args:
                 params["arguments"] = self._expand_variables(command_args)
-            run_coroutine(self._run(session, command_name, params))
-
-    async def _run(self, session: Session, command_name: str, params: ExecuteCommandParams) -> None:
-        result: LSPAny | Error = await session.run_command(params, progress=True, view=self.view)
-        if isinstance(result, Error):
-            self.handle_error_async(result, command_name)
-        else:
-            self.handle_success_async(result, command_name)
+            result = await session.run_command(params, progress=True, view=self.view)
+            if isinstance(result, Error):
+                self.handle_error_async(result, command_name)
+            else:
+                self.handle_success_async(result, command_name)
 
     def handle_success_async(self, result: Any, command_name: str) -> None:
         """

--- a/plugin/formatting.py
+++ b/plugin/formatting.py
@@ -241,10 +241,7 @@ class LspFormatDocumentRangeCommand(LspTextCommand):
             return True
         return False
 
-    def run(self, edit: sublime.Edit, event: dict | None = None) -> None:
-        run_coroutine(self._run())
-
-    async def _run(self) -> None:
+    async def run(self, event: dict | None = None) -> None:
         if (potential_error := await format_selection(self.get_listener())) and isinstance(potential_error, Error):
             sublime.status_message(f'Formatting error: {potential_error}')
 

--- a/plugin/inlay_hint.py
+++ b/plugin/inlay_hint.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from .core.aio import run_coroutine
 from .core.constants import RequestFlags
 from .core.constants import ST_VERSION
 from .core.css import css
@@ -42,10 +41,7 @@ class LspToggleInlayHintsCommand(LspWindowCommand):
             return sublime.load_settings('LSP.sublime-settings').get('show_inlay_hints')
         return False
 
-    def run(self, enable: bool | None = None) -> None:
-        run_coroutine(self._run(enable))
-
-    async def _run(self, enable: bool | None) -> None:
+    async def run(self, enable: bool | None = None) -> None:
         window_settings = self.window.settings()
         if not isinstance(enable, bool):
             enable = not bool(window_settings.get('lsp_show_inlay_hints'))
@@ -68,12 +64,14 @@ class LspToggleInlayHintsCommand(LspWindowCommand):
 class LspInlayHintClickCommand(LspTextCommand):
     capability = 'inlayHintProvider'
 
-    def run(self, _edit: sublime.Edit, session_name: str, inlay_hint: InlayHint, phantom_uuid: str,
-            event: dict | None = None, label_part: InlayHintLabelPart | None = None) -> None:
-        run_coroutine(self._run(session_name, inlay_hint, phantom_uuid, label_part))
-
-    async def _run(self, session_name: str, inlay_hint: InlayHint, phantom_uuid: str,
-            label_part: InlayHintLabelPart | None = None) -> None:
+    async def run(
+        self,
+        session_name: str,
+        inlay_hint: InlayHint,
+        phantom_uuid: str,
+        event: dict | None = None,
+        label_part: InlayHintLabelPart | None = None,
+    ) -> None:
         # Insert textEdits for the given inlay hint.
         # If a InlayHintLabelPart was clicked, label_part will be passed as an argument to the LspInlayHintClickCommand
         # and InlayHintLabelPart.command will be executed.

--- a/plugin/lsp_task.py
+++ b/plugin/lsp_task.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from .core.aio import run_coroutine
 from .core.logging import exception_log
 from .core.registry import LspTextCommand
 from .core.settings import userprefs
@@ -57,10 +56,7 @@ class LspTextCommandWithTasks(LspTextCommand, ABC):
         """Override this to execute code when all tasks are completed."""
 
     @override
-    def run(self, edit: sublime.Edit, **kwargs: dict[str, Any]) -> None:
-        run_coroutine(self._run(**kwargs))
-
-    async def _run(self, **kwargs: dict[str, Any]) -> None:
+    async def run(self, **kwargs: dict[str, Any]) -> None:
         if self._tasks_runner:
             # Request to cancel the task.
             if self._tasks_runner.cancel():

--- a/plugin/symbols.py
+++ b/plugin/symbols.py
@@ -8,7 +8,6 @@ from ..protocol import SymbolInformation
 from ..protocol import SymbolKind
 from ..protocol import SymbolTag
 from ..protocol import WorkspaceSymbol
-from .core.aio import run_coroutine
 from .core.constants import SYMBOL_KINDS
 from .core.input_handlers import DynamicListInputHandler
 from .core.input_handlers import PreselectedListInputHandler
@@ -328,10 +327,7 @@ class LspWorkspaceSymbolsCommand(LspWindowCommand):
 
     capability = 'workspaceSymbolProvider'
 
-    def run(self, symbol: WorkspaceSymbolValue) -> None:
-        run_coroutine(self._run(symbol))
-
-    async def _run(self, symbol: WorkspaceSymbolValue) -> None:
+    async def run(self, symbol: WorkspaceSymbolValue) -> None:
         session_name = symbol['session']
         if session := self.session_by_name(session_name):
             if location := symbol.get('location'):


### PR DESCRIPTION
This PR makes LspTextCommand inherit from sublime_aio.ViewCommand. The benefit is that this ViewCommand has special handling for `async def run()` methods. So, you can write directly such a method, without having to use the somewhat cumbersome pattern of defining an `async def _run()` method and invoking that one, via `run_coroutine`, in the regular `run()` method. So:

```py
# OLD
FooBarCommand(LspTextcommand):
    def run(self, edit: sublime.Edit, foo: str, bar: str) -> None:
        run_coroutine(self._run(foo, bar))

    async def _run(self, foo: str, bar: str) -> None:
        ...
```

```py
# NEW
FooBarCommand(LspTextCommand):
    async def run(self, foo: str, bar: str) -> None:
        ...
```

_However_, I see TypeErrors being thrown for old LspTextCommand-derived classes that don't have an async `run()` method. This PR is blocked on that: https://github.com/packagecontrol/sublime_aio/issues/34