### PR TITLE
chore(test): ignore package with type issues

### DIFF
--- a/.github/workflows/test-community-packages.yaml
+++ b/.github/workflows/test-community-packages.yaml
@@ -29,6 +29,7 @@ jobs:
             --exclude LSP \
             --exclude LSP-aurelia \
             --exclude LSP-gnols \
+            --exclude LSP-MaaFramework \
             --exclude LSP-pyvoice \
             --exclude LSP-vale-ls \
             --exclude WolframLanguage


### PR DESCRIPTION
Ignore new package when testing - see https://github.com/Windsland52/maa-support-sublime/issues/1