### PR TITLE
Narrow HtmlSheet return type in type stubs

### DIFF
--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -1041,7 +1041,7 @@ class Window:
         """
         ...
 
-    def new_html_sheet(self, name: str, contents: str, flags: NewFileFlags = ..., group: int = ...) -> Sheet:
+    def new_html_sheet(self, name: str, contents: str, flags: NewFileFlags = ..., group: int = ...) -> HtmlSheet:
         """
         Construct a sheet with HTML contents rendered using minihtml.
 


### PR DESCRIPTION
I've seen that this return type from our type stubs causes some lint errors in a few packages (or require `type: ignore` workarounds) for valid code like
```python
sheet = window.new_html_sheet('My HtmlSheet', '')
sheet.set_contents('Hello')  # Cannot access attribute "set_contents" for class "Sheet"
```

I initially copied the return type `Sheet` from the original type hints in `sublime.py`, but this return type is actually not accurate and can be narrowed to `HtmlSheet`. So now that we have type checking for community packages in CI, let's fix it here.