### PR TITLE
Fix handling of unchanged diagnostics report

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -2223,10 +2223,11 @@ class Session(APIHandler, TransportCallbacks):
             debug("ignoring unsuitable diagnostics for", uri, "reason:", reason)
             return
         if diagnostics is not None:
-            # `None` means we received an UnchangedDocumentDiagnosticReport, in which case we still have to redraw
-            # diagnostic regions in the view to maintain the original positions.
             self.diagnostics.set_diagnostics(uri, identifier, diagnostics)
             mgr.on_diagnostics_updated()
+        # Even if we received an UnchangedDocumentDiagnosticReport (represented by the diagnostics argument being None)
+        # we still have to redraw the diagnostic regions in the view to ensure they keep their original positions after
+        # a buffer change.
         if session_buffer := self.get_session_buffer_for_uri_async(uri):
             self._publish_diagnostics_to_session_buffer_async(
                 session_buffer, self.diagnostics.get_diagnostics_for_uri(uri), version)

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -2209,7 +2209,11 @@ class Session(APIHandler, TransportCallbacks):
         self.handle_diagnostics_async(params['uri'], None, None, params['diagnostics'])
 
     def handle_diagnostics_async(
-        self, uri: DocumentUri, identifier: DiagnosticsIdentifier, version: int | None, diagnostics: list[Diagnostic]
+        self,
+        uri: DocumentUri,
+        identifier: DiagnosticsIdentifier,
+        version: int | None,
+        diagnostics: list[Diagnostic] | None
     ) -> None:
         mgr = self.manager()
         if not mgr:
@@ -2218,8 +2222,11 @@ class Session(APIHandler, TransportCallbacks):
         if isinstance(reason, str):
             debug("ignoring unsuitable diagnostics for", uri, "reason:", reason)
             return
-        self.diagnostics.set_diagnostics(uri, identifier, diagnostics)
-        mgr.on_diagnostics_updated()
+        if diagnostics is not None:
+            # `None` means we received an UnchangedDocumentDiagnosticReport, in which case we still have to redraw
+            # diagnostic regions in the view to maintain the original positions.
+            self.diagnostics.set_diagnostics(uri, identifier, diagnostics)
+            mgr.on_diagnostics_updated()
         if session_buffer := self.get_session_buffer_for_uri_async(uri):
             self._publish_diagnostics_to_session_buffer_async(
                 session_buffer, self.diagnostics.get_diagnostics_for_uri(uri), version)

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -2059,16 +2059,16 @@ class Session(APIHandler, TransportCallbacks):
     ) -> None:
         if reset_pending_response:
             self.workspace_diagnostics_pending_responses[identifier] = None
-        for diagnostic_report in response['items']:
-            uri = normalize_uri(diagnostic_report['uri'])
-            version = diagnostic_report['version']
+        for report in response['items']:
+            uri = normalize_uri(report['uri'])
+            version = report['version']
             # Skip if outdated
             if isinstance(version, int) and (session_buffer := self.get_session_buffer_for_uri_async(uri)) and \
                     version < session_buffer.last_synced_version:
                 continue
-            self.diagnostics_result_ids[(uri, identifier)] = diagnostic_report.get('resultId')
-            if is_workspace_full_document_diagnostic_report(diagnostic_report):
-                self.handle_diagnostics_async(uri, identifier, version, diagnostic_report['items'])
+            self.diagnostics_result_ids[(uri, identifier)] = report.get('resultId')
+            diagnostics = report['items'] if is_workspace_full_document_diagnostic_report(report) else None
+            self.handle_diagnostics_async(uri, identifier, version, diagnostics)
 
     def _on_workspace_diagnostics_error_async(self, identifier: DiagnosticsIdentifier, error: ResponseError) -> None:
         if error['code'] == LSPErrorCodes.ServerCancelled:

--- a/plugin/session_buffer.py
+++ b/plugin/session_buffer.py
@@ -671,14 +671,14 @@ class SessionBuffer:
         self._diagnostics_versions[identifier] = version
         self._document_diagnostic_pending_requests[identifier] = None
         self.session.diagnostics_result_ids[(self._last_known_uri, identifier)] = response.get('resultId')
-        if is_related_full_document_diagnostic_report(response):
-            self.session.handle_diagnostics_async(self._last_known_uri, identifier, version, response['items'])
+        diagnostics = response['items'] if is_related_full_document_diagnostic_report(response) else None
+        self.session.handle_diagnostics_async(self._last_known_uri, identifier, version, diagnostics)
         if related_documents := response.get('relatedDocuments'):
-            for uri, diagnostic_report in related_documents.items():
+            for uri, report in related_documents.items():
                 uri = normalize_uri(uri)
-                self.session.diagnostics_result_ids[(uri, identifier)] = diagnostic_report.get('resultId')
-                if is_full_document_diagnostic_report(diagnostic_report):
-                    self.session.handle_diagnostics_async(uri, identifier, None, diagnostic_report['items'])
+                self.session.diagnostics_result_ids[(uri, identifier)] = report.get('resultId')
+                diagnostics = report['items'] if is_full_document_diagnostic_report(report) else None
+                self.session.handle_diagnostics_async(uri, identifier, None, diagnostics)
 
     def _on_document_diagnostic_error_async(
         self, view: sublime.View, identifier: DiagnosticsIdentifier, version: int, error: ResponseError


### PR DESCRIPTION
I noticed that [UnchangedDocumentDiagnosticReport](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#unchangedDocumentDiagnosticReport) is not handled correctly. Unchanged diagnostics report means that the previous diagnostics (and as far as I understand, including the diagnostic's `range`) are still accurate. Currently we do "nothing" when we receive such a report:
https://github.com/sublimelsp/LSP/blob/bef834e8a09e3b083c62a3969721aec9c371cdff/plugin/session_buffer.py#L674-L676

But actually we need to redraw diagnostics regions in the view, because diagnostics are typically requested after a buffer change, and ST automatically adjusts/shifts existing region decorations if lines before the region we removed or added, or characters were inserted or removed on the same line before the region.

If lines or characters were inserted or removed *after* the diagnostics regions it didn't matter, because in that case the drawn regions are not affected anyway.

I added another `None` value as possible argument to `Session.handle_diagnostics_async`, which means that we received unchanged diagnostics, i.e. stored diagnostics don't need to be updated, but we still need to trigger a redraw.