### PR TITLE
Fix Git base scopes in language ID mapping

### DIFF
--- a/plugin/core/constants.py
+++ b/plugin/core/constants.py
@@ -287,8 +287,6 @@ LANGUAGE_IDENTIFIERS: dict[str, str] = {
     "source.cs": LanguageKind.CSharp,
     "source.dosbatch": LanguageKind.WindowsBat,
     "source.fixedform-fortran": "fortran",  # https://packagecontrol.io/packages/Fortran
-    "source.git.commit": LanguageKind.GitCommit,
-    "source.git.rebase": LanguageKind.GitRebase,
     "source.js": LanguageKind.JavaScript,
     "source.js.react": LanguageKind.JavaScriptReact,  # https://github.com/Thom1729/Sublime-JS-Custom
     "source.json-tmlanguage": "jsonc",  # https://github.com/SublimeText/PackageDev
@@ -308,6 +306,9 @@ LANGUAGE_IDENTIFIERS: dict[str, str] = {
     "source.yaml.helm": 'helm',  # https://github.com/SublimeText/YamlPipelines
     "text.advanced_csv": "csv",  # https://github.com/SublimeText/AFileIcon
     "text.django": LanguageKind.HTML,  # https://github.com/willstott101/django-sublime-syntax
+    "text.git.commit": LanguageKind.GitCommit,
+    "text.git.commit-message": LanguageKind.GitCommit,
+    "text.git.rebase": LanguageKind.GitRebase,
     "text.html.handlebars": LanguageKind.Handlebars,
     "text.html.markdown": LanguageKind.Markdown,
     "text.html.markdown.rmarkdown": LanguageKind.R,  # https://github.com/REditorSupport/sublime-ide-r

--- a/plugin/core/constants.py
+++ b/plugin/core/constants.py
@@ -307,7 +307,6 @@ LANGUAGE_IDENTIFIERS: dict[str, str] = {
     "text.advanced_csv": "csv",  # https://github.com/SublimeText/AFileIcon
     "text.django": LanguageKind.HTML,  # https://github.com/willstott101/django-sublime-syntax
     "text.git.commit": LanguageKind.GitCommit,
-    "text.git.commit-message": LanguageKind.GitCommit,
     "text.git.rebase": LanguageKind.GitRebase,
     "text.html.handlebars": LanguageKind.Handlebars,
     "text.html.markdown": LanguageKind.Markdown,


### PR DESCRIPTION
Fix syntax scopes from
- https://github.com/sublimehq/Packages/blob/master/Git%20Formats/Git%20Commit.sublime-syntax (`text.git.commit`)
- https://github.com/sublimehq/Packages/blob/master/Git%20Formats/Git%20Rebase.sublime-syntax (`text.git.rebase`)

---

*Edit*: there is also https://github.com/sublimehq/Packages/blob/master/Git%20Formats/Git%20Commit%20Message.sublime-syntax with base scope `text.git.commit-message`, but I see now that it is only used as a base syntax for https://github.com/sublimehq/Packages/blob/master/Git%20Formats/Git%20Commit.sublime-syntax, so it seems that base scope is never actually used and we don't need it here 