### PR TITLE
Docs: add instructions for Slang language server

### DIFF
--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -265,7 +265,7 @@ Follow installation instructions on [LSP-graphql](https://github.com/sublimelsp/
 ## Helm
 
 1. Install [helm-ls](https://github.com/mrjosh/helm-ls).
-2. Install the [Yaml​Pipelines](https://packagecontrol.io/packages/YamlPipelines) package from Package Control for syntax highlighting.
+2. Install the [YamlPipelines](https://packagecontrol.io/packages/YamlPipelines) package from Package Control for syntax highlighting.
 3. (Optional & recommended) Install [yaml-language-server](https://github.com/mrjosh/helm-ls?tab=readme-ov-file#integration-with-yaml-language-server).
 4. Open `Preferences > Package Settings > LSP > Server Configurations` and add the `"helm-ls"` configuration:
 

--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -6,8 +6,8 @@ If you encounter problems, consult the [common issues](troubleshooting.md#common
 
 If there are no setup steps for a language server on this page, but a [language server implementation](https://microsoft.github.io/language-server-protocol/implementors/servers/) exist, follow the guide for [creating a client configuration](./client_configuration.md). Pull requests for adding a new configuration are welcome.
 
-!!! tip "We recommend installing [LSP-json](https://packagecontrol.io/packages/LSP-json)."
-    [LSP-json](https://packagecontrol.io/packages/LSP-json) provides completions and diagnostics when editing JSON files that adhere to a JSON schema.
+!!! tip "We recommend installing [LSP-json](https://packages.sublimetext.io/packages/LSP-json)."
+    [LSP-json](https://packages.sublimetext.io/packages/LSP-json) provides completions and diagnostics when editing JSON files that adhere to a JSON schema.
 
 !!! info "For legacy ST3 docs, see [lsp.readthedocs.io](https://lsp.readthedocs.io)."
 
@@ -24,7 +24,7 @@ Follow installation instructions on [LSP-angular](https://github.com/sublimelsp/
     cargo install asm-lsp
     ```
 
-2. Install the [x86 and x86_64 Assembly](https://packagecontrol.io/packages/x86%20and%20x86_64%20Assembly) package from Package Control.
+2. Install the [x86 and x86_64 Assembly](https://packages.sublimetext.io/packages/x86%20and%20x86_64%20Assembly) package from Package Control.
 
 3. Open `Preferences > Package Settings > LSP > Server Configurations` and add the `"asm-lsp"` configuration:
 
@@ -173,7 +173,7 @@ Follow installation instructions on [LSP-elm](https://github.com/sublimelsp/LSP-
 
 ## F\#
 
-1. Install the [F#](https://packagecontrol.io/packages/F%23) package from Package Control for syntax highlighting.
+1. Install the [F#](https://packages.sublimetext.io/packages/F%23) package from Package Control for syntax highlighting.
 2. Make sure you have installed the latest [.NET SDK](https://dotnet.microsoft.com/download).
 3. Install the [FsAutoComplete](https://github.com/fsharp/FsAutoComplete) from command prompt using the following command:
 
@@ -201,7 +201,7 @@ Follow installation instructions on [LSP-elm](https://github.com/sublimelsp/LSP-
 
 ## Fortran
 
-1. Install the [ModernFortran](https://packagecontrol.io/packages/ModernFortran) or the [Fortran](https://packagecontrol.io/packages/Fortran) package from Package Control for syntax highlighting.
+1. Install the [ModernFortran](https://packages.sublimetext.io/packages/ModernFortran) or the [Fortran](https://packages.sublimetext.io/packages/Fortran) package from Package Control for syntax highlighting.
 2. Install the [fortls](https://fortls.fortran-lang.org/quickstart.html#download) language server.
 3. Open `Preferences > Package Settings > LSP > Server Configurations` and add the `"fortls"` configuration:
 
@@ -226,7 +226,7 @@ Follow installation instructions on [LSP-gopls](https://github.com/sublimelsp/LS
 
 ## GDScript (Godot Engine)
 
-1. Install the [GDScript (Godot Engine)](https://packagecontrol.io/packages/GDScript%20(Godot%20Engine)) package from Package Control for syntax highlighting.
+1. Install the [GDScript (Godot Engine)](https://packages.sublimetext.io/packages/GDScript%20(Godot%20Engine)) package from Package Control for syntax highlighting.
 2. Launch the Godot Editor on the project you are working on and leave it running.
 3. Open `Preferences > Package Settings > LSP > Server Configurations` and add the `"godot-lsp"` configuration:
 
@@ -265,7 +265,7 @@ Follow installation instructions on [LSP-graphql](https://github.com/sublimelsp/
 ## Helm
 
 1. Install [helm-ls](https://github.com/mrjosh/helm-ls).
-2. Install the [YamlPipelines](https://packagecontrol.io/packages/YamlPipelines) package from Package Control for syntax highlighting.
+2. Install the [YamlPipelines](https://packages.sublimetext.io/packages/YamlPipelines) package from Package Control for syntax highlighting.
 3. (Optional & recommended) Install [yaml-language-server](https://github.com/mrjosh/helm-ls?tab=readme-ov-file#integration-with-yaml-language-server).
 4. Open `Preferences > Package Settings > LSP > Server Configurations` and add the `"helm-ls"` configuration:
 
@@ -386,7 +386,7 @@ Follow installation instructions on [LSP-julia](https://github.com/sublimelsp/LS
 
 ## Kotlin
 
-1. Install the [Kotlin](https://packagecontrol.io/packages/Kotlin) package from Package Control for syntax highlighting.
+1. Install the [Kotlin](https://packages.sublimetext.io/packages/Kotlin) package from Package Control for syntax highlighting.
 2. Install the [Kotlin Language Server](https://github.com/fwcd/KotlinLanguageServer) (requires [building](https://github.com/fwcd/KotlinLanguageServer/blob/master/BUILDING.md) first).
 3. Open `Preferences > Package Settings > LSP > Server Configurations` and add the `"kotlinls"` configuration:
 
@@ -508,7 +508,7 @@ Follow installation instructions on [LSP-marksman](https://github.com/sublimelsp
 
 ## MediaWiki
 
-1. Install the [Mediawiker](https://packagecontrol.io/packages/Mediawiker) package from Package Control for syntax highlighting.
+1. Install the [Mediawiker](https://packages.sublimetext.io/packages/Mediawiker) package from Package Control for syntax highlighting.
 2. Install the `wikitext-lsp` package:
 
     ```sh
@@ -545,7 +545,7 @@ Follow [installation instructions on nixd](https://github.com/nix-community/nixd
 
 ## OCaml/Reason
 
-1. Install the [Reason](https://packagecontrol.io/packages/Reason) package from Package Control for syntax highlighting.
+1. Install the [Reason](https://packages.sublimetext.io/packages/Reason) package from Package Control for syntax highlighting.
 2. Install the [Reason Language Server](https://github.com/jaredly/reason-language-server#sublime-text).
 3. Open `Preferences > Package Settings > LSP > Server Configurations` and add the `"reason"` configuration:
 
@@ -685,7 +685,7 @@ Follow installation instructions on [R-IDE](https://github.com/REditorSupport/su
 
 ## Racket
 
-1. Install the [Racket](https://packagecontrol.io/packages/Racket) package from Package Control for syntax highlighting.
+1. Install the [Racket](https://packages.sublimetext.io/packages/Racket) package from Package Control for syntax highlighting.
 2. Follow the instructions for installation at [racket-langserver](https://github.com/jeapostrophe/racket-langserver).
 3. Open `Preferences > Package Settings > LSP > Server Configurations` and add the `"racket-langserver"` configuration:
 
@@ -932,7 +932,7 @@ Follow installation instructions on [LSP-metals](https://github.com/scalameta/me
 
 ## Solidity
 
-1. Install the [Ethereum](https://packagecontrol.io/packages/Ethereum) package from Package Control for syntax highlighting.
+1. Install the [Ethereum](https://packages.sublimetext.io/packages/Ethereum) package from Package Control for syntax highlighting.
 2. Install the [github:NomicFoundation/hardhat-vscode](https://github.com/NomicFoundation/hardhat-vscode/tree/development/server) language server.
 3. Open `Preferences > Package Settings > LSP > Server Configurations` and add the `"solidity"` configuration:
 
@@ -979,7 +979,7 @@ Follow installation instructions on [LSP-SourceKit](https://github.com/sublimels
 
 ## SystemVerilog
 
-1. Install the [SystemVerilog](https://packagecontrol.io/packages/SystemVerilog) package from Package Control for syntax highlighting.
+1. Install the [SystemVerilog](https://packages.sublimetext.io/packages/SystemVerilog) package from Package Control for syntax highlighting.
 2. Make sure you install the latest version of [Verible](https://github.com/chipsalliance/verible).
 3. Open `Preferences > Package Settings > LSP > Server Configurations` and add the `"verible"` configuration:
 
@@ -1009,7 +1009,7 @@ Follow installation instructions on [LSP-terraform](https://github.com/sublimels
 
 ## Toit
 
-1. Install the [Toit](https://packagecontrol.io/packages/Toit) package from Package Control for syntax highlighting.
+1. Install the [Toit](https://packages.sublimetext.io/packages/Toit) package from Package Control for syntax highlighting.
 2. Install the [Jaguar Language Server](https://github.com/toitlang/jaguar).
 3. Open `Preferences > Package Settings > LSP > Server Configurations` and add the `"jag"` configuration:
 
@@ -1080,7 +1080,7 @@ Follow installation instructions on [LSP-vetur](https://github.com/sublimelsp/LS
 
 ## Vala
 
-1. Install the [Vala-TMBundle](https://packagecontrol.io/packages/Vala-TMBundle) package from Package Control to add Vala syntax highlighting and for Vala files to be reconginsed.
+1. Install the [Vala-TMBundle](https://packages.sublimetext.io/packages/Vala-TMBundle) package from Package Control to add Vala syntax highlighting and for Vala files to be reconginsed.
 2. Install the [Vala Language Server](https://github.com/Prince781/vala-language-server)
 3. Add Vala Langauge Server to LSP settings:
 

--- a/docs/src/language_servers.md
+++ b/docs/src/language_servers.md
@@ -884,6 +884,52 @@ Follow installation instructions on [LSP-metals](https://github.com/scalameta/me
     }
     ```
 
+## Slang
+
+1. Install the [Slang](https://packages.sublimetext.io/packages/Slang) package from Package Control for syntax highlighting.
+2. Download and unzip the Slang compiler from <https://github.com/shader-slang/slang/releases>. The `slangd` language server executable is inside the `bin` folder, so you can either add that to your PATH environment variable, or you need to specify the full path in the config below. Alternatively, the [Vulkan SDK](https://vulkan.lunarg.com/sdk/home) also includes the Slang compiler and language server, so you can skip this step if you already have that installed.
+3. Open `Preferences > Package Settings > LSP > Server Configurations` and add the `"slang-lsp"` configuration:
+
+    ```jsonc
+    {
+        "slang-lsp": {
+            "enabled": true,
+            "command": ["slangd"],
+            "selector": "source.slang",
+            "settings": {
+                // Predefined macros to use in the language server. Each item contains one macro definition. You can also use `macro_name=value` syntax to specify the value of the macro.
+                "slang.predefinedMacros": [],
+                // Controls whether or not the language server should look in all sub-directories in the current workspace for an include or imported file if it is not found in the explicitly specified search paths.
+                "slang.searchInAllWorkspaceDirectories": true,
+                // The language server will search for the included or imported file in these additional directories first. If not found, the server will look in all sub directories in the current workspace (if enabled by the setting).
+                "slang.additionalSearchPaths": [],
+                // Controls whether or not to enable commit characters for selecting an auto completion item in addition to pressing enter. Options: "off", "membersOnly", "on"
+                "slang.enableCommitCharactersInAutoCompletion": "off",  // This functionality is not supported by Sublime LSP.
+                // Controls whether or not to format code automatically while typing. Requires clang-format to be discoverable from PATH.
+                "slang.format.enableFormatOnType": true,
+                // The location of clang-format for auto formatting, including the executable name. If left unspecified, will attempt to find `clang-format` under `PATH`.
+                "slang.format.clangFormatLocation": "",
+                // The `-style` argument to pass to clang-format, without quotes. Examples: `Microsoft`, `LLVM`, `file:fileName`.
+                "slang.format.clangFormatStyle": "file",
+                // The `-fallback-style` argument to pass to clang-format, without quotes. Examples: `Microsoft`, `LLVM`, `file:fileName`.
+                "slang.format.clangFormatFallbackStyle": "{BasedOnStyle: Microsoft, BreakBeforeBraces: Allman, ColumnLimit: 0}",
+                // Controls whether the extension is allowed to make line-break changes when reformatting the code on typing.
+                "slang.format.allowLineBreakChangesInOnTypeFormatting": false,
+                // Controls whether the extension is allowed to make line-break changes when doing range formatting, such as formatting on paste or on command.
+                "slang.format.allowLineBreakChangesInRangeFormatting": false,
+                // Enable inlay hints for duduced decl types, e.g. the deduced type in `var i = 2`
+                "slang.inlayHints.deducedTypes": true,
+                // Enable inlay hints for parameter names at call sites.
+                "slang.inlayHints.parameterNames": true,
+                // Controls the workspace flavor of the language server. Options: "standard", "vfx"
+                "slang.workspaceFlavor": "standard",
+                // The assumed Slang language version for source files that do not contain a `#language` directive. The empty default follows the compiler's own default version. Set this to match the version you build with (for example a global `-std`/`-language-version` option) so the editor does not report false errors on directive-less files. A per-file `#language` directive always overrides this setting. Options: "" (use the compiler's default language version), "2018", "2025", "2026", "latest"
+                "slang.predefinedLanguageVersion": "",
+            }
+        }
+    }
+    ```
+
 ## Solidity
 
 1. Install the [Ethereum](https://packagecontrol.io/packages/Ethereum) package from Package Control for syntax highlighting.


### PR DESCRIPTION
1. Add instructions for Slang language server. I noticed that there is also a helper package for this server at https://github.com/LDAP/LSP-slangd, but that package is not on Package Control, uses the old `AbstractPlugin`, installs an older version of the language server, and it looks like it doesn't provide any additional functionalities. So for now we can add the manual config.
2. Removed zero-width space in YamlPipelines name (I assume that was accidental).
3. Replaced old https://packagecontrol.io/ links with the new Package Control website https://packages.sublimetext.io/